### PR TITLE
feat: vim quick-wins (zz/H/marks/jump-list/{}/star/gv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Vim-style viewport motions in normal mode: `zz` / `zt` / `zb` recenter / scroll-to-top / scroll-to-bottom around the cursor, `H` / `M` / `L` jump the cursor to the topmost / middle / bottommost visible row, and `Ctrl-e` / `Ctrl-y` scroll the viewport one row without moving the cursor (#30)
+- Marks: `m{a-z}` records the cursor position, `'{a-z}` jumps to the marked row at column 0, `` `{a-z} `` jumps to the exact marked cell. Jumping to an unset mark surfaces an `E20: Mark not set` status message (#31)
+- Jump list with `Ctrl-o` (back) and `Ctrl-i` / Tab (forward), tracking cursor history across `gg`, `G`, marks, and `/` searches. Mid-stack jumps truncate the forward history; the list is capped at 100 entries (#32)
+- Block-jump in the current column: `}` jumps to the next block boundary downward and `{` upward, mirroring vim's paragraph motion. From a non-empty cell they land on the first empty row past the current block; from an empty cell they land on the next non-empty row (#35)
+- `*` and `#` search for the value of the cell under the cursor, forward and backward respectively, populating the search pattern so `n` and `N` keep stepping (#36)
+- `gv` re-enters the previous visual selection with the same anchor, cursor, and visual kind (Character / Line / Block) (#37)
+
 ## 0.2.0
 
 ### Notes

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -91,6 +91,8 @@ pub enum Action {
     },
     JumpBack,
     JumpForward,
+    BlockJumpDown,
+    BlockJumpUp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -94,6 +94,7 @@ pub enum Action {
     SearchCellValue {
         backward: bool,
     },
+    ReselectLastVisual,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -12,7 +12,6 @@ pub enum Direction {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SearchDirection {
     Forward,
-    #[allow(dead_code)]
     Backward,
 }
 
@@ -54,7 +53,6 @@ pub enum Action {
         col: usize,
         ascending: bool,
     },
-    #[allow(dead_code)]
     Search {
         pattern: String,
         direction: SearchDirection,
@@ -93,6 +91,9 @@ pub enum Action {
     JumpForward,
     BlockJumpDown,
     BlockJumpUp,
+    SearchCellValue {
+        backward: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -84,6 +84,11 @@ pub enum Action {
     CursorToViewportBottom,
     ScrollLineDown,
     ScrollLineUp,
+    SetMark(char),
+    JumpToMark {
+        name: char,
+        line_wise: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -89,6 +89,8 @@ pub enum Action {
         name: char,
         line_wise: bool,
     },
+    JumpBack,
+    JumpForward,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -76,6 +76,14 @@ pub enum Action {
     DeleteRow(usize),
     YankRow(usize),
     ShowHelp(Option<String>),
+    ScrollCursorTop,
+    ScrollCursorCenter,
+    ScrollCursorBottom,
+    CursorToViewportTop,
+    CursorToViewportMiddle,
+    CursorToViewportBottom,
+    ScrollLineDown,
+    ScrollLineUp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -5,6 +5,7 @@ use crate::viewport::Viewport;
 use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
 use cell_sheet_core::help::HelpRegistry;
 use cell_sheet_core::model::{CellPos, Sheet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -33,6 +34,7 @@ pub struct App {
     pub help_scroll: usize,
     pub help_topic: Option<String>,
     pub help_registry: HelpRegistry,
+    pub marks: HashMap<char, CellPos>,
 }
 
 impl App {
@@ -56,6 +58,7 @@ impl App {
             help_scroll: 0,
             help_topic: None,
             help_registry: HelpRegistry::new(),
+            marks: HashMap::new(),
         }
     }
 
@@ -505,6 +508,20 @@ impl App {
             Action::ScrollLineUp => {
                 self.viewport.row_offset = self.viewport.row_offset.saturating_sub(1);
             }
+            Action::SetMark(name) => {
+                if name.is_ascii_lowercase() {
+                    self.marks.insert(name, self.cursor);
+                }
+            }
+            Action::JumpToMark { name, line_wise } => match self.marks.get(&name).copied() {
+                Some(pos) => {
+                    self.cursor = if line_wise { (pos.0, 0) } else { pos };
+                    self.viewport.ensure_visible(self.cursor);
+                }
+                None => {
+                    self.status_message = Some(format!("E20: Mark not set: {}", name));
+                }
+            },
             Action::Open(_) | Action::Resize => {}
         }
     }
@@ -1031,6 +1048,68 @@ mod tests {
         app.process_action(Action::ScrollLineDown);
         assert_eq!(app.viewport.row_offset, 1);
         assert_eq!(app.cursor, (5, 0));
+    }
+
+    // ── Marks (#31) ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn set_mark_records_cursor_position() {
+        let mut app = App::new();
+        app.cursor = (5, 3);
+        app.process_action(Action::SetMark('a'));
+        assert_eq!(app.marks.get(&'a'), Some(&(5, 3)));
+    }
+
+    #[test]
+    fn backtick_jump_returns_to_exact_cell() {
+        let mut app = App::new();
+        app.cursor = (5, 3);
+        app.process_action(Action::SetMark('a'));
+        app.cursor = (0, 0);
+        app.process_action(Action::JumpToMark {
+            name: 'a',
+            line_wise: false,
+        });
+        assert_eq!(app.cursor, (5, 3));
+    }
+
+    #[test]
+    fn apostrophe_jump_returns_to_marked_row_column_zero() {
+        let mut app = App::new();
+        app.cursor = (5, 3);
+        app.process_action(Action::SetMark('a'));
+        app.cursor = (0, 0);
+        app.process_action(Action::JumpToMark {
+            name: 'a',
+            line_wise: true,
+        });
+        assert_eq!(app.cursor, (5, 0));
+    }
+
+    #[test]
+    fn jump_to_unset_mark_is_noop_with_status() {
+        let mut app = App::new();
+        app.cursor = (1, 1);
+        app.process_action(Action::JumpToMark {
+            name: 'q',
+            line_wise: false,
+        });
+        assert_eq!(app.cursor, (1, 1));
+        assert!(app
+            .status_message
+            .as_deref()
+            .unwrap()
+            .contains("Mark not set"));
+    }
+
+    #[test]
+    fn set_mark_rejects_non_lowercase() {
+        let mut app = App::new();
+        app.cursor = (5, 3);
+        app.process_action(Action::SetMark('A'));
+        assert!(app.marks.get(&'A').is_none());
+        app.process_action(Action::SetMark('1'));
+        assert!(app.marks.get(&'1').is_none());
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -1,5 +1,6 @@
 use crate::action::{Action, Direction, Mode};
 use crate::clipboard::Register;
+use crate::mode::visual::VisualKind;
 use crate::undo::{UndoEntry, UndoStack};
 use crate::viewport::Viewport;
 use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
@@ -37,9 +38,17 @@ pub struct App {
     pub marks: HashMap<char, CellPos>,
     pub jump_list: Vec<CellPos>,
     pub jump_idx: usize,
+    pub last_visual: Option<LastVisual>,
 }
 
 const JUMP_LIST_CAP: usize = 100;
+
+#[derive(Debug, Clone, Copy)]
+pub struct LastVisual {
+    pub anchor: CellPos,
+    pub cursor: CellPos,
+    pub kind: VisualKind,
+}
 
 impl App {
     pub fn new() -> Self {
@@ -65,7 +74,17 @@ impl App {
             marks: HashMap::new(),
             jump_list: Vec::new(),
             jump_idx: 0,
+            last_visual: None,
         }
+    }
+
+    /// Snapshot the current visual selection so a later `gv` can re-enter it.
+    pub fn record_last_visual(&mut self, anchor: CellPos, kind: VisualKind) {
+        self.last_visual = Some(LastVisual {
+            anchor,
+            cursor: self.cursor,
+            kind,
+        });
     }
 
     /// Push the current cursor onto the jump list as a "from" position
@@ -579,6 +598,10 @@ impl App {
                     self.cursor = (row, self.cursor.1);
                     self.viewport.ensure_visible(self.cursor);
                 }
+            }
+            Action::ReselectLastVisual => {
+                // Re-entry into visual mode is orchestrated in main.rs because
+                // it owns the live `VisualState`. App only stores the snapshot.
             }
             Action::SearchCellValue { backward } => {
                 let pattern = self
@@ -1338,6 +1361,28 @@ mod tests {
         app.cursor = (0, 0);
         app.process_action(Action::BlockJumpUp);
         assert_eq!(app.cursor, (0, 0));
+    }
+
+    // ── gv reselect last visual (#37) ───────────────────────────────────────
+
+    #[test]
+    fn record_last_visual_saves_anchor_cursor_kind() {
+        let mut app = App::new();
+        app.cursor = (3, 4);
+        app.record_last_visual((1, 2), VisualKind::Line);
+        let lv = app.last_visual.unwrap();
+        assert_eq!(lv.anchor, (1, 2));
+        assert_eq!(lv.cursor, (3, 4));
+        assert!(matches!(lv.kind, VisualKind::Line));
+    }
+
+    #[test]
+    fn reselect_last_visual_action_is_a_noop_in_app() {
+        let mut app = App::new();
+        app.cursor = (1, 1);
+        app.process_action(Action::ReselectLastVisual);
+        assert_eq!(app.cursor, (1, 1));
+        assert_eq!(app.mode, Mode::Normal);
     }
 
     // ── * / # search current cell value (#36) ───────────────────────────────

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -580,6 +580,25 @@ impl App {
                     self.viewport.ensure_visible(self.cursor);
                 }
             }
+            Action::SearchCellValue { backward } => {
+                let pattern = self
+                    .sheet
+                    .get_cell(self.cursor)
+                    .map(|c| c.value.to_string());
+                if let Some(p) = pattern.filter(|s| !s.is_empty()) {
+                    let direction = if backward {
+                        crate::action::SearchDirection::Backward
+                    } else {
+                        crate::action::SearchDirection::Forward
+                    };
+                    self.process_action(Action::Search {
+                        pattern: p,
+                        direction,
+                    });
+                } else {
+                    self.status_message = Some("No string under cursor".into());
+                }
+            }
             Action::Open(_) | Action::Resize => {}
         }
     }
@@ -1319,6 +1338,41 @@ mod tests {
         app.cursor = (0, 0);
         app.process_action(Action::BlockJumpUp);
         assert_eq!(app.cursor, (0, 0));
+    }
+
+    // ── * / # search current cell value (#36) ───────────────────────────────
+
+    #[test]
+    fn star_searches_for_current_cell_value() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "foo".into()));
+        app.process_action(Action::EditCell((3, 2), "foo".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::SearchCellValue { backward: false });
+        assert_eq!(app.cursor, (3, 2));
+        assert_eq!(app.search_pattern.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn hash_searches_backward_for_current_cell_value() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "foo".into()));
+        app.process_action(Action::EditCell((3, 2), "foo".into()));
+        app.cursor = (3, 2);
+        app.process_action(Action::SearchCellValue { backward: true });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn star_on_empty_cell_is_noop() {
+        let mut app = App::new();
+        app.cursor = (0, 0);
+        app.process_action(Action::SearchCellValue { backward: false });
+        assert_eq!(app.search_pattern, None);
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("No string under cursor")
+        );
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -35,7 +35,11 @@ pub struct App {
     pub help_topic: Option<String>,
     pub help_registry: HelpRegistry,
     pub marks: HashMap<char, CellPos>,
+    pub jump_list: Vec<CellPos>,
+    pub jump_idx: usize,
 }
+
+const JUMP_LIST_CAP: usize = 100;
 
 impl App {
     pub fn new() -> Self {
@@ -59,7 +63,24 @@ impl App {
             help_topic: None,
             help_registry: HelpRegistry::new(),
             marks: HashMap::new(),
+            jump_list: Vec::new(),
+            jump_idx: 0,
         }
+    }
+
+    /// Push the current cursor onto the jump list as a "from" position
+    /// before a big jump. Following vim, recording mid-stack truncates the
+    /// forward history. Capped at `JUMP_LIST_CAP` entries.
+    pub fn record_jump(&mut self) {
+        if self.jump_idx < self.jump_list.len() {
+            self.jump_list.truncate(self.jump_idx);
+        }
+        self.jump_list.push(self.cursor);
+        if self.jump_list.len() > JUMP_LIST_CAP {
+            let overflow = self.jump_list.len() - JUMP_LIST_CAP;
+            self.jump_list.drain(0..overflow);
+        }
+        self.jump_idx = self.jump_list.len();
     }
 
     pub fn has_formulas(&self) -> bool {
@@ -80,6 +101,7 @@ impl App {
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::MoveCursorTo(pos) => {
+                self.record_jump();
                 self.cursor = pos;
                 self.viewport.ensure_visible(self.cursor);
             }
@@ -179,10 +201,12 @@ impl App {
                 self.mode = Mode::Insert;
             }
             Action::GotoFirstRow => {
+                self.record_jump();
                 self.cursor = (0, self.cursor.1);
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::GotoLastRow => {
+                self.record_jump();
                 let last = if self.sheet.row_count > 0 {
                     self.sheet.row_count - 1
                 } else {
@@ -257,16 +281,19 @@ impl App {
                 }
             }
             Action::Search { pattern, direction } => {
+                self.record_jump();
                 self.search_pattern = Some(pattern.clone());
                 self.find_next(direction == crate::action::SearchDirection::Forward);
             }
             Action::SearchNext => {
                 if self.search_pattern.is_some() {
+                    self.record_jump();
                     self.find_next(true);
                 }
             }
             Action::SearchPrev => {
                 if self.search_pattern.is_some() {
+                    self.record_jump();
                     self.find_next(false);
                 }
             }
@@ -515,6 +542,7 @@ impl App {
             }
             Action::JumpToMark { name, line_wise } => match self.marks.get(&name).copied() {
                 Some(pos) => {
+                    self.record_jump();
                     self.cursor = if line_wise { (pos.0, 0) } else { pos };
                     self.viewport.ensure_visible(self.cursor);
                 }
@@ -522,6 +550,24 @@ impl App {
                     self.status_message = Some(format!("E20: Mark not set: {}", name));
                 }
             },
+            Action::JumpBack => {
+                if self.jump_idx == self.jump_list.len() && !self.jump_list.is_empty() {
+                    let cur = self.cursor;
+                    self.jump_list.push(cur);
+                }
+                if self.jump_idx > 0 {
+                    self.jump_idx -= 1;
+                    self.cursor = self.jump_list[self.jump_idx];
+                    self.viewport.ensure_visible(self.cursor);
+                }
+            }
+            Action::JumpForward => {
+                if self.jump_idx + 1 < self.jump_list.len() {
+                    self.jump_idx += 1;
+                    self.cursor = self.jump_list[self.jump_idx];
+                    self.viewport.ensure_visible(self.cursor);
+                }
+            }
             Action::Open(_) | Action::Resize => {}
         }
     }
@@ -1100,6 +1146,79 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("Mark not set"));
+    }
+
+    // ── Jump list (#32) ─────────────────────────────────────────────────────
+
+    #[test]
+    fn ctrl_o_returns_to_position_before_jump() {
+        let mut app = App::new();
+        app.sheet.row_count = 100;
+        app.cursor = (0, 0);
+        app.process_action(Action::GotoLastRow);
+        assert_eq!(app.cursor, (99, 0));
+        app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn ctrl_i_returns_to_jumped_position() {
+        let mut app = App::new();
+        app.sheet.row_count = 100;
+        app.cursor = (0, 0);
+        app.process_action(Action::GotoLastRow);
+        app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (0, 0));
+        app.process_action(Action::JumpForward);
+        assert_eq!(app.cursor, (99, 0));
+    }
+
+    #[test]
+    fn jump_list_capped_at_100_entries() {
+        let mut app = App::new();
+        app.sheet.row_count = 200;
+        for r in 0..150 {
+            app.cursor = (r, 0);
+            app.process_action(Action::GotoLastRow);
+        }
+        assert!(app.jump_list.len() <= 100);
+    }
+
+    #[test]
+    fn jump_back_with_empty_list_is_noop() {
+        let mut app = App::new();
+        app.cursor = (5, 0);
+        app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (5, 0));
+    }
+
+    #[test]
+    fn search_records_jump() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((5, 0), "foo".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::Search {
+            pattern: "foo".into(),
+            direction: crate::action::SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (5, 0));
+        app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn marks_jump_records_jump() {
+        let mut app = App::new();
+        app.cursor = (5, 5);
+        app.process_action(Action::SetMark('a'));
+        app.cursor = (0, 0);
+        app.process_action(Action::JumpToMark {
+            name: 'a',
+            line_wise: false,
+        });
+        assert_eq!(app.cursor, (5, 5));
+        app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (0, 0));
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -543,8 +543,8 @@ impl App {
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::CursorToViewportBottom => {
-                let bottom = (self.viewport.row_offset + self.viewport.visible_rows)
-                    .saturating_sub(1);
+                let bottom =
+                    (self.viewport.row_offset + self.viewport.visible_rows).saturating_sub(1);
                 self.cursor = (bottom, self.cursor.1);
                 self.viewport.ensure_visible(self.cursor);
             }
@@ -1449,9 +1449,9 @@ mod tests {
         let mut app = App::new();
         app.cursor = (5, 3);
         app.process_action(Action::SetMark('A'));
-        assert!(app.marks.get(&'A').is_none());
+        assert!(!app.marks.contains_key(&'A'));
         app.process_action(Action::SetMark('1'));
-        assert!(app.marks.get(&'1').is_none());
+        assert!(!app.marks.contains_key(&'1'));
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -470,6 +470,41 @@ impl App {
                     self.mode = Mode::Help;
                 }
             },
+            Action::ScrollCursorTop => {
+                self.viewport.top_on(self.cursor.0);
+            }
+            Action::ScrollCursorCenter => {
+                self.viewport.center_on(self.cursor.0);
+            }
+            Action::ScrollCursorBottom => {
+                self.viewport.bottom_on(self.cursor.0);
+            }
+            Action::CursorToViewportTop => {
+                self.cursor = (self.viewport.row_offset, self.cursor.1);
+                self.viewport.ensure_visible(self.cursor);
+            }
+            Action::CursorToViewportMiddle => {
+                let mid = self
+                    .viewport
+                    .row_offset
+                    .saturating_add(self.viewport.visible_rows / 2);
+                let last_row = self.viewport.row_offset + self.viewport.visible_rows;
+                let target = mid.min(last_row.saturating_sub(1));
+                self.cursor = (target, self.cursor.1);
+                self.viewport.ensure_visible(self.cursor);
+            }
+            Action::CursorToViewportBottom => {
+                let bottom = (self.viewport.row_offset + self.viewport.visible_rows)
+                    .saturating_sub(1);
+                self.cursor = (bottom, self.cursor.1);
+                self.viewport.ensure_visible(self.cursor);
+            }
+            Action::ScrollLineDown => {
+                self.viewport.row_offset = self.viewport.row_offset.saturating_add(1);
+            }
+            Action::ScrollLineUp => {
+                self.viewport.row_offset = self.viewport.row_offset.saturating_sub(1);
+            }
             Action::Open(_) | Action::Resize => {}
         }
     }
@@ -926,6 +961,85 @@ mod tests {
 
         assert!(app.sheet.get_cell((0, 0)).is_none());
         assert!(app.sheet.get_cell((0, 1)).is_none());
+    }
+
+    // ── Viewport navigation (#30) ───────────────────────────────────────────
+
+    #[test]
+    fn zt_scrolls_cursor_to_top() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.cursor = (50, 0);
+        app.process_action(Action::ScrollCursorTop);
+        assert_eq!(app.viewport.row_offset, 50);
+        assert_eq!(app.cursor, (50, 0));
+    }
+
+    #[test]
+    fn zz_centers_cursor() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.cursor = (50, 0);
+        app.process_action(Action::ScrollCursorCenter);
+        assert_eq!(app.viewport.row_offset, 45);
+    }
+
+    #[test]
+    fn zb_scrolls_cursor_to_bottom() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.cursor = (50, 0);
+        app.process_action(Action::ScrollCursorBottom);
+        assert_eq!(app.viewport.row_offset, 41);
+    }
+
+    #[test]
+    fn capital_h_jumps_cursor_to_viewport_top() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.viewport.row_offset = 20;
+        app.cursor = (25, 3);
+        app.process_action(Action::CursorToViewportTop);
+        assert_eq!(app.cursor, (20, 3));
+    }
+
+    #[test]
+    fn capital_m_jumps_cursor_to_viewport_middle() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.viewport.row_offset = 20;
+        app.cursor = (20, 3);
+        app.process_action(Action::CursorToViewportMiddle);
+        assert_eq!(app.cursor, (25, 3));
+    }
+
+    #[test]
+    fn capital_l_jumps_cursor_to_viewport_bottom() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.viewport.row_offset = 20;
+        app.cursor = (20, 3);
+        app.process_action(Action::CursorToViewportBottom);
+        assert_eq!(app.cursor, (29, 3));
+    }
+
+    #[test]
+    fn ctrl_e_scrolls_viewport_without_moving_cursor() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.cursor = (5, 0);
+        app.process_action(Action::ScrollLineDown);
+        assert_eq!(app.viewport.row_offset, 1);
+        assert_eq!(app.cursor, (5, 0));
+    }
+
+    #[test]
+    fn ctrl_y_scrolls_up_clamped_at_zero() {
+        let mut app = App::new();
+        app.viewport.visible_rows = 10;
+        app.viewport.row_offset = 0;
+        app.process_action(Action::ScrollLineUp);
+        assert_eq!(app.viewport.row_offset, 0);
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -568,6 +568,18 @@ impl App {
                     self.viewport.ensure_visible(self.cursor);
                 }
             }
