### PR TITLE
feat: non-interactive CLI mode for headless read/write/eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Non-interactive CLI mode for scripting against `.cell`, CSV, and TSV files
+  without launching the TUI: `--read <ref>` prints a cell or range, `--eval <expr>`
+  evaluates a formula in-place without saving, and repeatable `--write <ref> <value>`
+  flags batch into a single save (#6)
+
 ### Fixed
 
 - Visual-mode `d` (clear range) is now undoable with `u` and redoable with `Ctrl-R`, including formula preservation (#13)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "clap",
  "crossterm",
  "ratatui",
+ "tempfile",
 ]
 
 [[package]]
@@ -463,6 +464,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filedescriptor"
@@ -1371,6 +1378,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ To explore an example sheet with formulas, ranges, and IF logic:
 cell examples/demo.cell
 ```
 
+## Headless mode
+
+For shell pipelines, Makefiles, and CI, `cell` can read from and write to a
+file without launching the TUI:
+
+```sh
+cell sales.cell --read A1                 # print one cell's computed value
+cell sales.cell --read B1:B10             # print a range as TSV
+cell sales.cell --eval '=SUM(B1:B10)'     # evaluate a formula (no save)
+cell sales.cell --write A1 42             # set a cell, recalc, save in place
+cell sales.cell --write A1 42 --write B1 7 # batch multiple writes into one save
+cell sales.cell --write Total '=SUM(B:B)' --read Total  # write a formula, then print it
+```
+
+- Cell references are 1-indexed and Excel-style (`A1`, `AA10`, `A1:B3`).
+- The `=` prefix on `--eval` is optional.
+- Writes whose value starts with `=` are stored as formulas; others are auto-typed (number vs text).
+- Operations apply in a fixed order per invocation: writes → save → reads → evals.
+- Errors print to stderr; the process exits non-zero on bad refs, parse errors, or missing files.
+
 ## Keybindings
 
 If you know Vim, you know cell.

--- a/crates/cell-sheet-tui/Cargo.toml
+++ b/crates/cell-sheet-tui/Cargo.toml
@@ -18,3 +18,6 @@ cell-sheet-core.workspace = true
 ratatui = "0.30"
 crossterm = "0.29"
 clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/cell-sheet-tui/src/headless.rs
+++ b/crates/cell-sheet-tui/src/headless.rs
@@ -1,0 +1,212 @@
+//! Non-interactive CLI surface (issue #6).
+//!
+//! Lets users run `cell` headlessly to read/eval/write cells from shell
+//! pipelines, Makefiles, and CI without launching the TUI. Operations apply in
+//! a fixed order: writes → save → reads → evals. Results print to stdout, one
+//! per `--read`/`--eval` flag, and ranges render as TSV (rows separated by
+//! `\n`, columns by `\t`).
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use cell_sheet_core::formula::ast::{CellRef, Expr};
+use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use cell_sheet_core::formula::{eval, parser};
+use cell_sheet_core::io::{cell_format, csv as csv_io};
+use cell_sheet_core::model::{CellPos, CellValue, Sheet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Format {
+    Csv,
+    Tsv,
+    Cell,
+}
+
+impl Format {
+    fn from_path(path: &Path) -> Self {
+        match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase()
+            .as_str()
+        {
+            "tsv" => Format::Tsv,
+            "cell" => Format::Cell,
+            _ => Format::Csv,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Options {
+    pub file: PathBuf,
+    pub reads: Vec<String>,
+    pub evals: Vec<String>,
+    pub writes: Vec<(String, String)>,
+}
+
+impl Options {
+    pub fn is_active(&self) -> bool {
+        !self.reads.is_empty() || !self.evals.is_empty() || !self.writes.is_empty()
+    }
+}
+
+/// Run the requested headless operations and write their textual results to
+/// `out`. Errors are returned with a human-readable message; callers are
+/// responsible for emitting them to stderr and choosing an exit code.
+pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
+    let format = Format::from_path(&opts.file);
+    let (mut sheet, mut deps) = load(&opts.file, format)
+        .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
+
+    if !opts.writes.is_empty() {
+        for (idx, (ref_str, value)) in opts.writes.iter().enumerate() {
+            let pos = parse_single_ref(ref_str).ok_or_else(|| {
+                format!(
+                    "invalid cell reference for --write #{}: {ref_str:?}",
+                    idx + 1
+                )
+            })?;
+            apply_write(&mut sheet, &mut deps, pos, value);
+        }
+        recalculate(&mut sheet, &deps);
+        save(&opts.file, format, &sheet)
+            .map_err(|e| format!("failed to write {}: {e}", opts.file.display()))?;
+    }
+
+    for ref_str in &opts.reads {
+        let rendered = render_read(&sheet, ref_str)?;
+        writeln!(out, "{rendered}").map_err(|e| format!("write error: {e}"))?;
+    }
+
+    for expr in &opts.evals {
+        let formula = expr.strip_prefix('=').unwrap_or(expr);
+        let value = eval::evaluate(formula, &sheet);
+        if let CellValue::Error(err) = &value {
+            return Err(format!("evaluation error in {expr:?}: {err}"));
+        }
+        writeln!(out, "{value}").map_err(|e| format!("write error: {e}"))?;
+    }
+
+    Ok(())
+}
+
+fn load(path: &Path, format: Format) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
+    let file = std::fs::File::open(path)?;
+    let mut sheet = match format {
+        Format::Csv => csv_io::read_csv(file, b',')?,
+        Format::Tsv => csv_io::read_csv(file, b'\t')?,
+        Format::Cell => cell_format::read_cell_format(file)?,
+    };
+    let mut deps = DepGraph::new();
+
+    let formula_cells: Vec<_> = sheet
+        .cells
+        .iter()
+        .filter(|(_, cell)| cell.raw.starts_with('='))
+        .map(|(pos, cell)| (*pos, cell.raw.clone()))
+        .collect();
+    for (pos, raw) in formula_cells {
+        set_formula(&mut sheet, &mut deps, pos, &raw);
+    }
+    recalculate(&mut sheet, &deps);
+
+    Ok((sheet, deps))
+}
+
+fn save(path: &Path, format: Format, sheet: &Sheet) -> Result<(), Box<dyn std::error::Error>> {
+    let file = std::fs::File::create(path)?;
+    match format {
+        Format::Csv => csv_io::write_csv(sheet, file, b',')?,
+        Format::Tsv => csv_io::write_csv(sheet, file, b'\t')?,
+        Format::Cell => cell_format::write_cell_format(sheet, file)?,
+    }
+    Ok(())
+}
+
+fn apply_write(sheet: &mut Sheet, deps: &mut DepGraph, pos: CellPos, value: &str) {
+    if value.starts_with('=') {
+        set_formula(sheet, deps, pos, value);
+    } else {
+        // Drop any prior formula edges so dependents don't keep tracking this cell.
+        deps.remove(pos);
+        sheet.set_cell(pos, value);
+    }
+    mark_dirty(sheet, deps, pos);
+}
+
+/// Parse a single A1-style reference like "A1" or "AB12". 1-indexed rows.
+/// Internally reuses the formula parser so behaviour stays in sync with
+/// formulas typed inside the TUI.
+fn parse_single_ref(s: &str) -> Option<CellPos> {
+    let trimmed = s.trim();
+    let expr = parser::parse(trimmed).ok()?;
+    match expr {
+        Expr::CellRef(CellRef { row, col, .. }) => Some((row, col)),
+        _ => None,
+    }
+}
+
+fn parse_range_ref(s: &str) -> Option<(CellPos, CellPos)> {
+    let trimmed = s.trim();
+    let expr = parser::parse(trimmed).ok()?;
+    match expr {
+        Expr::CellRef(CellRef { row, col, .. }) => Some(((row, col), (row, col))),
+        Expr::Range { start, end } => {
+            let r1 = start.row.min(end.row);
+            let r2 = start.row.max(end.row);
+            let c1 = start.col.min(end.col);
+            let c2 = start.col.max(end.col);
+            Some(((r1, c1), (r2, c2)))
+        }
+        _ => None,
+    }
+}
+
+fn render_read(sheet: &Sheet, ref_str: &str) -> Result<String, String> {
+    let (start, end) = parse_range_ref(ref_str)
+        .ok_or_else(|| format!("invalid cell reference for --read: {ref_str:?}"))?;
+
+    let mut rows = Vec::with_capacity(end.0 - start.0 + 1);
+    for r in start.0..=end.0 {
+        let mut cols = Vec::with_capacity(end.1 - start.1 + 1);
+        for c in start.1..=end.1 {
+            let value = match sheet.get_cell((r, c)) {
+                Some(cell) => cell.value.to_string(),
+                None => String::new(),
+            };
+            cols.push(value);
+        }
+        rows.push(cols.join("\t"));
+    }
+    Ok(rows.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_ref_basic() {
+        assert_eq!(parse_single_ref("A1"), Some((0, 0)));
+        assert_eq!(parse_single_ref("B3"), Some((2, 1)));
+        assert_eq!(parse_single_ref("AA10"), Some((9, 26)));
+    }
+
+    #[test]
+    fn parse_single_ref_rejects_garbage() {
+        assert_eq!(parse_single_ref("not-a-ref"), None);
+        assert_eq!(parse_single_ref(""), None);
+        assert_eq!(parse_single_ref("A1:B2"), None);
+    }
+
+    #[test]
+    fn parse_range_ref_normalises_corners() {
+        assert_eq!(
+            parse_range_ref("B3:A1"),
+            Some(((0, 0), (2, 1))),
+            "range corners should be normalised so iteration is forward"
+        );
+    }
+}

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod clipboard;
+mod headless;
 mod mode;
 mod render;
 mod undo;
@@ -17,19 +18,72 @@ use crossterm::{
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 #[derive(Parser)]
 #[command(name = "cell", version, about = "A terminal spreadsheet editor")]
 struct Cli {
     /// File to open (CSV, TSV, or .cell)
     file: Option<PathBuf>,
+
+    /// Print the computed value of a cell or range (e.g. A1, A1:B3).
+    /// Repeat to read multiple refs. Ranges render as TSV.
+    #[arg(long, value_name = "REF")]
+    read: Vec<String>,
+
+    /// Evaluate a formula against the loaded sheet without persisting.
+    /// The leading `=` is optional. Repeat to evaluate multiple expressions.
+    #[arg(long, value_name = "EXPR")]
+    eval: Vec<String>,
+
+    /// Set a cell to a value (auto-detects formula if it starts with `=`).
+    /// Repeat to batch multiple writes into a single save.
+    #[arg(long, value_names = ["REF", "VALUE"], num_args = 2)]
+    write: Vec<String>,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> ExitCode {
     let cli = Cli::parse();
+
+    let opts = headless::Options {
+        file: cli.file.clone().unwrap_or_default(),
+        reads: cli.read,
+        evals: cli.eval,
+        writes: cli
+            .write
+            .chunks_exact(2)
+            .map(|c| (c[0].clone(), c[1].clone()))
+            .collect(),
+    };
+
+    if opts.is_active() {
+        if cli.file.is_none() {
+            eprintln!("error: a FILE argument is required for --read/--eval/--write");
+            return ExitCode::from(2);
+        }
+        let mut stdout = io::stdout().lock();
+        return match headless::run(&opts, &mut stdout) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(msg) => {
+                eprintln!("error: {msg}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    match run_tui(cli.file.as_deref()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_tui(file: Option<&std::path::Path>) -> Result<(), Box<dyn std::error::Error>> {
     let mut app = App::new();
 
-    if let Some(path) = &cli.file {
+    if let Some(path) = file {
         load_file(&mut app, path)?;
     }
 

--- a/crates/cell-sheet-tui/tests/headless.rs
+++ b/crates/cell-sheet-tui/tests/headless.rs
@@ -1,0 +1,220 @@
+//! Integration tests for the non-interactive (headless) CLI surface added in #6.
+//!
+//! These spawn the `cell` binary directly and assert on stdout/stderr/exit
+//! status, so they exercise the same code path real users hit from the shell.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_cell");
+
+fn write_csv(dir: &TempDir, name: &str, contents: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(contents.as_bytes()).unwrap();
+    path
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(BIN)
+        .args(args)
+        .output()
+        .expect("failed to spawn cell binary")
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8(out.stdout.clone()).unwrap()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8(out.stderr.clone()).unwrap()
+}
+
+fn cell_path(dir: &TempDir, name: &str) -> PathBuf {
+    dir.path().join(name)
+}
+
+#[test]
+fn read_single_cell_prints_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "10,20\n30,40\n");
+
+    let out = run(&[path.to_str().unwrap(), "--read", "A1"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "10\n");
+}
+
+#[test]
+fn read_range_prints_tsv_grid() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "10,20\n30,40\n");
+
+    let out = run(&[path.to_str().unwrap(), "--read", "A1:B2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "10\t20\n30\t40\n");
+}
+
+#[test]
+fn read_evaluates_formula_cells() {
+    let dir = tempfile::tempdir().unwrap();
+    // .cell format preserves formulas; reading A2 must return the computed value.
+    let cell_file = "# cell v1\nsize 2 1\nlet A0 = 5\nformula A1 = =A1+3\n";
+    let path = cell_path(&dir, "data.cell");
+    std::fs::write(&path, cell_file).unwrap();
+
+    let out = run(&[path.to_str().unwrap(), "--read", "A2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "8\n");
+}
+
+#[test]
+fn eval_runs_against_loaded_sheet() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1\n2\n3\n4\n");
+
+    let out = run(&[path.to_str().unwrap(), "--eval", "=SUM(A1:A4)"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "10\n");
+}
+
+#[test]
+fn eval_accepts_expr_without_leading_equals() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1\n2\n3\n");
+
+    let out = run(&[path.to_str().unwrap(), "--eval", "AVERAGE(A1:A3)"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "2\n");
+}
+
+#[test]
+fn eval_does_not_persist() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1,2\n");
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    let out = run(&[path.to_str().unwrap(), "--eval", "=A1+B1"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(before, after, "--eval must not modify the file");
+}
+
+#[test]
+fn single_write_persists_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1,2\n3,4\n");
+
+    let out = run(&[path.to_str().unwrap(), "--write", "A1", "42"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert!(after.starts_with("42,2\n"), "got: {after:?}");
+}
+
+#[test]
+fn write_then_read_sees_new_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1\n");
+
+    let out = run(&[
+        path.to_str().unwrap(),
+        "--write",
+        "A1",
+        "99",
+        "--read",
+        "A1",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "99\n");
+}
+
+#[test]
+fn write_formula_recalculates_dependents() {
+    let dir = tempfile::tempdir().unwrap();
+    let cell_file = "# cell v1\nsize 2 1\nlet A0 = 1\nformula A1 = =A1*10\n";
+    let path = cell_path(&dir, "data.cell");
+    std::fs::write(&path, cell_file).unwrap();
+
+    let out = run(&[path.to_str().unwrap(), "--write", "A1", "7", "--read", "A2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "70\n");
+}
+
+#[test]
+fn batched_writes_apply_in_order_and_save_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", ",,\n");
+
+    let out = run(&[
+        path.to_str().unwrap(),
+        "--write",
+        "A1",
+        "10",
+        "--write",
+        "B1",
+        "20",
+        "--write",
+        "C1",
+        "30",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert!(after.starts_with("10,20,30\n"), "got: {after:?}");
+}
+
+#[test]
+fn write_auto_detects_formula() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = cell_path(&dir, "data.cell");
+    std::fs::write(&path, "# cell v1\nsize 1 2\nlet A0 = 4\n").unwrap();
+
+    let out = run(&[
+        path.to_str().unwrap(),
+        "--write",
+        "B1",
+        "=A1*5",
+        "--read",
+        "B1",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "20\n");
+
+    // Round-trip: re-open with no flags should still see the stored formula.
+    let saved = std::fs::read_to_string(&path).unwrap();
+    assert!(saved.contains("formula B0 = =A1*5"), "got: {saved:?}");
+}
+
+#[test]
+fn bad_ref_errors_to_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1,2\n");
+
+    let out = run(&[path.to_str().unwrap(), "--read", "not-a-ref"]);
+    assert!(!out.status.success());
+    assert!(
+        !stderr(&out).is_empty(),
+        "expected an error message on stderr"
+    );
+}
+
+#[test]
+fn eval_parse_error_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "1\n");
+
+    let out = run(&[path.to_str().unwrap(), "--eval", "1++"]);
+    assert!(!out.status.success(), "stdout: {}", stdout(&out));
+    assert!(!stderr(&out).is_empty());
+}
+
+#[test]
+fn missing_file_exits_nonzero() {
+    let missing = Path::new("/definitely/not/a/real/path/cell-test-missing.csv");
+    let out = run(&[missing.to_str().unwrap(), "--read", "A1"]);
+    assert!(!out.status.success());
+    assert!(!stderr(&out).is_empty());
+}


### PR DESCRIPTION
Closes #6.

## Summary

Adds a non-interactive CLI surface so `cell` can be used in shell pipelines, Makefiles, and CI without launching the TUI:

- `--read <ref>` prints the computed value of a cell or range (`A1`, `A1:B3`); ranges render as TSV.
- `--eval <expr>` evaluates a formula against the loaded sheet without persisting (leading `=` optional).
- `--write <ref> <value>` sets a cell, auto-detecting formula vs literal; repeat the flag to batch multiple writes into a single save.
- Operations apply in a fixed order per invocation: writes → save → reads → evals.
- Cell refs are 1-indexed A1-style and reuse the existing formula parser so addressing stays consistent with formulas typed inside the TUI.
- Errors print to stderr; the process exits non-zero on bad refs, parse errors, or missing files.

The `cell-sheet-core` crate stays TUI-free; all new code lives in a new `crates/cell-sheet-tui/src/headless.rs` module dispatched from `main.rs` before the terminal is initialized, so headless mode never touches `crossterm`/raw mode.

## Examples on \`examples/demo.cell\`

```sh
cell examples/demo.cell --read E4                  # Rent's Q1 total -> 3600
cell examples/demo.cell --read B10:E10             # Monthly Total row as TSV
cell examples/demo.cell --eval '=SUM(B10:D10)'     # Q1 grand total
cell sales.cell --write A1 42 --write B1 7         # batch writes, one save
cell sales.cell --write Total '=SUM(B:B)' --read Total
```

## Test plan

- [x] \`cargo test --workspace\` (103 + 5 + 66 + 14 + 0 passing, all green)
- [x] \`cargo fmt --check\` and \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] 14 integration tests in \`crates/cell-sheet-tui/tests/headless.rs\` covering the acceptance criteria from #6: read cell, read range, read formula cell, eval with/without \`=\`, eval not persisting, single write, write+read, formula write recalculating dependents, batched writes saving once, formula round-trip, bad ref, eval parse error, missing file
- [x] Manual smoke check against \`examples/demo.cell\` (read, range, eval, write+read on a copy)

## Docs

- New \"Headless mode\" section in README.md
- CHANGELOG entry under Unreleased

Made with [Cursor](https://cursor.com)