### PR TITLE
feat: wire up `/`, `?` incremental search and `f`/`F`/`;`/`,` row find (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- `/<pattern>` and `?<pattern>` now open a search prompt that dispatches a
+  forward or backward search; `n` and `N` step through the matches as before.
+  Status line renders the corresponding `/` or `?` prefix while typing.
+  Search is incremental (vim's `incsearch`): the cursor jumps to the first
+  match as you type, `Esc` restores the cursor to where the prompt opened,
+  and `Enter` commits the pattern (#28)
+- `f<char>` / `F<char>` jump to the next / previous non-empty cell in the
+  current row whose displayed value starts with `<char>` (case-insensitive).
+  Triggered immediately on the target keypress without confirmation.
+  `;` repeats the last find, `,` repeats it reversed (#28)
+
 ## 0.2.0
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ If you know Vim, you know cell.
 | `Ctrl-R`            | Redo                         |
 | `v`                 | Visual selection             |
 | `Ctrl-V`            | Visual block selection       |
-| `/`                 | Search                       |
+| `/` / `?`           | Search forward / backward    |
 | `n` / `N`           | Next/previous match          |
+| `f<char>` / `F<char>` | Jump to next/prev cell in row starting with `<char>` |
+| `;` / `,`           | Repeat last `f`/`F` (same / reversed direction) |
 | `:`                 | Command mode                 |
 
 

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -160,8 +160,14 @@ pub static NORMAL_ENTRIES: &[HelpEntry] = &[
     HelpEntry {
         tags: &["/"],
         category: HelpCategory::Normal,
-        summary: "Search",
-        detail: "Open the search prompt. Type a pattern and press Enter to\nfind the next cell whose value contains the pattern.\nCase-insensitive.",
+        summary: "Search forward",
+        detail: "Open the forward-search prompt. Type a pattern and press Enter to\nfind the next cell whose value contains the pattern.\nCase-insensitive. Use n / N to step through matches.",
+    },
+    HelpEntry {
+        tags: &["?"],
+        category: HelpCategory::Normal,
+        summary: "Search backward",
+        detail: "Open the backward-search prompt. Type a pattern and press Enter\nto find the previous cell whose value contains the pattern.\nCase-insensitive. Use n / N to step through matches.",
     },
     HelpEntry {
         tags: &["n"],
@@ -174,6 +180,30 @@ pub static NORMAL_ENTRIES: &[HelpEntry] = &[
         category: HelpCategory::Normal,
         summary: "Previous search match",
         detail: "Jump to the previous cell matching the last search pattern.",
+    },
+    HelpEntry {
+        tags: &["f"],
+        category: HelpCategory::Normal,
+        summary: "Find char in row (forward)",
+        detail: "After f, the next keypress is the target character. The cursor\njumps to the next non-empty cell in the current row whose displayed\nvalue starts with that character (case-insensitive).\nUse ; to repeat and , to repeat reversed.",
+    },
+    HelpEntry {
+        tags: &["F"],
+        category: HelpCategory::Normal,
+        summary: "Find char in row (backward)",
+        detail: "Like f, but searches the current row to the left of the cursor.",
+    },
+    HelpEntry {
+        tags: &[";"],
+        category: HelpCategory::Normal,
+        summary: "Repeat last find",
+        detail: "Repeat the last f / F find in the same direction.",
+    },
+    HelpEntry {
+        tags: &[","],
+        category: HelpCategory::Normal,
+        summary: "Repeat last find reversed",
+        detail: "Repeat the last f / F find in the opposite direction.",
     },
 ];
 

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -12,8 +12,28 @@ pub enum Direction {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SearchDirection {
     Forward,
-    #[allow(dead_code)]
     Backward,
+}
+
+/// Discriminator for the prompt rendered in `Mode::Command`.
+///
+/// `:` parses ex-style commands. `/` and `?` parse a search pattern that
+/// is dispatched as `Action::Search` with the corresponding direction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CommandKind {
+    Colon,
+    Slash,
+    Question,
+}
+
+impl CommandKind {
+    pub fn prefix(self) -> char {
+        match self {
+            CommandKind::Colon => ':',
+            CommandKind::Slash => '/',
+            CommandKind::Question => '?',
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -54,13 +74,38 @@ pub enum Action {
         col: usize,
         ascending: bool,
     },
-    #[allow(dead_code)]
     Search {
         pattern: String,
         direction: SearchDirection,
     },
     SearchNext,
     SearchPrev,
+    /// Switch to `Mode::Command` with a search prompt (`/` or `?`).
+    /// Saves the current cursor as the search origin so Esc can restore it.
+    EnterSearch(SearchDirection),
+    /// Re-run the search from the saved origin as the user types in the
+    /// `/` or `?` prompt (vim's `incsearch`). Empty pattern restores the
+    /// cursor to the origin without committing a pattern.
+    SearchIncremental {
+        pattern: String,
+        direction: SearchDirection,
+    },
+    /// Esc out of a `/` or `?` prompt: restore the cursor to the saved
+    /// search origin and clear it.
+    CancelSearch,
+    /// Move the cursor to the next non-empty cell in the current row whose
+    /// displayed value starts with `ch` (case-insensitive). `forward = false`
+    /// scans left. `inclusive = true` lands on the match (`f`/`F`).
+    FindCharInRow {
+        ch: char,
+        forward: bool,
+        inclusive: bool,
+    },
+    /// Repeat the last `f`/`F` find. When `reversed`, flip the direction
+    /// (i.e. vim's `,`).
+    RepeatFind {
+        reversed: bool,
+    },
     #[allow(dead_code)]
     Resize,
     PageDown,

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -1,4 +1,4 @@
-use crate::action::{Action, Direction, Mode};
+use crate::action::{Action, CommandKind, Direction, Mode, SearchDirection};
 use crate::clipboard::Register;
 use crate::undo::{UndoEntry, UndoStack};
 use crate::viewport::Viewport;
@@ -23,8 +23,16 @@ pub struct App {
     pub register: Option<Register>,
     pub undo_stack: UndoStack,
     pub command_line: String,
+    pub command_kind: CommandKind,
     pub status_message: Option<String>,
     pub search_pattern: Option<String>,
+    /// Cursor position captured when the user opened a `/` or `?` prompt.
+    /// `Some` for the lifetime of an open search prompt; consumed on Esc
+    /// (cursor restored) or Enter with a non-empty pattern (committed).
+    pub search_origin: Option<CellPos>,
+    /// Last `f`/`F` target so `;` and `,` can replay it. Holds
+    /// `(char, forward, inclusive)`.
+    pub last_find: Option<(char, bool, bool)>,
     pub file_path: Option<PathBuf>,
     pub file_format: FileFormat,
     pub dirty: bool,
@@ -46,8 +54,11 @@ impl App {
             register: None,
             undo_stack: UndoStack::new(),
             command_line: String::new(),
+            command_kind: CommandKind::Colon,
             status_message: None,
             search_pattern: None,
+            search_origin: None,
+            last_find: None,
             file_path: None,
             file_format: FileFormat::Csv,
             dirty: false,
@@ -107,6 +118,10 @@ impl App {
                         .get_cell(self.cursor)
                         .map(|c| c.raw.clone())
                         .unwrap_or_default();
+                }
+                if mode == Mode::Command {
+                    self.command_kind = CommandKind::Colon;
+                    self.command_line.clear();
                 }
                 self.mode = mode;
             }
@@ -254,8 +269,82 @@ impl App {
                 }
             }
             Action::Search { pattern, direction } => {
+                if pattern.is_empty() {
+                    // Empty submit: restore cursor to where the prompt opened
+                    // (matches vim's behavior of "no match → no movement"),
+                    // and don't overwrite an existing pattern.
+                    if let Some(origin) = self.search_origin.take() {
+                        self.cursor = origin;
+                        self.viewport.ensure_visible(self.cursor);
+                    }
+                    return;
+                }
                 self.search_pattern = Some(pattern.clone());
-                self.find_next(direction == crate::action::SearchDirection::Forward);
+                let forward = direction == SearchDirection::Forward;
+                // If a prompt is open (origin set), commit at the incremental
+                // position by re-running the search from origin, including
+                // origin as a candidate. Without an open prompt (e.g.
+                // `Action::Search` dispatched directly), behave like vim's
+                // `/<pattern>`: step past the current cell.
+                let (origin, include_origin) = match self.search_origin.take() {
+                    Some(o) => (o, true),
+                    None => (self.cursor, false),
+                };
+                if !self.find_from(&pattern, forward, origin, include_origin) {
+                    if include_origin {
+                        self.cursor = origin;
+                        self.viewport.ensure_visible(self.cursor);
+                    }
+                    self.status_message = Some(format!("Pattern not found: {}", pattern));
+                }
+            }
+            Action::EnterSearch(direction) => {
+                self.command_line.clear();
+                self.command_kind = match direction {
+                    SearchDirection::Forward => CommandKind::Slash,
+                    SearchDirection::Backward => CommandKind::Question,
+                };
+                self.search_origin = Some(self.cursor);
+                self.mode = Mode::Command;
+            }
+            Action::SearchIncremental { pattern, direction } => {
+                let Some(origin) = self.search_origin else {
+                    return;
+                };
+                if pattern.is_empty() {
+                    self.cursor = origin;
+                    self.viewport.ensure_visible(self.cursor);
+                    return;
+                }
+                let forward = direction == SearchDirection::Forward;
+                if !self.find_from(&pattern, forward, origin, true) {
+                    // No match: snap back to origin so the user sees they're
+                    // not on a stale earlier match.
+                    self.cursor = origin;
+                    self.viewport.ensure_visible(self.cursor);
+                }
+            }
+            Action::CancelSearch => {
+                if let Some(origin) = self.search_origin.take() {
+                    self.cursor = origin;
+                    self.viewport.ensure_visible(self.cursor);
+                }
+                self.command_line.clear();
+                self.mode = Mode::Normal;
+            }
+            Action::FindCharInRow {
+                ch,
+                forward,
+                inclusive,
+            } => {
+                self.last_find = Some((ch, forward, inclusive));
+                self.find_char_in_row(ch, forward, inclusive);
+            }
+            Action::RepeatFind { reversed } => {
+                if let Some((ch, forward, inclusive)) = self.last_find {
+                    let dir = if reversed { !forward } else { forward };
+                    self.find_char_in_row(ch, dir, inclusive);
+                }
             }
             Action::SearchNext => {
                 if self.search_pattern.is_some() {
@@ -515,21 +604,38 @@ impl App {
     }
 
     fn find_next(&mut self, forward: bool) {
-        let pattern = match &self.search_pattern {
-            Some(p) => p.to_lowercase(),
+        let pattern = match self.search_pattern.clone() {
+            Some(p) => p,
             None => return,
         };
+        if !self.find_from(&pattern, forward, self.cursor, false) {
+            self.status_message = Some(format!("Pattern not found: {}", pattern));
+        }
+    }
 
+    /// Scan cells starting at `origin` in row-major order (wrapping) for the
+    /// first cell whose displayed value contains `pattern` (case-insensitive).
+    /// On a hit, moves the cursor and returns `true`. `include_origin` decides
+    /// whether `origin` itself is a candidate — `true` for incremental search
+    /// so typing the first matching char already lands on the origin if it
+    /// matches; `false` for `n`/`N` so they always step.
+    fn find_from(
+        &mut self,
+        pattern: &str,
+        forward: bool,
+        origin: CellPos,
+        include_origin: bool,
+    ) -> bool {
         let total_cells = self.sheet.row_count * self.sheet.col_count.max(1);
         if total_cells == 0 {
-            return;
+            return false;
         }
-
-        let (start_row, start_col) = self.cursor;
         let cols = self.sheet.col_count.max(1);
+        let needle = pattern.to_lowercase();
+        let start = if include_origin { 0 } else { 1 };
 
-        for offset in 1..=total_cells {
-            let flat = start_row * cols + start_col;
+        for offset in start..=total_cells {
+            let flat = origin.0 * cols + origin.1;
             let next_flat = if forward {
                 (flat + offset) % total_cells
             } else {
@@ -539,14 +645,64 @@ impl App {
             let col = next_flat % cols;
 
             if let Some(cell) = self.sheet.get_cell((row, col)) {
-                if cell.value.to_string().to_lowercase().contains(&pattern) {
+                if cell.value.to_string().to_lowercase().contains(&needle) {
                     self.cursor = (row, col);
+                    self.viewport.ensure_visible(self.cursor);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Move the cursor along the current row to the next non-empty cell whose
+    /// displayed value starts with `ch` (case-insensitive). On no match the
+    /// cursor stays put. `inclusive = false` lands one cell short (vim `t`).
+    fn find_char_in_row(&mut self, ch: char, forward: bool, inclusive: bool) {
+        let target = ch.to_lowercase().next().unwrap_or(ch);
+        let (row, col) = self.cursor;
+        let cols = self.sheet.col_count;
+        if cols == 0 {
+            return;
+        }
+
+        let cell_starts_with = |sheet: &Sheet, pos: CellPos, t: char| -> bool {
+            let Some(cell) = sheet.get_cell(pos) else {
+                return false;
+            };
+            let s = cell.value.to_string();
+            if s.is_empty() {
+                return false;
+            }
+            s.chars()
+                .next()
+                .map(|c| c.to_lowercase().next().unwrap_or(c) == t)
+                .unwrap_or(false)
+        };
+
+        if forward {
+            for c in (col + 1)..cols {
+                if cell_starts_with(&self.sheet, (row, c), target) {
+                    let landing = if inclusive {
+                        c
+                    } else {
+                        c.saturating_sub(1).max(col)
+                    };
+                    self.cursor = (row, landing);
+                    self.viewport.ensure_visible(self.cursor);
+                    return;
+                }
+            }
+        } else {
+            for c in (0..col).rev() {
+                if cell_starts_with(&self.sheet, (row, c), target) {
+                    let landing = if inclusive { c } else { (c + 1).min(col) };
+                    self.cursor = (row, landing);
                     self.viewport.ensure_visible(self.cursor);
                     return;
                 }
             }
         }
-        self.status_message = Some(format!("Pattern not found: {}", pattern));
     }
 
     fn apply_undo_entry(&mut self, entry: &UndoEntry, redo: bool) {
@@ -926,6 +1082,425 @@ mod tests {
 
         assert!(app.sheet.get_cell((0, 0)).is_none());
         assert!(app.sheet.get_cell((0, 1)).is_none());
+    }
+
+    // ── Search prompt (/?) ──────────────────────────────────────────────────
+
+    #[test]
+    fn enter_search_forward_sets_command_mode_with_slash_prefix() {
+        use crate::action::{CommandKind, SearchDirection};
+        let mut app = App::new();
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        assert_eq!(app.mode, Mode::Command);
+        assert_eq!(app.command_kind, CommandKind::Slash);
+        assert!(app.command_line.is_empty());
+    }
+
+    #[test]
+    fn enter_search_backward_sets_question_prefix() {
+        use crate::action::{CommandKind, SearchDirection};
+        let mut app = App::new();
+        app.process_action(Action::EnterSearch(SearchDirection::Backward));
+        assert_eq!(app.mode, Mode::Command);
+        assert_eq!(app.command_kind, CommandKind::Question);
+    }
+
+    #[test]
+    fn change_mode_command_resets_to_colon() {
+        use crate::action::{CommandKind, SearchDirection};
+        let mut app = App::new();
+        // Enter search, then user backs out and re-enters via `:`.
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::ChangeMode(Mode::Normal));
+        app.process_action(Action::ChangeMode(Mode::Command));
+        assert_eq!(app.command_kind, CommandKind::Colon);
+    }
+
+    #[test]
+    fn forward_search_populates_pattern_and_moves_cursor() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((0, 1), "beta".into()));
+        app.process_action(Action::EditCell((1, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::Search {
+            pattern: "gamma".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.search_pattern.as_deref(), Some("gamma"));
+        assert_eq!(app.cursor, (1, 0));
+    }
+
+    #[test]
+    fn backward_search_walks_backwards() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((1, 0), "beta".into()));
+        app.process_action(Action::EditCell((2, 0), "alpha".into()));
+        app.cursor = (1, 0);
+        app.process_action(Action::Search {
+            pattern: "alpha".into(),
+            direction: SearchDirection::Backward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn search_next_after_search_keeps_stepping() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "x".into()));
+        app.process_action(Action::EditCell((1, 0), "x".into()));
+        app.process_action(Action::EditCell((2, 0), "x".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::Search {
+            pattern: "x".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (1, 0));
+        app.process_action(Action::SearchNext);
+        assert_eq!(app.cursor, (2, 0));
+    }
+
+    #[test]
+    fn empty_pattern_does_not_overwrite_search_pattern() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::Search {
+            pattern: "first".into(),
+            direction: SearchDirection::Forward,
+        });
+        app.process_action(Action::Search {
+            pattern: String::new(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.search_pattern.as_deref(), Some("first"));
+    }
+
+    // ── Incremental search ──────────────────────────────────────────────────
+
+    #[test]
+    fn enter_search_records_origin() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.cursor = (3, 2);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        assert_eq!(app.search_origin, Some((3, 2)));
+    }
+
+    #[test]
+    fn incremental_search_moves_cursor_as_user_types() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((1, 0), "beta".into()));
+        app.process_action(Action::EditCell((2, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        // User types `g` — should jump to "gamma" already.
+        app.process_action(Action::SearchIncremental {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (2, 0));
+        // User adds `am` — still on gamma.
+        app.process_action(Action::SearchIncremental {
+            pattern: "gam".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (2, 0));
+    }
+
+    #[test]
+    fn incremental_search_does_not_compound_movement() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((1, 0), "alpine".into()));
+        app.process_action(Action::EditCell((2, 0), "ant".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        // First match for "a" with origin=(0,0) and include_origin=true is
+        // (0,0) itself. Without origin tracking, a second char would search
+        // again from (0,0) and stay; with origin tracking, "al" should still
+        // anchor on the origin and find (0,0) (alpha contains "al").
+        app.process_action(Action::SearchIncremental {
+            pattern: "a".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+        app.process_action(Action::SearchIncremental {
+            pattern: "alp".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+        app.process_action(Action::SearchIncremental {
+            pattern: "alpi".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (1, 0));
+    }
+
+    #[test]
+    fn incremental_search_empty_pattern_restores_to_origin() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((2, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::SearchIncremental {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (2, 0));
+        // User backspaces back to empty — cursor should snap back to origin.
+        app.process_action(Action::SearchIncremental {
+            pattern: String::new(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn incremental_search_no_match_snaps_back_to_origin() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((2, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::SearchIncremental {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (2, 0));
+        // Add a char that breaks the match — cursor should reset to origin.
+        app.process_action(Action::SearchIncremental {
+            pattern: "gz".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn cancel_search_restores_cursor_and_returns_to_normal() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((2, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::SearchIncremental {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (2, 0));
+        app.process_action(Action::CancelSearch);
+        assert_eq!(app.cursor, (0, 0));
+        assert_eq!(app.mode, Mode::Normal);
+        assert_eq!(app.search_origin, None);
+    }
+
+    #[test]
+    fn submit_search_commits_at_incremental_position() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((2, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::SearchIncremental {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        // Enter pressed: Action::Search submitted with the typed pattern.
+        app.process_action(Action::Search {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (2, 0));
+        assert_eq!(app.search_pattern.as_deref(), Some("g"));
+        assert_eq!(app.search_origin, None);
+    }
+
+    #[test]
+    fn submit_search_with_no_match_returns_to_origin() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::Search {
+            pattern: "zzz".into(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+        assert!(app.status_message.is_some());
+    }
+
+    #[test]
+    fn submit_empty_search_after_typing_restores_to_origin() {
+        use crate::action::SearchDirection;
+        let mut app = App::new();
+        app.process_action(Action::EditCell((2, 0), "gamma".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::EnterSearch(SearchDirection::Forward));
+        app.process_action(Action::SearchIncremental {
+            pattern: "g".into(),
+            direction: SearchDirection::Forward,
+        });
+        // User backspaces to empty then hits Enter.
+        app.process_action(Action::Search {
+            pattern: String::new(),
+            direction: SearchDirection::Forward,
+        });
+        assert_eq!(app.cursor, (0, 0));
+        assert_eq!(app.search_origin, None);
+    }
+
+    // ── f / F / ; / , ───────────────────────────────────────────────────────
+
+    fn setup_row(app: &mut App, cells: &[(usize, &str)]) {
+        for (col, raw) in cells {
+            app.process_action(Action::EditCell((0, *col), (*raw).into()));
+        }
+    }
+
+    #[test]
+    fn find_char_forward_lands_on_starts_with_match() {
+        let mut app = App::new();
+        setup_row(
+            &mut app,
+            &[(0, "alpha"), (1, "beta"), (2, "gamma"), (3, "delta")],
+        );
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'g',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 2));
+    }
+
+    #[test]
+    fn find_char_is_case_insensitive() {
+        let mut app = App::new();
+        setup_row(&mut app, &[(0, "alpha"), (1, "Beta"), (2, "gamma")]);
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'b',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 1));
+    }
+
+    #[test]
+    fn find_char_backward_lands_on_match() {
+        let mut app = App::new();
+        setup_row(
+            &mut app,
+            &[(0, "alpha"), (1, "beta"), (2, "gamma"), (3, "delta")],
+        );
+        app.cursor = (0, 3);
+        app.process_action(Action::FindCharInRow {
+            ch: 'a',
+            forward: false,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn find_char_no_match_keeps_cursor() {
+        let mut app = App::new();
+        setup_row(&mut app, &[(0, "alpha"), (1, "beta"), (2, "gamma")]);
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'z',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn find_char_skips_empty_cells() {
+        let mut app = App::new();
+        // Row has gaps at col 1 and 3.
+        setup_row(&mut app, &[(0, "alpha"), (2, "beta"), (4, "berry")]);
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'b',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 2));
+    }
+
+    #[test]
+    fn find_char_remembers_last_target_for_repeat() {
+        let mut app = App::new();
+        setup_row(&mut app, &[(0, "alpha"), (1, "beta"), (2, "berry")]);
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'b',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 1));
+        app.process_action(Action::RepeatFind { reversed: false });
+        assert_eq!(app.cursor, (0, 2));
+    }
+
+    #[test]
+    fn comma_repeats_find_reversed_direction() {
+        let mut app = App::new();
+        setup_row(
+            &mut app,
+            &[(0, "alpha"), (1, "beta"), (2, "berry"), (3, "delta")],
+        );
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'b',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 1));
+        // ; would step forward to col 2; , flips and steps back to col... but
+        // there's no `b` to the left of col 1. Cursor should stay put.
+        app.process_action(Action::RepeatFind { reversed: true });
+        assert_eq!(app.cursor, (0, 1));
+        // Now move right past berry, then , should walk back to it.
+        app.cursor = (0, 3);
+        app.process_action(Action::RepeatFind { reversed: true });
+        assert_eq!(app.cursor, (0, 2));
+    }
+
+    #[test]
+    fn repeat_find_with_no_prior_find_is_noop() {
+        let mut app = App::new();
+        setup_row(&mut app, &[(0, "alpha"), (1, "beta")]);
+        app.cursor = (0, 0);
+        app.process_action(Action::RepeatFind { reversed: false });
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn find_char_uses_displayed_value_not_raw() {
+        // Formula displayed value should drive the match, not the raw `=…`.
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "alpha".into()));
+        app.process_action(Action::EditCell((0, 1), "=\"banana\"".into()));
+        app.cursor = (0, 0);
+        app.process_action(Action::FindCharInRow {
+            ch: 'b',
+            forward: true,
+            inclusive: true,
+        });
+        assert_eq!(app.cursor, (0, 1));
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -153,7 +153,7 @@ fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use mode::command::{handle_command_key, parse_command, CommandAction};
+    use mode::command::{handle_command_key, submit, CommandAction};
     use mode::help::HelpState;
     use mode::insert::{handle_insert_char, handle_insert_key, InsertAction};
     use mode::normal::NormalState;
@@ -162,7 +162,6 @@ fn run_loop(
     let mut normal_state = NormalState::new();
     let mut visual_state: Option<VisualState> = None;
     let mut insert_cursor: usize = 0;
-    let mut search_mode = false;
     let mut wq_pending = false;
     let mut help_state = HelpState::new();
 
@@ -245,37 +244,58 @@ fn run_loop(
                     }
                     Mode::Help => help_state.handle_key(key, app, grid_height),
                     Mode::Command => {
+                        use action::{CommandKind, SearchDirection};
                         let cmd_action = handle_command_key(key, &app.command_line);
+                        let search_dir = match app.command_kind {
+                            CommandKind::Slash => Some(SearchDirection::Forward),
+                            CommandKind::Question => Some(SearchDirection::Backward),
+                            CommandKind::Colon => None,
+                        };
                         match cmd_action {
                             CommandAction::InsertChar(c) => {
                                 app.command_line.push(c);
-                                Action::Noop
+                                if let Some(dir) = search_dir {
+                                    Action::SearchIncremental {
+                                        pattern: app.command_line.clone(),
+                                        direction: dir,
+                                    }
+                                } else {
+                                    Action::Noop
+                                }
                             }
                             CommandAction::Backspace => {
                                 app.command_line.pop();
-                                Action::Noop
-                            }
-                            CommandAction::Execute(cmd) => {
-                                if search_mode {
-                                    search_mode = false;
-                                    let pattern = app.command_line.clone();
-                                    app.command_line.clear();
-                                    app.search_pattern = Some(pattern);
-                                    Action::ChangeMode(Mode::Normal)
-                                } else {
-                                    let is_wq = cmd.trim() == "wq";
-                                    let parsed = parse_command(&cmd);
-                                    app.command_line.clear();
-                                    if is_wq {
-                                        wq_pending = true;
+                                if let Some(dir) = search_dir {
+                                    Action::SearchIncremental {
+                                        pattern: app.command_line.clone(),
+                                        direction: dir,
                                     }
-                                    parsed
+                                } else {
+                                    Action::Noop
                                 }
                             }
-                            CommandAction::Cancel => {
+                            CommandAction::Execute(cmd) => {
+                                let kind = app.command_kind;
+                                let is_wq =
+                                    matches!(kind, CommandKind::Colon) && cmd.trim() == "wq";
+                                let parsed = submit(kind, &cmd);
                                 app.command_line.clear();
-                                search_mode = false;
-                                Action::ChangeMode(Mode::Normal)
+                                if is_wq {
+                                    wq_pending = true;
+                                }
+                                // Submitting any prompt returns to normal
+                                // mode regardless of whether the action
+                                // ends up moving the cursor.
+                                app.mode = Mode::Normal;
+                                parsed
+                            }
+                            CommandAction::Cancel => {
+                                if search_dir.is_some() {
+                                    Action::CancelSearch
+                                } else {
+                                    app.command_line.clear();
+                                    Action::ChangeMode(Mode::Normal)
+                                }
                             }
                             CommandAction::Noop => Action::Noop,
                         }
@@ -301,12 +321,6 @@ fn run_loop(
                 if matches!(&action, Action::ChangeCell(_) | Action::ChangeRange { .. }) {
                     insert_cursor = 0;
                 }
-                if let Action::ChangeMode(Mode::Command) = &action {
-                    if key.code == KeyCode::Char('/') {
-                        search_mode = true;
-                    }
-                }
-
                 app.process_action(action);
 
                 if wq_pending && !app.dirty {

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -1,6 +1,29 @@
-use crate::action::Action;
+use crate::action::{Action, CommandKind, SearchDirection};
 use crossterm::event::{KeyCode, KeyEvent};
 use std::path::PathBuf;
+
+/// Turn a submitted command line into an `Action`. The prompt prefix
+/// (`:`, `/`, `?`) decides how `input` is parsed: ex-style command vs
+/// search pattern.
+pub fn submit(kind: CommandKind, input: &str) -> Action {
+    match kind {
+        CommandKind::Colon => parse_command(input),
+        CommandKind::Slash => parse_search(input, SearchDirection::Forward),
+        CommandKind::Question => parse_search(input, SearchDirection::Backward),
+    }
+}
+
+fn parse_search(input: &str, direction: SearchDirection) -> Action {
+    let pattern = input.trim();
+    if pattern.is_empty() {
+        Action::Noop
+    } else {
+        Action::Search {
+            pattern: pattern.to_string(),
+            direction,
+        }
+    }
+}
 
 pub fn parse_command(input: &str) -> Action {
     let input = input.trim();
@@ -180,6 +203,53 @@ mod tests {
         assert_eq!(
             handle_command_key(key(KeyCode::Char('q')), ""),
             CommandAction::InsertChar('q')
+        );
+    }
+
+    #[test]
+    fn submit_colon_routes_to_parse_command() {
+        assert_eq!(
+            submit(CommandKind::Colon, "q"),
+            Action::Quit { force: false }
+        );
+    }
+
+    #[test]
+    fn submit_slash_dispatches_forward_search() {
+        assert_eq!(
+            submit(CommandKind::Slash, "foo"),
+            Action::Search {
+                pattern: "foo".into(),
+                direction: SearchDirection::Forward,
+            }
+        );
+    }
+
+    #[test]
+    fn submit_question_dispatches_backward_search() {
+        assert_eq!(
+            submit(CommandKind::Question, "bar"),
+            Action::Search {
+                pattern: "bar".into(),
+                direction: SearchDirection::Backward,
+            }
+        );
+    }
+
+    #[test]
+    fn submit_empty_search_is_noop() {
+        assert_eq!(submit(CommandKind::Slash, ""), Action::Noop);
+        assert_eq!(submit(CommandKind::Question, "   "), Action::Noop);
+    }
+
+    #[test]
+    fn submit_search_trims_whitespace() {
+        assert_eq!(
+            submit(CommandKind::Slash, "  hello  "),
+            Action::Search {
+                pattern: "hello".into(),
+                direction: SearchDirection::Forward,
+            }
         );
     }
 }

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -1,17 +1,46 @@
-use crate::action::{Action, Direction, Mode};
+use crate::action::{Action, Direction, Mode, SearchDirection};
 use crate::app::App;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FindKind {
+    /// `f<char>` — forward, inclusive.
+    Forward,
+    /// `F<char>` — backward, inclusive.
+    Backward,
+}
+
 pub struct NormalState {
     pub pending: Option<char>,
+    /// Set after `f` or `F` so the next keypress is consumed as the target.
+    pub pending_find: Option<FindKind>,
 }
 
 impl NormalState {
     pub fn new() -> Self {
-        NormalState { pending: None }
+        NormalState {
+            pending: None,
+            pending_find: None,
+        }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent, app: &App) -> Action {
+        // A pending `f`/`F` consumes the next keypress as its target,
+        // regardless of modifier (so `f<Shift+a>` still hits 'A').
+        if let Some(kind) = self.pending_find.take() {
+            return match key.code {
+                KeyCode::Char(c) => {
+                    let forward = matches!(kind, FindKind::Forward);
+                    Action::FindCharInRow {
+                        ch: c,
+                        forward,
+                        inclusive: true,
+                    }
+                }
+                _ => Action::Noop,
+            };
+        }
+
         // Handle Ctrl combinations first
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             return match key.code {
@@ -67,9 +96,20 @@ impl NormalState {
             KeyCode::Char('p') => Action::Paste(app.cursor),
             KeyCode::Char('P') => Action::PasteBefore(app.cursor),
             KeyCode::Char('u') => Action::Undo,
-            KeyCode::Char('/') => Action::ChangeMode(Mode::Command),
+            KeyCode::Char('/') => Action::EnterSearch(SearchDirection::Forward),
+            KeyCode::Char('?') => Action::EnterSearch(SearchDirection::Backward),
             KeyCode::Char('n') => Action::SearchNext,
             KeyCode::Char('N') => Action::SearchPrev,
+            KeyCode::Char('f') => {
+                self.pending_find = Some(FindKind::Forward);
+                Action::Noop
+            }
+            KeyCode::Char('F') => {
+                self.pending_find = Some(FindKind::Backward);
+                Action::Noop
+            }
+            KeyCode::Char(';') => Action::RepeatFind { reversed: false },
+            KeyCode::Char(',') => Action::RepeatFind { reversed: true },
             KeyCode::Enter => Action::ChangeMode(Mode::Insert),
             _ => Action::Noop,
         }
@@ -198,5 +238,111 @@ mod tests {
         let app = App::new();
         let mut state = NormalState::new();
         assert_eq!(state.handle_key(ctrl_key('d'), &app), Action::HalfPageDown);
+    }
+
+    #[test]
+    fn slash_enters_forward_search_prompt() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('/')), &app),
+            Action::EnterSearch(SearchDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn question_enters_backward_search_prompt() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('?')), &app),
+            Action::EnterSearch(SearchDirection::Backward)
+        );
+    }
+
+    #[test]
+    fn f_then_char_emits_forward_find() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('f')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('a')), &app),
+            Action::FindCharInRow {
+                ch: 'a',
+                forward: true,
+                inclusive: true,
+            }
+        );
+    }
+
+    #[test]
+    fn shift_f_then_char_emits_backward_find() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('F')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('Z')), &app),
+            Action::FindCharInRow {
+                ch: 'Z',
+                forward: false,
+                inclusive: true,
+            }
+        );
+    }
+
+    #[test]
+    fn pending_find_consumes_only_one_key() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        state.handle_key(key(KeyCode::Char('f')), &app);
+        state.handle_key(key(KeyCode::Char('a')), &app);
+        // After the find resolves, hjkl should resume working normally.
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('l')), &app),
+            Action::MoveCursor(Direction::Right)
+        );
+    }
+
+    #[test]
+    fn pending_find_swallows_non_char_keys() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('f')), &app),
+            Action::Noop
+        );
+        // Esc-as-target cancels the find without dispatching anything.
+        assert_eq!(state.handle_key(key(KeyCode::Esc), &app), Action::Noop);
+        // And it doesn't leave the state stuck.
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('h')), &app),
+            Action::MoveCursor(Direction::Left)
+        );
+    }
+
+    #[test]
+    fn semicolon_repeats_find() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char(';')), &app),
+            Action::RepeatFind { reversed: false }
+        );
+    }
+
+    #[test]
+    fn comma_repeats_find_reversed() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char(',')), &app),
+            Action::RepeatFind { reversed: true }
+        );
     }
 }

--- a/crates/cell-sheet-tui/src/render/mod.rs
+++ b/crates/cell-sheet-tui/src/render/mod.rs
@@ -105,7 +105,7 @@ pub fn render(
     frame.render_widget(
         CommandLine {
             content: &app.command_line,
-            prefix: ':',
+            prefix: app.command_kind.prefix(),
             active: is_command,
         },
         chunks[3],

--- a/examples/demo.cell
+++ b/examples/demo.cell
@@ -9,74 +9,61 @@ col-width 3 10
 col-width 4 12
 
 label A0 = "BUDGET 2026"
-
 label A2 = "Category"
 label B2 = "Jan"
 label C2 = "Feb"
 label D2 = "Mar"
 label E2 = "Q1 Total"
-
 label A3 = "Rent"
 let B3 = 1200
 let C3 = 1200
 let D3 = 1200
 formula E3 = =SUM(B4:D4)
-
 label A4 = "Food"
 let B4 = 450
 let C4 = 480
 let D4 = 390
 formula E4 = =SUM(B5:D5)
-
 label A5 = "Transport"
 let B5 = 120
 let C5 = 95
 let D5 = 140
 formula E5 = =SUM(B6:D6)
-
 label A6 = "Entertainment"
 let B6 = 80
 let C6 = 150
 let D6 = 60
 formula E6 = =SUM(B7:D7)
-
 label A7 = "Utilities"
 let B7 = 200
 let C7 = 180
 let D7 = 220
 formula E7 = =SUM(B8:D8)
-
 label A9 = "Monthly Total"
 formula B9 = =SUM(B4:B8)
 formula C9 = =SUM(C4:C8)
 formula D9 = =SUM(D4:D8)
 formula E9 = =SUM(E4:E8)
-
 label A11 = "Avg/Month"
 formula B11 = =AVERAGE(B4:B8)
 formula C11 = =AVERAGE(C4:C8)
 formula D11 = =AVERAGE(D4:D8)
-
 label A12 = "Highest"
 formula B12 = =MAX(B4:B8)
 formula C12 = =MAX(C4:C8)
 formula D12 = =MAX(D4:D8)
-
 label A13 = "Lowest"
 formula B13 = =MIN(B4:B8)
 formula C13 = =MIN(C4:C8)
 formula D13 = =MIN(D4:D8)
-
 label A14 = "# Categories"
 formula B14 = =COUNT(B4:B8)
 formula C14 = =COUNT(C4:C8)
 formula D14 = =COUNT(D4:D8)
-
 label A16 = "Budget Target"
 let B16 = 2100
 let C16 = 2100
 let D16 = 2100
-
 label A17 = "Status"
 formula B17 = =IF(B10<=B17,"Under","Over")
 formula C17 = =IF(C10<=C17,"Under","Over")


### PR DESCRIPTION
## Summary

Closes #28. Wires up the two missing vim-staple navigations in normal mode.

### `/<pattern>` and `?<pattern>` — search prompts

`Action::Search` and `find_next` already existed, but nothing dispatched
the action and the `/` prompt rendered with a `:` prefix. This change:

- Adds a `CommandKind` discriminator (`Colon` / `Slash` / `Question`) on
  `App` so the existing `Mode::Command` infrastructure can render `:`,
  `/`, or `?` and route the submitted line accordingly.
- Adds `Action::EnterSearch(SearchDirection)` (mapped to `/` and `?` in
  normal mode) which records the cursor as `search_origin`.
- Implements **incremental search** (vim's `incsearch`): each typed char
  or backspace dispatches `Action::SearchIncremental` which re-runs the
  search from `search_origin` (with origin as a candidate, so adding
  chars never compounds movement). No match snaps back to origin.
- `Esc` dispatches `Action::CancelSearch`, restoring the cursor to the
  origin. `Enter` commits at the incremental position.
- Empty submit restores the cursor and leaves any prior `search_pattern`
  intact, so `n`/`N` keep working after a stray Enter.

### `f<char>` / `F<char>` / `;` / `,` — find char in row

- `NormalState::pending_find` consumes the next keypress as the target
  (works for `Shift`-modified chars too).
- `Action::FindCharInRow { ch, forward, inclusive }` and
  `Action::RepeatFind { reversed }` are dispatched immediately on the
  target keypress (no Enter required).
- `App::find_char_in_row` scans the current row's non-empty cells,
  matches case-insensitively against the **displayed** value's first
  char (so `=\"banana\"` matches `b`), and leaves the cursor put on no
  match.
- `App::last_find` remembers the target so `;` repeats and `,` reverses.
- `inclusive` is plumbed through (always `true` for `f`/`F`); `t`/`T`
  is a one-line follow-up but out of scope per the issue.

### Docs

- `CHANGELOG.md` Unreleased entries under Added.
- `README.md` keybindings table updated with `/`/`?`, `f`/`F`, `;`/`,`.
- `crates/cell-sheet-core/src/help/entries.rs` adds entries for `?`,
  `f`, `F`, `;`, `,` and refreshes `/` so `:help` covers them.

## Test plan

- [x] 31 new unit tests across \`mode/normal.rs\`, \`mode/command.rs\`, and
  \`app.rs\` covering: prompt direction, prefix reset on \`:\`, incremental
  movement, no-compounding when adding chars, empty-pattern restore,
  no-match snap-back, Esc cancel restoring cursor, Enter commit at
  incremental position, find forward/backward/case-insensitive/no-match,
  empty-cell skipping, repeat semantics, displayed-value matching,
  pending-find swallowing non-char keys.
- [x] \`cargo fmt --all --check\`
- [x] \`RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --all-features\`
- [x] \`cargo test\` (226 tests passing)
- [ ] Manual: open a sheet, type \`/foo\` and verify cursor moves as you
  type; press Esc and verify cursor returns to its original position.
- [ ] Manual: navigate to a row, press \`fX\` (with \`X\` being a target
  char) and verify the cursor jumps immediately without confirmation;
  use \`;\` and \`,\` to repeat.


Made with [Cursor](https://cursor.com)