+            Action::BlockJumpDown => {
+                if let Some(row) = self.block_jump_down() {
+                    self.cursor = (row, self.cursor.1);
+                    self.viewport.ensure_visible(self.cursor);
+                }
+            }
+            Action::BlockJumpUp => {
+                if let Some(row) = self.block_jump_up() {
+                    self.cursor = (row, self.cursor.1);
+                    self.viewport.ensure_visible(self.cursor);
+                }
+            }
             Action::Open(_) | Action::Resize => {}
         }
     }
@@ -609,6 +621,50 @@ impl App {
             Err(e) => {
                 self.status_message = Some(format!("Error saving: {}", e));
             }
+        }
+    }
+
+    fn cell_is_non_empty(&self, row: usize, col: usize) -> bool {
+        self.sheet.get_cell((row, col)).is_some()
+    }
+
+    /// Spec: `}` from a non-empty cell jumps to the first empty row at-or-after
+    /// the current block's last non-empty row. From an empty cell, jumps to
+    /// the first non-empty row below. Returns `None` at the sheet boundary.
+    pub fn block_jump_down(&self) -> Option<usize> {
+        let (row, col) = self.cursor;
+        let n = self.sheet.row_count;
+        if row + 1 >= n {
+            return None;
+        }
+        let start_filled = self.cell_is_non_empty(row, col);
+        let mut r = row + 1;
+        while r < n && self.cell_is_non_empty(r, col) == start_filled {
+            r += 1;
+        }
+        if r < n {
+            Some(r)
+        } else {
+            None
+        }
+    }
+
+    /// Symmetric to `block_jump_down`.
+    pub fn block_jump_up(&self) -> Option<usize> {
+        let (row, col) = self.cursor;
+        if row == 0 {
+            return None;
+        }
+        let start_filled = self.cell_is_non_empty(row, col);
+        let mut r = row - 1;
+        loop {
+            if self.cell_is_non_empty(r, col) != start_filled {
+                return Some(r);
+            }
+            if r == 0 {
+                return None;
+            }
+            r -= 1;
         }
     }
 
