### PR TITLE
fix: use Neumaier summation for SUM and AVERAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   Triggered immediately on the target keypress without confirmation.
   `;` repeats the last find, `,` repeats it reversed (#28)
 
+### Fixed
+
+- `SUM` and `AVERAGE` now use Neumaier's improved Kahan compensated summation
+  instead of naive accumulation, eliminating catastrophic-cancellation errors
+  (e.g. `SUM(1e16, 1, -1e16)` now returns `1` instead of `0`) and keeping
+  long-sequence drift well below 1e-10 (#43)
+
 ## 0.2.0
 
 ### Notes

--- a/crates/cell-sheet-core/src/formula/functions.rs
+++ b/crates/cell-sheet-core/src/formula/functions.rs
@@ -14,9 +14,29 @@ fn collect_numbers(values: &[CellValue]) -> Result<Vec<f64>, CellError> {
     Ok(nums)
 }
 
+/// Neumaier's improved Kahan compensated summation.
+///
+/// Unlike naive accumulation, it captures the rounding error lost when a
+/// large and a small value are added, so it handles catastrophic cancellation
+/// (e.g. `[1e16, 1.0, -1e16]`) and long sequences of small floats correctly.
+fn neumaier_sum(nums: &[f64]) -> f64 {
+    let mut sum = 0.0f64;
+    let mut c = 0.0f64;
+    for &x in nums {
+        let t = sum + x;
+        c += if sum.abs() >= x.abs() {
+            (sum - t) + x
+        } else {
+            (x - t) + sum
+        };
+        sum = t;
+    }
+    sum + c
+}
+
 pub fn fn_sum(values: &[CellValue]) -> CellValue {
     match collect_numbers(values) {
-        Ok(nums) => CellValue::Number(nums.iter().sum()),
+        Ok(nums) => CellValue::Number(neumaier_sum(&nums)),
         Err(e) => CellValue::Error(e),
     }
 }
@@ -24,10 +44,10 @@ pub fn fn_sum(values: &[CellValue]) -> CellValue {
 pub fn fn_average(values: &[CellValue]) -> CellValue {
     match collect_numbers(values) {
         Ok(nums) if nums.is_empty() => CellValue::Error(CellError::DivZero),
-        Ok(nums) => {
-            let count = nums.len() as f64;
-            CellValue::Number(nums.iter().sum::<f64>() / count)
-        }
+        // Reuse the compensated sum so the mean inherits its accuracy;
+        // a naive sum/n approach has the same catastrophic-cancellation
+        // problem when individual values are very large.
+        Ok(nums) => CellValue::Number(neumaier_sum(&nums) / nums.len() as f64),
         Err(e) => CellValue::Error(e),
     }
 }
@@ -71,5 +91,69 @@ pub fn fn_if(args: &[CellValue]) -> CellValue {
         }
         CellValue::Error(e) => CellValue::Error(e.clone()),
         _ => CellValue::Error(CellError::Value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn num(n: f64) -> CellValue {
+        CellValue::Number(n)
+    }
+
+    fn extract_number(v: CellValue) -> f64 {
+        match v {
+            CellValue::Number(n) => n,
+            other => panic!("expected Number, got {:?}", other),
+        }
+    }
+
+    // SUM: catastrophic cancellation — naive accumulation loses 1.0 entirely
+    // because 1e16 + 1.0 rounds to 1e16 in f64.
+    #[test]
+    fn sum_catastrophic_cancellation_is_accurate() {
+        let values = vec![num(1e16), num(1.0), num(-1e16)];
+        assert_eq!(fn_sum(&values), CellValue::Number(1.0));
+    }
+
+    // SUM: long sequence — 10_000 × 0.1; the tight tolerance (1e-10)
+    // catches naive per-step drift that Neumaier summation avoids.
+    #[test]
+    fn sum_long_sequence_of_small_floats_is_accurate() {
+        let values: Vec<CellValue> = std::iter::repeat_n(num(0.1), 10_000).collect();
+        let result = extract_number(fn_sum(&values));
+        assert!(
+            (result - 1000.0).abs() < 1e-10,
+            "SUM error too large: |{result} - 1000| = {}",
+            (result - 1000.0).abs()
+        );
+    }
+
+    // AVERAGE: catastrophic cancellation — naive sum = 0.0, so naive mean = 0.0
+    // instead of the correct 1/3.
+    #[test]
+    fn average_catastrophic_cancellation_is_accurate() {
+        let values = vec![num(1e16), num(1.0), num(-1e16)];
+        let result = extract_number(fn_average(&values));
+        let expected = 1.0 / 3.0;
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "AVERAGE catastrophic error: |{result} - {expected}| = {}",
+            (result - expected).abs()
+        );
+    }
+
+    // AVERAGE: long sequence — compensated sum/n stays accurate without
+    // accumulating intermediate drift.
+    #[test]
+    fn average_long_sequence_of_small_floats_is_accurate() {
+        let values: Vec<CellValue> = std::iter::repeat_n(num(0.1), 10_000).collect();
+        let result = extract_number(fn_average(&values));
+        assert!(
+            (result - 0.1).abs() < 1e-14,
+            "AVERAGE error too large: |{result} - 0.1| = {}",
+            (result - 0.1).abs()
+        );
     }
 }


### PR DESCRIPTION
Closes #43

## Summary

- Replaces the naive `iter().sum()` accumulator in `fn_sum` with **Neumaier's improved Kahan compensated summation**, which captures the rounding error lost when a large and a small value are added together.
- `fn_average` is updated to use `neumaier_sum / count` rather than the previous `iter().sum() / count`; a Welford running-mean was considered but has the same catastrophic-cancellation problem as the naive approach when individual values span many orders of magnitude.

## Test plan

Four regression tests added to `crates/cell-sheet-core/src/formula/functions.rs`:

- [ ] `sum_catastrophic_cancellation_is_accurate` — `[1e16, 1.0, -1e16]` yields `1.0` (naive gives `0.0`)
- [ ] `sum_long_sequence_of_small_floats_is_accurate` — 10 000 × `0.1`, error < 1e-10
- [ ] `average_catastrophic_cancellation_is_accurate` — same inputs, mean within 1e-10 of `1/3`
- [ ] `average_long_sequence_of_small_floats_is_accurate` — 10 000 × `0.1`, mean error < 1e-14

All four tests fail on `main` and pass on this branch. Full `cargo fmt`, `cargo clippy`, and `cargo test` run clean.

Made with [Cursor](https://cursor.com)