### PR TITLE
Fix visual mode and Vim motion bugs

### DIFF
--- a/crates/cell-tui/src/action.rs
+++ b/crates/cell-tui/src/action.rs
@@ -22,6 +22,8 @@ pub enum Action {
     EditCell(CellPos, String),
     ClearCell(CellPos),
     ClearRange { start: CellPos, end: CellPos },
+    ChangeCell(CellPos),
+    ChangeRange { start: CellPos, end: CellPos },
     #[allow(dead_code)]
     YankCell(CellPos),
     YankRange { start: CellPos, end: CellPos },

--- a/crates/cell-tui/src/action.rs
+++ b/crates/cell-tui/src/action.rs
@@ -61,6 +61,7 @@ pub enum Mode {
     Normal,
     Insert,
     Visual,
+    VisualLine,
     VisualBlock,
     Command,
     Help,

--- a/crates/cell-tui/src/app.rs
+++ b/crates/cell-tui/src/app.rs
@@ -236,19 +236,22 @@ impl App {
                 self.dirty = true;
             }
             Action::Paste(pos) | Action::PasteBefore(pos) => {
-                let dest_row = if matches!(action, Action::Paste(_)) { pos.0 + 1 } else { pos.0 };
+                let is_after = matches!(action, Action::Paste(_));
                 if let Some(reg) = &self.register.clone() {
                     match reg {
                         Register::Cell(raw) => {
-                            let adjusted = crate::clipboard::adjust_formula(raw, dest_row as isize - pos.0 as isize, 0);
+                            // Cell: p pastes at cursor, P also at cursor (no row offset)
+                            let adjusted = crate::clipboard::adjust_formula(raw, 0, 0);
                             if adjusted.starts_with('=') {
-                                cell_core::formula::deps::set_formula(&mut self.sheet, &mut self.deps, (dest_row, pos.1), &adjusted);
+                                cell_core::formula::deps::set_formula(&mut self.sheet, &mut self.deps, pos, &adjusted);
                             } else {
-                                self.sheet.set_cell((dest_row, pos.1), &adjusted);
+                                self.sheet.set_cell(pos, &adjusted);
                             }
                             self.dirty = true;
                         }
                         Register::Row(cells) => {
+                            // Row (yy/dd): p pastes on line below, P on current line
+                            let dest_row = if is_after { pos.0 + 1 } else { pos.0 };
                             for (col, raw) in cells.iter().enumerate() {
                                 if !raw.is_empty() {
                                     let adjusted = crate::clipboard::adjust_formula(raw, dest_row as isize - pos.0 as isize, 0);
@@ -258,11 +261,12 @@ impl App {
                             self.dirty = true;
                         }
                         Register::Block(block) => {
+                            // Block (visual selection): p pastes at cursor position
                             for (r_off, row_data) in block.iter().enumerate() {
                                 for (c_off, raw) in row_data.iter().enumerate() {
                                     if !raw.is_empty() {
                                         let adjusted = crate::clipboard::adjust_formula(raw, r_off as isize, c_off as isize);
-                                        self.sheet.set_cell((dest_row + r_off, pos.1 + c_off), &adjusted);
+                                        self.sheet.set_cell((pos.0 + r_off, pos.1 + c_off), &adjusted);
                                     }
                                 }
                             }

--- a/crates/cell-tui/src/app.rs
+++ b/crates/cell-tui/src/app.rs
@@ -198,10 +198,11 @@ impl App {
                 self.register = Some(Register::Row(cells));
             }
             Action::YankRange { start, end } => {
+                let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
                 let mut block = Vec::new();
                 for row in start.0..=end.0 {
                     let mut row_data = Vec::new();
-                    for col in start.1..=end.1 {
+                    for col in start.1..=max_col {
                         let raw = self.sheet.get_cell((row, col)).map(|c| c.raw.clone()).unwrap_or_default();
                         row_data.push(raw);
                     }
@@ -210,10 +211,11 @@ impl App {
                 self.register = Some(Register::Block(block));
             }
             Action::ClearRange { start, end } => {
+                let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
                 let mut block = Vec::new();
                 for row in start.0..=end.0 {
                     let mut row_data = Vec::new();
-                    for col in start.1..=end.1 {
+                    for col in start.1..=max_col {
                         let raw = self.sheet.get_cell((row, col)).map(|c| c.raw.clone()).unwrap_or_default();
                         row_data.push(raw);
                         self.sheet.clear_cell((row, col));

--- a/crates/cell-tui/src/app.rs
+++ b/crates/cell-tui/src/app.rs
@@ -111,6 +111,31 @@ impl App {
                     self.dirty = true;
                 }
             }
+            Action::ChangeCell(pos) => {
+                let old_raw = self.sheet.get_cell(pos).map(|c| c.raw.clone()).unwrap_or_default();
+                if !old_raw.is_empty() {
+                    self.undo_stack.push(UndoEntry::CellEdit { pos, old_raw, new_raw: String::new() });
+                    self.sheet.clear_cell(pos);
+                    self.dirty = true;
+                }
+                self.insert_buffer = String::new();
+                self.mode = Mode::Insert;
+            }
+            Action::ChangeRange { start, end } => {
+                let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
+                for row in start.0..=end.0 {
+                    for col in start.1..=max_col {
+                        let old_raw = self.sheet.get_cell((row, col)).map(|c| c.raw.clone()).unwrap_or_default();
+                        if !old_raw.is_empty() {
+                            self.undo_stack.push(UndoEntry::CellEdit { pos: (row, col), old_raw, new_raw: String::new() });
+                            self.sheet.clear_cell((row, col));
+                        }
+                    }
+                }
+                self.dirty = true;
+                self.insert_buffer = String::new();
+                self.mode = Mode::Insert;
+            }
             Action::GotoFirstRow => { self.cursor = (0, self.cursor.1); self.viewport.ensure_visible(self.cursor); }
             Action::GotoLastRow => {
                 let last = if self.sheet.row_count > 0 { self.sheet.row_count - 1 } else { 0 };

--- a/crates/cell-tui/src/main.rs
+++ b/crates/cell-tui/src/main.rs
@@ -48,6 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn load_file(app: &mut App, path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    use cell_core::formula::deps::{set_formula, recalculate};
+
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
     match ext.as_str() {
         "csv" => {
@@ -72,6 +74,17 @@ fn load_file(app: &mut App, path: &std::path::Path) -> Result<(), Box<dyn std::e
         }
     }
     app.file_path = Some(path.to_path_buf());
+
+    // Register formulas in the dependency graph and evaluate them
+    let formula_cells: Vec<_> = app.sheet.cells.iter()
+        .filter(|(_, cell)| cell.raw.starts_with('='))
+        .map(|(pos, cell)| (*pos, cell.raw.clone()))
+        .collect();
+    for (pos, raw) in formula_cells {
+        set_formula(&mut app.sheet, &mut app.deps, pos, &raw);
+    }
+    recalculate(&mut app.sheet, &app.deps);
+
     Ok(())
 }
 

--- a/crates/cell-tui/src/main.rs
+++ b/crates/cell-tui/src/main.rs
@@ -154,6 +154,7 @@ fn run_loop(
                                 Action::ChangeMode(Mode::Normal)
                                     | Action::ClearRange { .. }
                                     | Action::YankRange { .. }
+                                    | Action::ChangeRange { .. }
                             );
                             if exits {
                                 visual_state = None;
@@ -210,9 +211,12 @@ fn run_loop(
                 if let Action::ChangeMode(Mode::VisualBlock) = &action {
                     visual_state = Some(VisualState::new(app.cursor, VisualKind::Block));
                 }
-                if let Action::ChangeMode(Mode::Insert) = &action {
+                if matches!(&action, Action::ChangeMode(Mode::Insert)) {
                     insert_cursor = app.sheet.get_cell(app.cursor)
                         .map(|c| c.raw.len()).unwrap_or(0);
+                }
+                if matches!(&action, Action::ChangeCell(_) | Action::ChangeRange { .. }) {
+                    insert_cursor = 0;
                 }
                 if let Action::ChangeMode(Mode::Command) = &action {
                     if key.code == KeyCode::Char('/') {

--- a/crates/cell-tui/src/main.rs
+++ b/crates/cell-tui/src/main.rs
@@ -82,7 +82,7 @@ fn run_loop(
     use mode::normal::NormalState;
     use mode::insert::{handle_insert_key, handle_insert_char, InsertAction};
     use mode::command::{handle_command_key, parse_command, CommandAction};
-    use mode::visual::VisualState;
+    use mode::visual::{VisualState, VisualKind};
     use mode::help::HelpState;
 
     let mut normal_state = NormalState::new();
@@ -96,8 +96,9 @@ fn run_loop(
         let grid_height = terminal.size()?.height.saturating_sub(3) as usize;
         app.viewport.visible_rows = grid_height;
 
+        let selection = visual_state.as_ref().map(|vs| vs.selection(app.cursor));
         terminal.draw(|frame| {
-            render::render(frame, app);
+            render::render(frame, app, selection);
         })?;
 
         if event::poll(std::time::Duration::from_millis(100))? {
@@ -145,7 +146,7 @@ fn run_loop(
                             }
                         }
                     }
-                    Mode::Visual | Mode::VisualBlock => {
+                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
                         if let Some(ref vs) = visual_state {
                             let action = vs.handle_key(key, app);
                             if action == Action::ChangeMode(Mode::Normal) {
@@ -194,10 +195,13 @@ fn run_loop(
                 };
 
                 if let Action::ChangeMode(Mode::Visual) = &action {
-                    visual_state = Some(VisualState::new(app.cursor, false));
+                    visual_state = Some(VisualState::new(app.cursor, VisualKind::Character));
+                }
+                if let Action::ChangeMode(Mode::VisualLine) = &action {
+                    visual_state = Some(VisualState::new(app.cursor, VisualKind::Line));
                 }
                 if let Action::ChangeMode(Mode::VisualBlock) = &action {
-                    visual_state = Some(VisualState::new(app.cursor, true));
+                    visual_state = Some(VisualState::new(app.cursor, VisualKind::Block));
                 }
                 if let Action::ChangeMode(Mode::Insert) = &action {
                     insert_cursor = app.sheet.get_cell(app.cursor)

--- a/crates/cell-tui/src/main.rs
+++ b/crates/cell-tui/src/main.rs
@@ -110,8 +110,9 @@ fn run_loop(
         app.viewport.visible_rows = grid_height;
 
         let selection = visual_state.as_ref().map(|vs| vs.selection(app.cursor));
+        let ic = insert_cursor;
         terminal.draw(|frame| {
-            render::render(frame, app, selection);
+            render::render(frame, app, selection, ic);
         })?;
 
         if event::poll(std::time::Duration::from_millis(100))? {

--- a/crates/cell-tui/src/main.rs
+++ b/crates/cell-tui/src/main.rs
@@ -149,8 +149,15 @@ fn run_loop(
                     Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
                         if let Some(ref vs) = visual_state {
                             let action = vs.handle_key(key, app);
-                            if action == Action::ChangeMode(Mode::Normal) {
+                            let exits = matches!(
+                                action,
+                                Action::ChangeMode(Mode::Normal)
+                                    | Action::ClearRange { .. }
+                                    | Action::YankRange { .. }
+                            );
+                            if exits {
                                 visual_state = None;
+                                app.mode = Mode::Normal;
                             }
                             action
                         } else {

--- a/crates/cell-tui/src/mode/normal.rs
+++ b/crates/cell-tui/src/mode/normal.rs
@@ -51,6 +51,7 @@ impl NormalState {
             KeyCode::Char('i') | KeyCode::Char('a') => Action::ChangeMode(Mode::Insert),
             KeyCode::Char('o') => Action::ChangeMode(Mode::Insert),
             KeyCode::Char('v') => Action::ChangeMode(Mode::Visual),
+            KeyCode::Char('V') => Action::ChangeMode(Mode::VisualLine),
             KeyCode::Char(':') => Action::ChangeMode(Mode::Command),
             KeyCode::Char('x') => Action::ClearCell(app.cursor),
             KeyCode::Char('p') => Action::Paste(app.cursor),

--- a/crates/cell-tui/src/mode/normal.rs
+++ b/crates/cell-tui/src/mode/normal.rs
@@ -53,6 +53,7 @@ impl NormalState {
             KeyCode::Char('v') => Action::ChangeMode(Mode::Visual),
             KeyCode::Char('V') => Action::ChangeMode(Mode::VisualLine),
             KeyCode::Char(':') => Action::ChangeMode(Mode::Command),
+            KeyCode::Char('c') => Action::ChangeCell(app.cursor),
             KeyCode::Char('x') => Action::ClearCell(app.cursor),
             KeyCode::Char('p') => Action::Paste(app.cursor),
             KeyCode::Char('P') => Action::PasteBefore(app.cursor),

--- a/crates/cell-tui/src/mode/visual.rs
+++ b/crates/cell-tui/src/mode/visual.rs
@@ -3,23 +3,37 @@ use cell_core::model::CellPos;
 use crate::action::{Action, Direction, Mode};
 use crate::app::App;
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VisualKind {
+    Character,
+    Line,
+    Block,
+}
+
 pub struct VisualState {
     pub anchor: CellPos,
-    #[allow(dead_code)]
-    pub is_block: bool,
+    pub kind: VisualKind,
 }
 
 impl VisualState {
-    pub fn new(anchor: CellPos, is_block: bool) -> Self {
-        VisualState { anchor, is_block }
+    pub fn new(anchor: CellPos, kind: VisualKind) -> Self {
+        VisualState { anchor, kind }
     }
 
     pub fn selection(&self, cursor: CellPos) -> (CellPos, CellPos) {
         let r1 = self.anchor.0.min(cursor.0);
         let r2 = self.anchor.0.max(cursor.0);
-        let c1 = self.anchor.1.min(cursor.1);
-        let c2 = self.anchor.1.max(cursor.1);
-        ((r1, c1), (r2, c2))
+        match self.kind {
+            VisualKind::Line => {
+                // Select entire rows — use 0 to usize::MAX so all visible columns match
+                ((r1, 0), (r2, usize::MAX))
+            }
+            VisualKind::Character | VisualKind::Block => {
+                let c1 = self.anchor.1.min(cursor.1);
+                let c2 = self.anchor.1.max(cursor.1);
+                ((r1, c1), (r2, c2))
+            }
+        }
     }
 
     pub fn handle_key(&self, key: KeyEvent, app: &App) -> Action {
@@ -46,7 +60,7 @@ mod tests {
 
     #[test]
     fn selection_normalized() {
-        let state = VisualState::new((2, 3), false);
+        let state = VisualState::new((2, 3), VisualKind::Character);
         let (start, end) = state.selection((0, 1));
         assert_eq!(start, (0, 1));
         assert_eq!(end, (2, 3));
@@ -54,16 +68,24 @@ mod tests {
 
     #[test]
     fn selection_same_cell() {
-        let state = VisualState::new((1, 1), false);
+        let state = VisualState::new((1, 1), VisualKind::Character);
         let (start, end) = state.selection((1, 1));
         assert_eq!(start, (1, 1));
         assert_eq!(end, (1, 1));
     }
 
     #[test]
+    fn selection_line_selects_full_rows() {
+        let state = VisualState::new((1, 3), VisualKind::Line);
+        let (start, end) = state.selection((3, 1));
+        assert_eq!(start, (1, 0));
+        assert_eq!(end, (3, usize::MAX));
+    }
+
+    #[test]
     fn hjkl_in_visual() {
         let app = App::new();
-        let state = VisualState::new((0, 0), false);
+        let state = VisualState::new((0, 0), VisualKind::Character);
         assert_eq!(state.handle_key(key(KeyCode::Char('j')), &app), Action::MoveCursor(Direction::Down));
     }
 
@@ -71,7 +93,7 @@ mod tests {
     fn d_clears_range() {
         let mut app = App::new();
         app.cursor = (2, 2);
-        let state = VisualState::new((0, 0), false);
+        let state = VisualState::new((0, 0), VisualKind::Character);
         assert_eq!(state.handle_key(key(KeyCode::Char('d')), &app), Action::ClearRange { start: (0, 0), end: (2, 2) });
     }
 
@@ -79,14 +101,14 @@ mod tests {
     fn y_yanks_range() {
         let mut app = App::new();
         app.cursor = (1, 1);
-        let state = VisualState::new((0, 0), false);
+        let state = VisualState::new((0, 0), VisualKind::Character);
         assert_eq!(state.handle_key(key(KeyCode::Char('y')), &app), Action::YankRange { start: (0, 0), end: (1, 1) });
     }
 
     #[test]
     fn esc_exits_visual() {
         let app = App::new();
-        let state = VisualState::new((0, 0), false);
+        let state = VisualState::new((0, 0), VisualKind::Character);
         assert_eq!(state.handle_key(key(KeyCode::Esc), &app), Action::ChangeMode(Mode::Normal));
     }
 }

--- a/crates/cell-tui/src/mode/visual.rs
+++ b/crates/cell-tui/src/mode/visual.rs
@@ -43,6 +43,7 @@ impl VisualState {
             KeyCode::Char('j') | KeyCode::Down => Action::MoveCursor(Direction::Down),
             KeyCode::Char('k') | KeyCode::Up => Action::MoveCursor(Direction::Up),
             KeyCode::Char('l') | KeyCode::Right => Action::MoveCursor(Direction::Right),
+            KeyCode::Char('c') => Action::ChangeRange { start, end },
             KeyCode::Char('d') => Action::ClearRange { start, end },
             KeyCode::Char('y') => Action::YankRange { start, end },
             KeyCode::Esc => Action::ChangeMode(Mode::Normal),

--- a/crates/cell-tui/src/render/formula_bar.rs
+++ b/crates/cell-tui/src/render/formula_bar.rs
@@ -13,6 +13,15 @@ pub struct FormulaBar<'a> {
     pub is_editing: bool,
 }
 
+impl<'a> FormulaBar<'a> {
+    /// Returns the x offset where content text begins (address width + separator).
+    pub fn content_x(&self) -> u16 {
+        let addr = format!(" {}{} ", col_index_to_label(self.cursor.1), self.cursor.0 + 1);
+        let sep = " │ ";
+        addr.len() as u16 + sep.len() as u16
+    }
+}
+
 impl<'a> Widget for FormulaBar<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         if area.height == 0 { return; }

--- a/crates/cell-tui/src/render/mod.rs
+++ b/crates/cell-tui/src/render/mod.rs
@@ -8,6 +8,7 @@ use ratatui::{
     Frame,
     layout::{Constraint, Layout, Direction},
 };
+use cell_core::model::CellPos;
 use crate::app::App;
 use crate::action::Mode;
 use grid::Grid;
@@ -16,7 +17,7 @@ use status_bar::StatusBar;
 use command_line::CommandLine;
 use help::HelpView;
 
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &App, selection: Option<(CellPos, CellPos)>) {
     if app.mode == Mode::Help {
         frame.render_widget(HelpView {
             registry: &app.help_registry,
@@ -44,7 +45,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     }, chunks[0]);
 
     frame.render_widget(Grid {
-        sheet: &app.sheet, viewport: &app.viewport, cursor: app.cursor, selection: None,
+        sheet: &app.sheet, viewport: &app.viewport, cursor: app.cursor, selection,
     }, chunks[1]);
 
     let file_name = app.file_path.as_ref().and_then(|p| p.file_name()).and_then(|n| n.to_str());

--- a/crates/cell-tui/src/render/mod.rs
+++ b/crates/cell-tui/src/render/mod.rs
@@ -17,7 +17,7 @@ use status_bar::StatusBar;
 use command_line::CommandLine;
 use help::HelpView;
 
-pub fn render(frame: &mut Frame, app: &App, selection: Option<(CellPos, CellPos)>) {
+pub fn render(frame: &mut Frame, app: &App, selection: Option<(CellPos, CellPos)>, insert_cursor: usize) {
     if app.mode == Mode::Help {
         frame.render_widget(HelpView {
             registry: &app.help_registry,
@@ -39,10 +39,21 @@ pub fn render(frame: &mut Frame, app: &App, selection: Option<(CellPos, CellPos)
         .split(area);
 
     let cell_content = app.sheet.get_cell(app.cursor).map(|c| c.raw.as_str()).unwrap_or("");
-    let display_content = if app.mode == Mode::Insert { &app.insert_buffer } else { cell_content };
-    frame.render_widget(FormulaBar {
-        cursor: app.cursor, content: display_content, is_editing: app.mode == Mode::Insert,
-    }, chunks[0]);
+    let is_editing = app.mode == Mode::Insert;
+    let display_content = if is_editing { &app.insert_buffer } else { cell_content };
+    let formula_bar = FormulaBar {
+        cursor: app.cursor, content: display_content, is_editing,
+    };
+    let content_x = formula_bar.content_x();
+    frame.render_widget(formula_bar, chunks[0]);
+
+    if is_editing {
+        let cursor_x = chunks[0].x + content_x + insert_cursor as u16;
+        let cursor_y = chunks[0].y;
+        if cursor_x < chunks[0].x + chunks[0].width {
+            frame.set_cursor_position((cursor_x, cursor_y));
+        }
+    }
 
     frame.render_widget(Grid {
         sheet: &app.sheet, viewport: &app.viewport, cursor: app.cursor, selection,

--- a/crates/cell-tui/src/render/status_bar.rs
+++ b/crates/cell-tui/src/render/status_bar.rs
@@ -28,6 +28,7 @@ impl<'a> Widget for StatusBar<'a> {
             Mode::Normal => " NORMAL ",
             Mode::Insert => " INSERT ",
             Mode::Visual => " VISUAL ",
+            Mode::VisualLine => " V-LINE ",
             Mode::VisualBlock => " V-BLOCK ",
             Mode::Command => " COMMAND ",
             Mode::Help => " HELP ",
@@ -35,13 +36,13 @@ impl<'a> Widget for StatusBar<'a> {
         let mode_bg = match self.mode {
             Mode::Normal => Color::Rgb(68, 68, 68),       // dark gray — Vim default
             Mode::Insert => Color::Rgb(95, 175, 0),       // green — Vim insert
-            Mode::Visual | Mode::VisualBlock => Color::Rgb(215, 135, 0), // orange — Vim visual
-            Mode::Command => Color::Rgb(68, 68, 68),      // dark gray — same as normal
+            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => Color::Rgb(215, 135, 0), // orange — Vim visual
+            Mode::Command | Mode::Help => Color::Rgb(68, 68, 68), // dark gray — same as normal
         };
         let mode_fg = match self.mode {
-            Mode::Normal | Mode::Command => Color::White,
+            Mode::Normal | Mode::Command | Mode::Help => Color::White,
             Mode::Insert => Color::Black,
-            Mode::Visual | Mode::VisualBlock => Color::Black,
+            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => Color::Black,
         };
         let mode_style = Style::default().fg(mode_fg).bg(mode_bg).add_modifier(Modifier::BOLD);
         buf.set_string(area.x, area.y, mode_str, mode_style);


### PR DESCRIPTION
## Summary

- **Visual mode highlighting**: Wire up selection rendering so `v`/`V`/`Ctrl-V` selections are highlighted in blue on the grid
- **V-LINE mode (`V`)**: Add linewise visual selection with full-row highlighting, replacing the unused `is_block` bool with a proper `VisualKind` enum
- **Exit visual on operators**: `d`, `y`, and `c` in visual mode now return to normal mode like Vim
- **Fix V-LINE crash**: Clamp column range in yank/delete to prevent iterating `usize::MAX` columns when operating on linewise selections
- **Fix paste off-by-one**: Block registers (from visual selection) paste at cursor; only row registers (`yy`/`dd`) use the +1 row offset for `p`
- **Add `c` (change) motion**: Clear cell/range and enter insert mode in both normal and visual mode
- **Evaluate formulas on file load**: Register formulas in the dep graph and recalculate when opening `.cell` files
- **Insert mode cursor**: Show a blinking terminal cursor at the correct position in the formula bar during editing

## Test plan

- [ ] `v` → move cursor → verify blue highlight on selected cells
- [ ] `V` → `j`/`k` → verify entire rows highlighted, status bar shows `V-LINE`
- [ ] `Ctrl-V` → move → verify block selection, status bar shows `V-BLOCK`
- [ ] In visual mode: `d` deletes selection and returns to normal mode
- [ ] In visual mode: `y` yanks selection and returns to normal mode
- [ ] `V` → select rows → `d` → verify no hang/crash
- [ ] `V` → `y` → `j` → `p` → verify line pastes at current row (no off-by-one)
- [ ] `c` in normal mode clears cell and enters insert mode
- [ ] `v` → select → `c` → clears range and enters insert mode
- [ ] Open a `.cell` file with formulas → verify values are computed
- [ ] Enter insert mode → arrow keys move cursor within formula bar text

🤖 Generated with [Claude Code](https://claude.com/claude-code)