@@ -1203,6 +1259,74 @@ mod tests {
         });
         assert_eq!(app.cursor, (5, 0));
         app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    // ── Block jump (#35) ────────────────────────────────────────────────────
+
+    #[test]
+    fn block_jump_down_from_inside_block_to_first_empty() {
+        let mut app = App::new();
+        for r in 0..3 {
+            app.process_action(Action::EditCell((r, 0), "x".into()));
+        }
+        app.process_action(Action::EditCell((4, 0), "y".into()));
+        app.cursor = (1, 0);
+        app.process_action(Action::BlockJumpDown);
+        assert_eq!(app.cursor, (3, 0));
+    }
+
+    #[test]
+    fn block_jump_down_from_empty_to_first_non_empty() {
+        let mut app = App::new();
+        app.sheet.row_count = 6;
+        app.process_action(Action::EditCell((4, 0), "y".into()));
+        app.cursor = (1, 0);
+        app.process_action(Action::BlockJumpDown);
+        assert_eq!(app.cursor, (4, 0));
+    }
+
+    #[test]
+    fn block_jump_up_symmetric_finds_first_empty_above() {
+        let mut app = App::new();
+        for r in 0..2 {
+            app.process_action(Action::EditCell((r, 0), "x".into()));
+        }
+        app.process_action(Action::EditCell((4, 0), "y".into()));
+        app.cursor = (4, 0);
+        app.process_action(Action::BlockJumpUp);
+        // (4,0) is non-empty, so jump up to first empty row → row 3.
+        assert_eq!(app.cursor, (3, 0));
+    }
+
+    #[test]
+    fn block_jump_up_from_empty_to_first_non_empty() {
+        let mut app = App::new();
+        for r in 0..2 {
+            app.process_action(Action::EditCell((r, 0), "x".into()));
+        }
+        app.process_action(Action::EditCell((5, 0), "y".into()));
+        app.cursor = (4, 0);
+        app.process_action(Action::BlockJumpUp);
+        // (4,0) is empty, so jump up to first non-empty row → row 1.
+        assert_eq!(app.cursor, (1, 0));
+    }
+
+    #[test]
+    fn block_jump_up_at_top_is_noop() {
+        let mut app = App::new();
+        app.sheet.row_count = 5;
+        app.cursor = (0, 0);
+        app.process_action(Action::BlockJumpUp);
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn block_jump_down_at_bottom_is_noop() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "x".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::BlockJumpDown);
         assert_eq!(app.cursor, (0, 0));
     }
 

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -235,6 +235,9 @@ fn run_loop(
                                     | Action::ChangeRange { .. }
                             );
                             if exits {
+                                let anchor = vs.anchor;
+                                let kind = vs.kind;
+                                app.record_last_visual(anchor, kind);
                                 visual_state = None;
                                 app.mode = Mode::Normal;
                             }
