### PR TITLE
Fix crossterm double-entry on Windows

### DIFF
--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -11,7 +11,7 @@ use action::{Action, Mode};
 use app::{App, FileFormat};
 use clap::Parser;
 use crossterm::{
-    event::{self, Event, KeyCode},
+    event::{self, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -178,6 +178,10 @@ fn run_loop(
 
         if event::poll(std::time::Duration::from_millis(100))? {
             if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                
                 app.status_message = None;
 
                 let action = match app.mode {


### PR DESCRIPTION
Fixes issue with crossterm on Windows where key press and key release are treated as separate events. Manually tested with ":q!" on cmd.exe.

See https://github.com/garritfra/cell/issues/44