### PR TITLE
Fix undo for `dd` row delete (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.6
+
+### Fixed
+
+- `dd` (delete row) is now undoable with `u`, matching Vim's behavior (#5)
+
 ## 0.1.5
 
 ### Fixed

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -331,17 +331,24 @@ impl App {
             }
             Action::DeleteRow(row) => {
                 let mut cells = Vec::new();
+                let mut changes = Vec::new();
                 for col in 0..self.sheet.col_count {
                     let raw = self
                         .sheet
                         .get_cell((row, col))
                         .map(|c| c.raw.clone())
                         .unwrap_or_default();
+                    if !raw.is_empty() {
+                        changes.push(((row, col), raw.clone(), String::new()));
+                        self.sheet.clear_cell((row, col));
+                    }
                     cells.push(raw);
-                    self.sheet.clear_cell((row, col));
                 }
                 self.register = Some(Register::Row(cells));
-                self.dirty = true;
+                if !changes.is_empty() {
+                    self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
+                    self.dirty = true;
+                }
             }
             Action::Paste(pos) | Action::PasteBefore(pos) => {
                 let is_after = matches!(action, Action::Paste(_));
@@ -520,16 +527,25 @@ impl App {
                 old_raw,
                 new_raw,
             } => {
-                let raw = if redo { new_raw } else { old_raw };
-                if raw.is_empty() {
-                    self.sheet.clear_cell(*pos);
-                } else if raw.starts_with('=') {
-                    set_formula(&mut self.sheet, &mut self.deps, *pos, raw);
-                } else {
-                    self.sheet.set_cell(*pos, raw);
+                self.restore_cell(*pos, if redo { new_raw } else { old_raw });
+                recalculate(&mut self.sheet, &self.deps);
+            }
+            UndoEntry::MultiCellEdit { changes } => {
+                for (pos, old_raw, new_raw) in changes {
+                    self.restore_cell(*pos, if redo { new_raw } else { old_raw });
                 }
                 recalculate(&mut self.sheet, &self.deps);
             }
+        }
+    }
+
+    fn restore_cell(&mut self, pos: CellPos, raw: &str) {
+        if raw.is_empty() {
+            self.sheet.clear_cell(pos);
+        } else if raw.starts_with('=') {
+            set_formula(&mut self.sheet, &mut self.deps, pos, raw);
+        } else {
+            self.sheet.set_cell(pos, raw);
         }
     }
 }
@@ -572,5 +588,67 @@ mod tests {
         assert_eq!(app.mode, Mode::Help);
         app.process_action(Action::ChangeMode(Mode::Normal));
         assert_eq!(app.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn dd_can_be_undone() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::EditCell((0, 1), "world".into()));
+        app.process_action(Action::EditCell((1, 0), "keep".into()));
+
+        app.process_action(Action::DeleteRow(0));
+        assert!(app.sheet.get_cell((0, 0)).is_none());
+        assert!(app.sheet.get_cell((0, 1)).is_none());
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).map(|c| c.raw.as_str()),
+            Some("keep")
+        );
+
+        app.process_action(Action::Undo);
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("hello")
+        );
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("world")
+        );
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).map(|c| c.raw.as_str()),
+            Some("keep")
+        );
+    }
+
+    #[test]
+    fn dd_can_be_redone() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::EditCell((0, 1), "world".into()));
+
+        app.process_action(Action::DeleteRow(0));
+        app.process_action(Action::Undo);
+        app.process_action(Action::Redo);
+
+        assert!(app.sheet.get_cell((0, 0)).is_none());
+        assert!(app.sheet.get_cell((0, 1)).is_none());
+    }
+
+    #[test]
+    fn dd_undo_preserves_formula() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "10".into()));
+        app.process_action(Action::EditCell((0, 1), "=A1*2".into()));
+
+        app.process_action(Action::DeleteRow(0));
+        app.process_action(Action::Undo);
+
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("=A1*2")
+        );
+        // Formula should re-evaluate after restoration.
+        let val = app.sheet.get_cell((0, 1)).map(|c| c.value.to_string());
+        assert_eq!(val.as_deref(), Some("20"));
     }
 }

--- a/crates/cell-sheet-tui/src/undo.rs
+++ b/crates/cell-sheet-tui/src/undo.rs
@@ -7,6 +7,11 @@ pub enum UndoEntry {
         old_raw: String,
         new_raw: String,
     },
+    /// A group of cell edits applied atomically (e.g. `dd` deleting a row).
+    /// Each tuple is `(pos, old_raw, new_raw)`.
+    MultiCellEdit {
+        changes: Vec<(CellPos, String, String)>,
+    },
 }
 
 pub struct UndoStack {


### PR DESCRIPTION
## Summary

- `Action::DeleteRow` (the `dd` motion) cleared the row's cells but never pushed anything to the undo stack, so pressing `u` afterwards did nothing. Vim makes `dd` undoable, and the issue reporter rightly expected the same here.
- Added a `MultiCellEdit { changes: Vec<(pos, old, new)> }` variant to `UndoEntry` so a grouped, atomic set of cell changes can be undone/redone as a single step.
- `DeleteRow` now records non-empty cells in a `MultiCellEdit` and skips marking the buffer dirty when the row was already empty (consistent with `ClearCell` / `ChangeCell`).
- Refactored `apply_undo_entry` to share a `restore_cell` helper between the two variants so formula restoration paths stay consistent.

Closes #5

## Test plan

- [x] `cargo test` (47/47 pass, including 3 new tests in `app::tests`)
  - `dd_can_be_undone` — full row content restored after `u`
  - `dd_can_be_redone` — `Ctrl-r` re-clears the row
  - `dd_undo_preserves_formula` — formulas re-evaluate after restoration (e.g. `=A1*2` returns `20`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manual smoke: enter `cell`, type a few cells, `dd`, then `u`, confirm row reappears


Made with [Cursor](https://cursor.com)