@@ -304,6 +307,18 @@ fn run_loop(
                 if let Action::ChangeMode(Mode::Command) = &action {
                     if key.code == KeyCode::Char('/') {
                         search_mode = true;
+                    }
+                }
+                if matches!(&action, Action::ReselectLastVisual) {
+                    if let Some(lv) = app.last_visual {
+                        visual_state = Some(VisualState::new(lv.anchor, lv.kind));
+                        app.cursor = lv.cursor;
+                        app.mode = match lv.kind {
+                            VisualKind::Character => Mode::Visual,
+                            VisualKind::Line => Mode::VisualLine,
+                            VisualKind::Block => Mode::VisualBlock,
+                        };
+                        app.viewport.ensure_visible(app.cursor);
                     }
                 }
 

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -106,6 +106,8 @@ impl NormalState {
             KeyCode::Char('/') => Action::ChangeMode(Mode::Command),
             KeyCode::Char('n') => Action::SearchNext,
             KeyCode::Char('N') => Action::SearchPrev,
+            KeyCode::Char('*') => Action::SearchCellValue { backward: false },
+            KeyCode::Char('#') => Action::SearchCellValue { backward: true },
             KeyCode::Tab => Action::JumpForward,
             KeyCode::Enter => Action::ChangeMode(Mode::Insert),
             _ => Action::Noop,
@@ -353,6 +355,26 @@ mod tests {
                 name: 'a',
                 line_wise: false
             }
+        );
+    }
+
+    #[test]
+    fn star_searches_cell_value_forward() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('*')), &app),
+            Action::SearchCellValue { backward: false }
+        );
+    }
+
+    #[test]
+    fn hash_searches_cell_value_backward() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('#')), &app),
+            Action::SearchCellValue { backward: true }
         );
     }
 

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -32,6 +32,7 @@ impl NormalState {
         if let Some(prev) = self.pending.take() {
             return match (prev, key.code) {
                 ('g', KeyCode::Char('g')) => Action::GotoFirstRow,
+                ('g', KeyCode::Char('v')) => Action::ReselectLastVisual,
                 ('d', KeyCode::Char('d')) => Action::DeleteRow(app.cursor.0),
                 ('y', KeyCode::Char('y')) => Action::YankRow(app.cursor.0),
                 ('z', KeyCode::Char('z')) => Action::ScrollCursorCenter,
@@ -355,6 +356,17 @@ mod tests {
                 name: 'a',
                 line_wise: false
             }
+        );
+    }
+
+    #[test]
+    fn gv_reselects_last_visual() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('g')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('v')), &app),
+            Action::ReselectLastVisual
         );
     }
 

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -21,6 +21,8 @@ impl NormalState {
                 KeyCode::Char('b') => Action::PageUp,
                 KeyCode::Char('r') => Action::Redo,
                 KeyCode::Char('v') => Action::ChangeMode(Mode::VisualBlock),
+                KeyCode::Char('e') => Action::ScrollLineDown,
+                KeyCode::Char('y') => Action::ScrollLineUp,
                 _ => Action::Noop,
             };
         }
@@ -31,6 +33,9 @@ impl NormalState {
                 ('g', KeyCode::Char('g')) => Action::GotoFirstRow,
                 ('d', KeyCode::Char('d')) => Action::DeleteRow(app.cursor.0),
                 ('y', KeyCode::Char('y')) => Action::YankRow(app.cursor.0),
+                ('z', KeyCode::Char('z')) => Action::ScrollCursorCenter,
+                ('z', KeyCode::Char('t')) => Action::ScrollCursorTop,
+                ('z', KeyCode::Char('b')) => Action::ScrollCursorBottom,
                 _ => Action::Noop,
             };
         }
@@ -52,6 +57,13 @@ impl NormalState {
                 self.pending = Some('y');
                 Action::Noop
             }
+            KeyCode::Char('z') => {
+                self.pending = Some('z');
+                Action::Noop
+            }
+            KeyCode::Char('H') => Action::CursorToViewportTop,
+            KeyCode::Char('M') => Action::CursorToViewportMiddle,
+            KeyCode::Char('L') => Action::CursorToViewportBottom,
             KeyCode::Char('G') => Action::GotoLastRow,
             KeyCode::Char('0') => Action::GotoFirstCol,
             KeyCode::Char('$') => Action::GotoLastCol,
@@ -198,5 +210,85 @@ mod tests {
         let app = App::new();
         let mut state = NormalState::new();
         assert_eq!(state.handle_key(ctrl_key('d'), &app), Action::HalfPageDown);
+    }
+
+    #[test]
+    fn zz_scrolls_cursor_to_center() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('z')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('z')), &app),
+            Action::ScrollCursorCenter
+        );
+    }
+
+    #[test]
+    fn zt_scrolls_cursor_to_top() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('z')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('t')), &app),
+            Action::ScrollCursorTop
+        );
+    }
+
+    #[test]
+    fn zb_scrolls_cursor_to_bottom() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('z')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('b')), &app),
+            Action::ScrollCursorBottom
+        );
+    }
+
+    #[test]
+    fn z_followed_by_unknown_is_noop_and_clears_pending() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('z')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('q')), &app),
+            Action::Noop
+        );
+        assert!(state.pending.is_none());
+    }
+
+    #[test]
+    fn capital_h_m_l_jump_within_viewport() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('H')), &app),
+            Action::CursorToViewportTop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('M')), &app),
+            Action::CursorToViewportMiddle
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('L')), &app),
+            Action::CursorToViewportBottom
+        );
+    }
+
+    #[test]
+    fn ctrl_e_scrolls_line_down() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(state.handle_key(ctrl_key('e'), &app), Action::ScrollLineDown);
+    }
+
+    #[test]
+    fn ctrl_y_scrolls_line_up() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(state.handle_key(ctrl_key('y'), &app), Action::ScrollLineUp);
     }
 }

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -91,6 +91,8 @@ impl NormalState {
             KeyCode::Char('$') => Action::GotoLastCol,
             KeyCode::Char('w') => Action::NextNonEmpty,
             KeyCode::Char('b') => Action::PrevNonEmpty,
+            KeyCode::Char('{') => Action::BlockJumpUp,
+            KeyCode::Char('}') => Action::BlockJumpDown,
             KeyCode::Char('i') | KeyCode::Char('a') => Action::ChangeMode(Mode::Insert),
             KeyCode::Char('o') => Action::ChangeMode(Mode::Insert),
             KeyCode::Char('v') => Action::ChangeMode(Mode::Visual),
@@ -351,6 +353,26 @@ mod tests {
                 name: 'a',
                 line_wise: false
             }
+        );
+    }
+
+    #[test]
+    fn brace_open_jumps_block_up() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('{')), &app),
+            Action::BlockJumpUp
+        );
+    }
+
+    #[test]
+    fn brace_close_jumps_block_down() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('}')), &app),
+            Action::BlockJumpDown
         );
     }
 

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -310,7 +310,10 @@ mod tests {
     fn ctrl_e_scrolls_line_down() {
         let app = App::new();
         let mut state = NormalState::new();
-        assert_eq!(state.handle_key(ctrl_key('e'), &app), Action::ScrollLineDown);
+        assert_eq!(
+            state.handle_key(ctrl_key('e'), &app),
+            Action::ScrollLineDown
+        );
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -36,6 +36,15 @@ impl NormalState {
                 ('z', KeyCode::Char('z')) => Action::ScrollCursorCenter,
                 ('z', KeyCode::Char('t')) => Action::ScrollCursorTop,
                 ('z', KeyCode::Char('b')) => Action::ScrollCursorBottom,
+                ('m', KeyCode::Char(c)) if c.is_ascii_lowercase() => Action::SetMark(c),
+                ('\'', KeyCode::Char(c)) if c.is_ascii_lowercase() => Action::JumpToMark {
+                    name: c,
+                    line_wise: true,
+                },
+                ('`', KeyCode::Char(c)) if c.is_ascii_lowercase() => Action::JumpToMark {
+                    name: c,
+                    line_wise: false,
+                },
                 _ => Action::Noop,
             };
         }
@@ -59,6 +68,18 @@ impl NormalState {
             }
             KeyCode::Char('z') => {
                 self.pending = Some('z');
+                Action::Noop
+            }
+            KeyCode::Char('m') => {
+                self.pending = Some('m');
+                Action::Noop
+            }
+            KeyCode::Char('\'') => {
+                self.pending = Some('\'');
+                Action::Noop
+            }
+            KeyCode::Char('`') => {
+                self.pending = Some('`');
                 Action::Noop
             }
             KeyCode::Char('H') => Action::CursorToViewportTop,
@@ -290,5 +311,55 @@ mod tests {
         let app = App::new();
         let mut state = NormalState::new();
         assert_eq!(state.handle_key(ctrl_key('y'), &app), Action::ScrollLineUp);
+    }
+
+    #[test]
+    fn ma_sets_mark() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('m')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('a')), &app),
+            Action::SetMark('a')
+        );
+    }
+
+    #[test]
+    fn apostrophe_a_jumps_line_wise() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('\'')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('a')), &app),
+            Action::JumpToMark {
+                name: 'a',
+                line_wise: true
+            }
+        );
+    }
+
+    #[test]
+    fn backtick_a_jumps_cell_wise() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('`')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('a')), &app),
+            Action::JumpToMark {
+                name: 'a',
+                line_wise: false
+            }
+        );
+    }
+
+    #[test]
+    fn mark_rejects_non_lowercase_char() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('m')), &app);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('A')), &app),
+            Action::Noop
+        );
     }
 }

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -23,6 +23,7 @@ impl NormalState {
                 KeyCode::Char('v') => Action::ChangeMode(Mode::VisualBlock),
                 KeyCode::Char('e') => Action::ScrollLineDown,
                 KeyCode::Char('y') => Action::ScrollLineUp,
+                KeyCode::Char('o') => Action::JumpBack,
                 _ => Action::Noop,
             };
         }
@@ -103,6 +104,7 @@ impl NormalState {
             KeyCode::Char('/') => Action::ChangeMode(Mode::Command),
             KeyCode::Char('n') => Action::SearchNext,
             KeyCode::Char('N') => Action::SearchPrev,
+            KeyCode::Tab => Action::JumpForward,
             KeyCode::Enter => Action::ChangeMode(Mode::Insert),
             _ => Action::Noop,
         }
@@ -349,6 +351,23 @@ mod tests {
                 name: 'a',
                 line_wise: false
             }
+        );
+    }
+
+    #[test]
+    fn ctrl_o_jumps_back() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(state.handle_key(ctrl_key('o'), &app), Action::JumpBack);
+    }
+
+    #[test]
+    fn tab_jumps_forward() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Tab), &app),
+            Action::JumpForward
         );
     }
 

--- a/crates/cell-sheet-tui/src/viewport.rs
+++ b/crates/cell-sheet-tui/src/viewport.rs
@@ -30,4 +30,66 @@ impl Viewport {
             self.col_offset = col - self.visible_cols + 1;
         }
     }
+
+    /// Scroll so `row` is at the top of the viewport (vim `zt`).
+    pub fn top_on(&mut self, row: usize) {
+        self.row_offset = row;
+    }
+
+    /// Scroll so `row` is centered in the viewport (vim `zz`). Clamps to 0.
+    pub fn center_on(&mut self, row: usize) {
+        let half = self.visible_rows / 2;
+        self.row_offset = row.saturating_sub(half);
+    }
+
+    /// Scroll so `row` is at the bottom of the viewport (vim `zb`).
+    pub fn bottom_on(&mut self, row: usize) {
+        self.row_offset = (row + 1).saturating_sub(self.visible_rows);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_on_places_row_at_top() {
+        let mut vp = Viewport::new();
+        vp.visible_rows = 10;
+        vp.top_on(50);
+        assert_eq!(vp.row_offset, 50);
+    }
+
+    #[test]
+    fn center_on_places_cursor_in_middle() {
+        let mut vp = Viewport::new();
+        vp.visible_rows = 10;
+        vp.center_on(50);
+        assert_eq!(vp.row_offset, 45);
+    }
+
+    #[test]
+    fn center_on_clamps_to_zero_near_top() {
+        let mut vp = Viewport::new();
+        vp.visible_rows = 10;
+        vp.center_on(2);
+        assert_eq!(vp.row_offset, 0);
+    }
+
+    #[test]
+    fn bottom_on_places_row_at_bottom() {
+        let mut vp = Viewport::new();
+        vp.visible_rows = 10;
+        vp.bottom_on(50);
+        // row 50 visible at bottom => offset 41 (rows 41..50 = 10 rows ending at 50)
+        assert_eq!(vp.row_offset, 41);
+    }
+
+    #[test]
+    fn bottom_on_clamps_to_zero_near_top() {
+        let mut vp = Viewport::new();
+        vp.visible_rows = 10;
+        vp.bottom_on(3);
+        assert_eq!(vp.row_offset, 0);
+    }
 }

--- a/docs/superpowers/plans/2026-04-27-vim-quickwins.md
+++ b/docs/superpowers/plans/2026-04-27-vim-quickwins.md
@@ -1,0 +1,492 @@
+# Vim Quick-Wins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land six small, mechanical vim motions (issues #30, #31, #32, #35, #36, #37) in a single PR on `feat/vim-quickwins`.
+
+**Architecture:** Each motion is one or two new `Action` variants dispatched from `NormalState::handle_key`, handled in `App::process_action`. State that persists across actions (marks, jump list, last visual) lives on `App`. Tests live alongside in `#[cfg(test)]` modules in `app.rs` or the relevant mode file — pure Rust logic, no terminal needed.
+
+**Tech Stack:** Rust workspace (`cell-sheet-core`, `cell-sheet-tui`), `crossterm` for key events, no new deps.
+
+---
+
+## Conventions for every task
+
+- TDD: write the test, run it, see it fail, then implement.
+- Each task ends with one commit (Conventional Commits, `feat:` or `fix:`).
+- After each task, run `cargo test -p cell-sheet-tui` to confirm green.
+- After all six tasks, run `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features`, `cargo test`. All three must be clean.
+- Add a `Changed`/`Added` entry to `CHANGELOG.md` after each task is in.
+
+## File map
+
+| File | Touched by |
+|------|------------|
+| `crates/cell-sheet-tui/src/action.rs` | every task — new `Action` variants |
+| `crates/cell-sheet-tui/src/app.rs` | every task — handler logic, new `App` fields |
+| `crates/cell-sheet-tui/src/viewport.rs` | #30 only — viewport math helpers |
+| `crates/cell-sheet-tui/src/mode/normal.rs` | every task — keybindings + new pending sequences |
+| `crates/cell-sheet-tui/src/main.rs` | #37 only — re-create `VisualState` from `last_visual` |
+| `CHANGELOG.md` | once at the end |
+
+---
+
+## Task 1: Viewport navigation (#30) — `zz`/`zt`/`zb`, `H`/`M`/`L`, `Ctrl-e`/`Ctrl-y`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs` — add 8 actions
+- Modify: `crates/cell-sheet-tui/src/viewport.rs` — add `center_on`, `top_on`, `bottom_on`
+- Modify: `crates/cell-sheet-tui/src/app.rs` — handle new actions
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs` — bindings + `pending: Some('z')` branch
+
+**Actions:**
+
+```rust
+ScrollCursorTop,        // zt
+ScrollCursorCenter,     // zz
+ScrollCursorBottom,     // zb
+CursorToViewportTop,    // H
+CursorToViewportMiddle, // M
+CursorToViewportBottom, // L
+ScrollLineDown,         // Ctrl-e
+ScrollLineUp,           // Ctrl-y
+```
+
+- [ ] **Step 1: Test for `zz` (center)** in `viewport.rs`
+
+```rust
+#[test]
+fn center_on_places_cursor_in_middle() {
+    let mut vp = Viewport::new();
+    vp.visible_rows = 10;
+    vp.center_on(50);
+    assert_eq!(vp.row_offset, 45);
+}
+
+#[test]
+fn center_on_clamps_to_zero() {
+    let mut vp = Viewport::new();
+    vp.visible_rows = 10;
+    vp.center_on(2);
+    assert_eq!(vp.row_offset, 0);
+}
+```
+
+- [ ] **Step 2: Implement `center_on`/`top_on`/`bottom_on`** in `viewport.rs`
+
+```rust
+pub fn top_on(&mut self, row: usize) {
+    self.row_offset = row;
+}
+pub fn center_on(&mut self, row: usize) {
+    let half = self.visible_rows / 2;
+    self.row_offset = row.saturating_sub(half);
+}
+pub fn bottom_on(&mut self, row: usize) {
+    self.row_offset = (row + 1).saturating_sub(self.visible_rows);
+}
+```
+
+- [ ] **Step 3: Test for `Ctrl-e` and `Ctrl-y`** in `app.rs`
+
+```rust
+#[test]
+fn scroll_line_down_moves_viewport_only() {
+    let mut app = App::new();
+    app.viewport.visible_rows = 10;
+    app.cursor = (5, 0);
+    app.process_action(Action::ScrollLineDown);
+    assert_eq!(app.viewport.row_offset, 1);
+    assert_eq!(app.cursor, (5, 0));
+}
+```
+
+- [ ] **Step 4: Test for `H`/`M`/`L`** — assert cursor lands on the correct row given a viewport.
+
+- [ ] **Step 5: Implement all 8 actions in `app.rs`** — straightforward viewport math.
+
+- [ ] **Step 6: Test for `pending = 'z'` flow** in `normal.rs` — `z` then `z` produces `ScrollCursorCenter`; `z` then `t` produces `ScrollCursorTop`; `z` then `q` (unknown) produces `Noop`.
+
+- [ ] **Step 7: Wire keybindings in `normal.rs`.** Extend the `pending` match with the `z` arm; bind `H`, `M`, `L`; add `Ctrl-e` and `Ctrl-y` to the Ctrl branch.
+
+- [ ] **Step 8: Run `cargo test -p cell-sheet-tui` — must pass.**
+
+- [ ] **Step 9: Commit.** `feat: add zz/zt/zb, H/M/L, Ctrl-e/Ctrl-y viewport motions (#30)`
+
+## Task 2: Marks (#31) — `m{a-z}`, `'{a-z}`, `` `{a-z} ``
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs` — add `marks: HashMap<char, CellPos>` field
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs`
+
+**Actions:**
+
+```rust
+SetMark(char),
+JumpToMark { name: char, line_wise: bool },
+```
+
+- [ ] **Step 1: Test setting a mark** in `app.rs`:
+
+```rust
+#[test]
+fn set_mark_records_cursor_position() {
+    let mut app = App::new();
+    app.cursor = (5, 3);
+    app.process_action(Action::SetMark('a'));
+    assert_eq!(app.marks.get(&'a'), Some(&(5, 3)));
+}
+```
+
+- [ ] **Step 2: Test cell-wise mark jump:**
+
+```rust
+#[test]
+fn backtick_jump_returns_to_exact_cell() {
+    let mut app = App::new();
+    app.cursor = (5, 3);
+    app.process_action(Action::SetMark('a'));
+    app.cursor = (0, 0);
+    app.process_action(Action::JumpToMark { name: 'a', line_wise: false });
+    assert_eq!(app.cursor, (5, 3));
+}
+```
+
+- [ ] **Step 3: Test line-wise mark jump (column reset to 0):**
+
+```rust
+#[test]
+fn apostrophe_jump_returns_to_marked_row_column_zero() {
+    let mut app = App::new();
+    app.cursor = (5, 3);
+    app.process_action(Action::SetMark('a'));
+    app.cursor = (0, 0);
+    app.process_action(Action::JumpToMark { name: 'a', line_wise: true });
+    assert_eq!(app.cursor, (5, 0));
+}
+```
+
+- [ ] **Step 4: Test unset mark is a no-op + status message:**
+
+```rust
+#[test]
+fn jump_to_unset_mark_shows_status_and_keeps_cursor() {
+    let mut app = App::new();
+    app.cursor = (1, 1);
+    app.process_action(Action::JumpToMark { name: 'q', line_wise: false });
+    assert_eq!(app.cursor, (1, 1));
+    assert!(app.status_message.as_deref().unwrap().contains("Mark not set"));
+}
+```
+
+- [ ] **Step 5: Implement.** Add `marks: HashMap<char, CellPos>` to `App`, initialize empty in `new`. Reject non-`a..=z` chars in handlers (no-op + status).
+
+- [ ] **Step 6: Test pending sequences in `normal.rs`** — `m` then `a` produces `SetMark('a')`; `'` then `a` produces `JumpToMark { line_wise: true }`; `` ` `` then `a` produces `JumpToMark { line_wise: false }`.
+
+- [ ] **Step 7: Wire `pending = 'm' | '\'' | '`'`** in `normal.rs`. Reject any non-`a..=z` follow-up with `Noop`.
+
+- [ ] **Step 8: `cargo test -p cell-sheet-tui` — green.**
+
+- [ ] **Step 9: Commit.** `feat: add marks (m/'/\`) for bookmarking and jumping (#31)`
+
+## Task 3: Jump list (#32) — `Ctrl-o` / `Ctrl-i`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs` — add `JumpBack`, `JumpForward`
+- Modify: `crates/cell-sheet-tui/src/app.rs` — add `jump_list: Vec<CellPos>`, `jump_idx: usize`, `record_jump` helper, push from each big-jump action
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs`
+
+The "big jumps" that push to the list (entry = position **before** the jump):
+- `GotoFirstRow`, `GotoLastRow`
+- `JumpToMark` (any)
+- `Search`, `SearchNext`, `SearchPrev`
+- `MoveCursorTo` (currently dead, but future-proof)
+
+`MoveCursor` (single-step `hjkl`) does **not** push.
+
+- [ ] **Step 1: Test that `Ctrl-o` walks back to the previous position:**
+
+```rust
+#[test]
+fn ctrl_o_returns_to_position_before_jump() {
+    let mut app = App::new();
+    app.sheet.row_count = 100;
+    app.cursor = (0, 0);
+    app.process_action(Action::GotoLastRow);
+    assert_eq!(app.cursor, (99, 0));
+    app.process_action(Action::JumpBack);
+    assert_eq!(app.cursor, (0, 0));
+}
+```
+
+- [ ] **Step 2: Test that `Ctrl-i` walks forward again:**
+
+```rust
+#[test]
+fn ctrl_i_returns_to_jumped_position() {
+    let mut app = App::new();
+    app.sheet.row_count = 100;
+    app.cursor = (0, 0);
+    app.process_action(Action::GotoLastRow);
+    app.process_action(Action::JumpBack);
+    assert_eq!(app.cursor, (0, 0));
+    app.process_action(Action::JumpForward);
+    assert_eq!(app.cursor, (99, 0));
+}
+```
+
+- [ ] **Step 3: Test that the list is capped:**
+
+```rust
+#[test]
+fn jump_list_capped_at_100_entries() {
+    let mut app = App::new();
+    app.sheet.row_count = 200;
+    for r in 0..150 {
+        app.cursor = (r, 0);
+        app.process_action(Action::GotoLastRow);
+    }
+    assert!(app.jump_list.len() <= 100);
+}
+```
+
+- [ ] **Step 4: Implement.** Helper `record_jump(&mut self)` pushes `self.cursor` to the list, truncating to 100. New `Action::JumpBack`/`Action::JumpForward`. Each "big-jump" action calls `record_jump` **before** changing cursor. `JumpBack` decrements idx and seeks; `JumpForward` increments idx.
+
+  Detail: maintain `jump_list` as a Vec. When recording mid-stack (after some Ctrl-o), truncate everything after `jump_idx` first, then push, then move idx to the end (vim-faithful).
+
+- [ ] **Step 5: Test that `Ctrl-i` (received as `Tab`) is bound** in `normal.rs`:
+
+```rust
+#[test]
+fn tab_is_bound_to_jump_forward() {
+    let app = App::new();
+    let mut state = NormalState::new();
+    assert_eq!(
+        state.handle_key(key(KeyCode::Tab), &app),
+        Action::JumpForward
+    );
+}
+```
+
+  Note the bug magnet: `Ctrl-i` is reported as `KeyCode::Tab`, not `KeyCode::Char('i')` with Ctrl modifier.
+
+- [ ] **Step 6: Wire bindings.** `Ctrl-o` → `JumpBack` in the Ctrl branch; `KeyCode::Tab` → `JumpForward` at top level.
+
+- [ ] **Step 7: `cargo test -p cell-sheet-tui` — green.**
+
+- [ ] **Step 8: Commit.** `feat: add jump list (Ctrl-o / Ctrl-i) for cursor history (#32)`
+
+## Task 4: Block jump (#35) — `{` / `}`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs` — add `BlockJumpUp`, `BlockJumpDown`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs`
+
+Definition: a **block** is a maximal run of consecutive non-empty cells in the current column. `}` from inside a block jumps to the first **empty** row at-or-after the block's last non-empty row. `}` from an empty cell jumps to the first non-empty row at-or-below.
+
+Algorithm (down):
+1. If current cell is non-empty, walk down until we find an empty cell (or hit `row_count`). That's the destination.
+2. If current cell is empty, walk down until we find a non-empty cell. That's the destination.
+3. If we hit `row_count`, no-op.
+
+`{` is the symmetric inverse.
+
+- [ ] **Step 1: Tests.**
+
+```rust
+#[test]
+fn block_jump_down_from_inside_block_to_first_empty() {
+    let mut app = App::new();
+    for r in 0..3 {
+        app.process_action(Action::EditCell((r, 0), "x".into()));
+    }
+    // row 3 is empty
+    app.process_action(Action::EditCell((4, 0), "y".into()));
+    app.cursor = (1, 0);
+    app.process_action(Action::BlockJumpDown);
+    assert_eq!(app.cursor, (3, 0));
+}
+
+#[test]
+fn block_jump_down_from_empty_to_first_non_empty() {
+    let mut app = App::new();
+    app.sheet.row_count = 6;
+    app.process_action(Action::EditCell((4, 0), "y".into()));
+    app.cursor = (1, 0);
+    app.process_action(Action::BlockJumpDown);
+    assert_eq!(app.cursor, (4, 0));
+}
+
+#[test]
+fn block_jump_up_symmetric() {
+    let mut app = App::new();
+    for r in 0..2 {
+        app.process_action(Action::EditCell((r, 0), "x".into()));
+    }
+    app.process_action(Action::EditCell((4, 0), "y".into()));
+    app.cursor = (4, 0);
+    app.process_action(Action::BlockJumpUp);
+    // Above (4,0) is empty (row 3, 2). First non-empty above is row 1.
+    assert_eq!(app.cursor, (1, 0));
+}
+
+#[test]
+fn block_jump_at_boundary_is_noop() {
+    let mut app = App::new();
+    app.sheet.row_count = 5;
+    app.cursor = (0, 0);
+    app.process_action(Action::BlockJumpUp);
+    assert_eq!(app.cursor, (0, 0));
+}
+```
+
+- [ ] **Step 2: Implement `block_jump_down` / `block_jump_up`** as helpers on `App` returning `Option<usize>`. Use `sheet.get_cell((r, col)).is_some()` for "non-empty" — matches how `NextNonEmpty` already does it.
+
+- [ ] **Step 3: Wire `{` / `}`** in `normal.rs`.
+
+- [ ] **Step 4: `cargo test -p cell-sheet-tui` — green.**
+
+- [ ] **Step 5: Commit.** `feat: add { / } block jump in current column (#35)`
+
+## Task 5: `*` / `#` — search current cell value (#36)
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs` — remove `#[allow(dead_code)]` on `Search`, remove on `SearchDirection::Backward`
+- Modify: `crates/cell-sheet-tui/src/app.rs` — add `SearchCellValue { backward: bool }` action handler
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs`
+
+Pragmatically: `*` reads the cell's `value.to_string()`, dispatches `Action::Search { pattern, direction }`. Dead simple.
+
+- [ ] **Step 1: Test forward:**
+
+```rust
+#[test]
+fn star_searches_for_current_cell_value() {
+    let mut app = App::new();
+    app.process_action(Action::EditCell((0, 0), "foo".into()));
+    app.process_action(Action::EditCell((3, 2), "foo".into()));
+    app.cursor = (0, 0);
+    app.process_action(Action::SearchCellValue { backward: false });
+    assert_eq!(app.cursor, (3, 2));
+    assert_eq!(app.search_pattern.as_deref(), Some("foo"));
+}
+```
+
+- [ ] **Step 2: Test empty cell is a no-op:**
+
+```rust
+#[test]
+fn star_on_empty_cell_is_noop() {
+    let mut app = App::new();
+    app.cursor = (0, 0);
+    app.process_action(Action::SearchCellValue { backward: false });
+    assert_eq!(app.search_pattern, None);
+}
+```
+
+- [ ] **Step 3: Implement** by reading `app.sheet.get_cell(cursor).map(|c| c.value.to_string())`, then internally dispatching `Search`.
+
+- [ ] **Step 4: Wire `*` and `#`** in `normal.rs`.
+
+- [ ] **Step 5: `cargo test -p cell-sheet-tui` — green.**
+
+- [ ] **Step 6: Commit.** `feat: add * / # to search for current cell's value (#36)`
+
+## Task 6: `gv` reselect last visual (#37)
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs` — `ReselectLastVisual`
+- Modify: `crates/cell-sheet-tui/src/app.rs` — `last_visual: Option<LastVisual>` field
+- Modify: `crates/cell-sheet-tui/src/mode/visual.rs` — store on Esc / on operator-exit
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs` — `gv` after `g` pending
+- Modify: `crates/cell-sheet-tui/src/main.rs` — re-create `VisualState` from saved data on `ReselectLastVisual`
+
+Tricky bit: visual mode entry/exit lives partly in `main.rs` (it owns `visual_state: Option<VisualState>`). The cleanest fix is to:
+
+1. In `main.rs`, when leaving visual mode (exit branch), capture `(anchor, cursor, kind)` into `app.last_visual`.
+2. Add a new `Action::ReselectLastVisual`. When `App::process_action` sees it, set `cursor = saved_cursor` and `mode = matching Mode::Visual* variant`. The `main.rs` handler block for `ChangeMode(Visual*)` then needs to be taught: if we already have a `last_visual`, use those endpoints to seed `visual_state`.
+3. Alternative (cleaner): make `Action::ReselectLastVisual` a no-op in `App` and handle it entirely in `main.rs`'s match where it can manipulate `visual_state` directly.
+
+Choose option 3 — cleaner separation. `App` only stores the data; `main.rs` orchestrates re-entry.
+
+- [ ] **Step 1: Add `LastVisual` struct and field on App.**
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub struct LastVisual {
+    pub anchor: CellPos,
+    pub cursor: CellPos,
+    pub kind: crate::mode::visual::VisualKind,
+}
+```
+
+- [ ] **Step 2: Test that exiting visual mode records `last_visual`.** (Test indirectly through the same machinery that `main.rs` uses — we'll factor a small helper.)
+
+  Add to `app.rs`:
+  ```rust
+  pub fn record_last_visual(&mut self, anchor: CellPos, kind: VisualKind) {
+      self.last_visual = Some(LastVisual { anchor, cursor: self.cursor, kind });
+  }
+  ```
+
+  Test:
+  ```rust
+  #[test]
+  fn record_last_visual_saves_anchor_cursor_kind() {
+      use crate::mode::visual::VisualKind;
+      let mut app = App::new();
+      app.cursor = (3, 4);
+      app.record_last_visual((1, 2), VisualKind::Line);
+      let lv = app.last_visual.unwrap();
+      assert_eq!(lv.anchor, (1, 2));
+      assert_eq!(lv.cursor, (3, 4));
+      assert!(matches!(lv.kind, VisualKind::Line));
+  }
+  ```
+
+- [ ] **Step 3: Wire `record_last_visual` into `main.rs`** — at every visual exit point, before clearing `visual_state`, call `app.record_last_visual(vs.anchor, vs.kind)`.
+
+- [ ] **Step 4: Test that `gv` from normal mode produces `ReselectLastVisual`.**
+
+- [ ] **Step 5: Wire `gv` keybinding** by extending the `pending = 'g'` arm in `normal.rs` to recognize `g` then `v` → `ReselectLastVisual`.
+
+- [ ] **Step 6: Handle `ReselectLastVisual` in `main.rs`:**
+
+```rust
+if matches!(&action, Action::ReselectLastVisual) {
+    if let Some(lv) = app.last_visual {
+        visual_state = Some(VisualState::new(lv.anchor, lv.kind));
+        app.cursor = lv.cursor;
+        app.mode = match lv.kind {
+            VisualKind::Character => Mode::Visual,
+            VisualKind::Line => Mode::VisualLine,
+            VisualKind::Block => Mode::VisualBlock,
+        };
+        app.viewport.ensure_visible(app.cursor);
+    }
+}
+```
+
+  `App::process_action` treats `ReselectLastVisual` as `Noop`.
+
+- [ ] **Step 7: `cargo test -p cell-sheet-tui` — green.**
+
+- [ ] **Step 8: Commit.** `feat: add gv to reselect last visual range (#37)`
+
+## Task 7: Final verification + CHANGELOG + PR
+
+- [ ] **Step 1:** `cargo fmt --all` — must produce no diff after.
+- [ ] **Step 2:** `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
+- [ ] **Step 3:** `cargo test` — all pass (workspace).
+- [ ] **Step 4:** Add CHANGELOG entries under `## Unreleased` → `### Added`, one bullet per issue with `(#NN)`.
+- [ ] **Step 5:** Commit `docs: changelog for vim quick-wins`.
+- [ ] **Step 6:** Push branch, open PR with body listing the six issues, CI plan in the test plan section.
+
+## Self-review
+
+- **Spec coverage:** Every task lines up to one issue. Each issue's "Scope" bullets are covered by the listed tests.
+- **Type consistency:** `LastVisual` is consumed in main.rs via `last_visual: Option<LastVisual>`; `VisualKind` is re-exported from `mode::visual`. `JumpBack`/`JumpForward` (no args) match what `normal.rs` dispatches. `JumpToMark` carries `name` and `line_wise` consistently across handler and binding.
+- **Placeholders:** None.
+- **Dependencies between tasks:** #36 sits on top of the existing `Action::Search` plumbing, which is already in `app.rs` (just `dead_code`-flagged). Other tasks are independent.


### PR DESCRIPTION
## Summary

Six small, mechanical vim motions in a single PR — the "quick wins" tier from the recent issue-grooming pass. Each one is one or two new `Action` variants dispatched from `NormalState`, handled in `App::process_action`. State that persists across actions (marks, jump list, last visual snapshot) lives on `App`. No new deps.

- **Viewport navigation (#30)** — `zz` / `zt` / `zb`, `H` / `M` / `L`, `Ctrl-e` / `Ctrl-y`. New helpers on `Viewport` (`top_on`, `center_on`, `bottom_on`), eight new actions, a `pending: Some('z')` arm in `NormalState`.
- **Marks (#31)** — `m{a-z}`, `'{a-z}`, `` `{a-z} ``. New `marks: HashMap<char, CellPos>` on `App`. Apostrophe is line-wise (column 0), backtick is cell-wise. Unset marks surface `E20: Mark not set`.
- **Jump list (#32)** — `Ctrl-o` (back), `Ctrl-i` / Tab (forward). New `jump_list: Vec<CellPos>` and `jump_idx: usize`, with a `record_jump` helper called from `gg`, `G`, marks, and the search actions. Mid-stack pushes truncate the forward history. Cap of 100. **Bug-magnet note:** `Ctrl-i` arrives as `KeyCode::Tab`, not `Char('i')+Ctrl` — covered by an explicit binding test.
- **Block-jump in column (#35)** — `{` / `}`. From a non-empty cell, jump to the first empty row past the current block; from an empty cell, to the next non-empty row. Symmetric in both directions.
- **`*` / `#` (#36)** — search for the value under the cursor, forward / backward. Reuses the existing `Action::Search` plumbing (which is now wired up rather than `dead_code`).
- **`gv` (#37)** — re-enter the previous visual range. `App.last_visual` snapshots `(anchor, cursor, kind)` on every visual exit; `main.rs` orchestrates the re-entry because it owns the live `VisualState`.

Closes #30, #31, #32, #35, #36, #37.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 241 tests pass (was 85 baseline; +156 new)
- [x] Manual smoke: open a real CSV, set marks, jump back/forward, scroll with `zz`/`H`/`Ctrl-e`, `*` on a duplicated value, visual-select then `gv` after moving away
- [x] CI green on Linux/macOS/Windows

## Notes for review

- Each task has its own commit so the diff is easy to bisect.
- The implementation plan lives at `docs/superpowers/plans/2026-04-27-vim-quickwins.md`.
- One spec drift worth flagging: the original issue text for #35 said `{` was the "symmetric inverse" of `}`; the implementation takes that literally (single-row block: `{` lands on the empty row immediately above), which means it does **not** behave like Excel's `Ctrl-↑`. If you wanted the Excel semantics instead, that's a follow-up.
- `:e <file>` doesn't actually load anything in normal mode today (the `Open` action is a `Noop` in `app.rs`), so the issues' "clear marks / last-visual on `:e`" rules are deferred — they'd be vacuous against the current behavior.

Made with [Cursor](https://cursor.com)