### PR TITLE
feat: custom CSV delimiter (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+# Test artifact created by unit tests that write to relative paths
+crates/cell-sheet-tui/data.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Custom field delimiter support: `--delimiter '|'` CLI flag, auto-detection from
+  file content, and `:set delimiter=X` ex-command. Writing with a non-standard
+  delimiter to a `.csv` or `.tsv` file shows a warning; use `:w!` to override.
+  Resolves #20.
+
 ## 0.3.1 (2026-04-28)
 
 ### Fixed

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -329,7 +329,7 @@ pub static COMMAND_ENTRIES: &[HelpEntry] = &[
         detail: "Sort all rows by the values in a column.\nUsage: :sort <column> [asc|desc]\n\nExamples:\n  :sort A        Sort by column A ascending\n  :sort B desc   Sort by column B descending",
     },
     HelpEntry {
-        tags: &[":set delimiter", "--delimiter"],
+        tags: &[":set delimiter", "--delimiter", "delimiter"],
         category: HelpCategory::Command,
         summary: "Set the field delimiter",
         detail: "Set the delimiter character used when reading or saving\nCSV/TSV files.\n\nUsage (ex-command):  :set delimiter=|\n                     :set delimiter=;\nUsage (CLI flag):    cell data.psv --delimiter '|'\n\nValid delimiters: any single printable ASCII character that\nis not a letter, digit, or double-quote (e.g. | ; , \\t).\n\nThe delimiter is auto-detected from file content on open\nwhen the --delimiter flag is not provided and the extension\nis not .tsv. Use --delimiter to override detection.\n\n:set delimiter only affects the next save — it does not\nre-parse the currently loaded file. To reload with a new\ndelimiter, close and reopen the file with --delimiter.",

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -290,13 +290,13 @@ pub static COMMAND_ENTRIES: &[HelpEntry] = &[
         tags: &[":w", ":write"],
         category: HelpCategory::Command,
         summary: "Save file",
-        detail: "Write the current sheet to disk. If no filename has been set,\nuse :w <path> to specify one.\n\nIf the sheet contains formulas and you save as CSV/TSV,\nCell will warn you. Use :w file.cell to preserve formulas,\nor :w! to force save as CSV (formulas become values).",
+        detail: "Write the current sheet to disk. If no filename has been set,\nuse :w <path> to specify one.\n\nIf the sheet contains formulas and you save as CSV/TSV,\nCell will warn you. Use :w file.cell to preserve formulas,\nor :w! to force save as CSV (formulas become values).\n\nIf the active delimiter (see :set delimiter) does not match\nthe file extension convention, Cell will also warn you.\nUse :w! to override.",
     },
     HelpEntry {
         tags: &[":w!"],
         category: HelpCategory::Command,
         summary: "Force save",
-        detail: "Write the current sheet to disk, even if formulas would be\nlost by saving as CSV/TSV.",
+        detail: "Write the current sheet to disk, bypassing both the\nformula-flatten warning and the non-standard-delimiter warning.",
     },
     HelpEntry {
         tags: &[":q", ":quit"],
@@ -327,6 +327,12 @@ pub static COMMAND_ENTRIES: &[HelpEntry] = &[
         category: HelpCategory::Command,
         summary: "Sort by column",
         detail: "Sort all rows by the values in a column.\nUsage: :sort <column> [asc|desc]\n\nExamples:\n  :sort A        Sort by column A ascending\n  :sort B desc   Sort by column B descending",
+    },
+    HelpEntry {
+        tags: &[":set delimiter", ":set", "--delimiter"],
+        category: HelpCategory::Command,
+        summary: "Set the field delimiter",
+        detail: "Set the delimiter character used when reading or saving\nCSV/TSV files.\n\nUsage (ex-command):  :set delimiter=|\n                     :set delimiter=;\nUsage (CLI flag):    cell data.psv --delimiter '|'\n\nValid delimiters: any single printable ASCII character that\nis not a letter, digit, or double-quote (e.g. | ; , \\t).\n\nThe delimiter is auto-detected from file content on open\nwhen the --delimiter flag is not provided and the extension\nis not .tsv. Use --delimiter to override detection.\n\n:set delimiter only affects the next save — it does not\nre-parse the currently loaded file. To reload with a new\ndelimiter, close and reopen the file with --delimiter.",
     },
     HelpEntry {
         tags: &[":help"],

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -329,7 +329,7 @@ pub static COMMAND_ENTRIES: &[HelpEntry] = &[
         detail: "Sort all rows by the values in a column.\nUsage: :sort <column> [asc|desc]\n\nExamples:\n  :sort A        Sort by column A ascending\n  :sort B desc   Sort by column B descending",
     },
     HelpEntry {
-        tags: &[":set delimiter", ":set", "--delimiter"],
+        tags: &[":set delimiter", "--delimiter"],
         category: HelpCategory::Command,
         summary: "Set the field delimiter",
         detail: "Set the delimiter character used when reading or saving\nCSV/TSV files.\n\nUsage (ex-command):  :set delimiter=|\n                     :set delimiter=;\nUsage (CLI flag):    cell data.psv --delimiter '|'\n\nValid delimiters: any single printable ASCII character that\nis not a letter, digit, or double-quote (e.g. | ; , \\t).\n\nThe delimiter is auto-detected from file content on open\nwhen the --delimiter flag is not provided and the extension\nis not .tsv. Use --delimiter to override detection.\n\n:set delimiter only affects the next save — it does not\nre-parse the currently loaded file. To reload with a new\ndelimiter, close and reopen the file with --delimiter.",

--- a/crates/cell-sheet-core/src/help/mod.rs
+++ b/crates/cell-sheet-core/src/help/mod.rs
@@ -167,5 +167,9 @@ mod tests {
         assert!(registry.find("IF").is_some(), "missing IF");
         assert!(registry.find("Esc").is_some(), "missing Esc");
         assert!(registry.find("v").is_some(), "missing v");
+        assert!(
+            registry.find(":set delimiter").is_some(),
+            "missing :set delimiter"
+        );
     }
 }

--- a/crates/cell-sheet-core/src/io/csv.rs
+++ b/crates/cell-sheet-core/src/io/csv.rs
@@ -4,6 +4,30 @@ use std::io::{Read, Write};
 const MAX_COL_WIDTH: u16 = 40;
 const DEFAULT_COL_WIDTH: u16 = 10;
 
+/// Inspect the first line of `sample` (up to 4 KiB) and return the most
+/// frequent delimiter among `,`, `\t`, `|`, `;`. Ties are broken in that
+/// order (comma wins ties). Returns `b','` for empty input.
+pub fn sniff_delimiter(sample: &[u8]) -> u8 {
+    let line_end = sample
+        .iter()
+        .position(|&b| b == b'\n')
+        .unwrap_or(sample.len());
+    let line = &sample[..line_end.min(4096)];
+
+    // Iterate in preference order so the first candidate wins ties.
+    let candidates = [b',', b'\t', b'|', b';'];
+    let mut best_delim = b',';
+    let mut best_count = 0usize;
+    for &d in &candidates {
+        let count = line.iter().filter(|&&b| b == d).count();
+        if count > best_count {
+            best_count = count;
+            best_delim = d;
+        }
+    }
+    best_delim
+}
+
 pub fn read_csv<R: Read>(reader: R, delimiter: u8) -> Result<Sheet, Box<dyn std::error::Error>> {
     let mut sheet = Sheet::new();
     let mut csv_reader = csv::ReaderBuilder::new()
@@ -189,5 +213,80 @@ mod tests {
         let sheet = read_csv(data.as_bytes(), b',').unwrap();
         assert!(sheet.col_widths[0] >= 5);
         assert!(sheet.col_widths[1] >= 5);
+    }
+
+    #[test]
+    fn sniff_pipe_delimiter() {
+        let sample = b"name|score|grade\nalice|95|A\n";
+        assert_eq!(sniff_delimiter(sample), b'|');
+    }
+
+    #[test]
+    fn sniff_semicolon_delimiter() {
+        let sample = b"a;b;c\n1;2;3\n";
+        assert_eq!(sniff_delimiter(sample), b';');
+    }
+
+    #[test]
+    fn sniff_tab_delimiter() {
+        let sample = b"a\tb\tc\n1\t2\t3\n";
+        assert_eq!(sniff_delimiter(sample), b'\t');
+    }
+
+    #[test]
+    fn sniff_empty_defaults_to_comma() {
+        assert_eq!(sniff_delimiter(b""), b',');
+    }
+
+    #[test]
+    fn sniff_tie_prefers_comma() {
+        // one comma, one pipe — comma wins ties
+        assert_eq!(sniff_delimiter(b"a,b|c\n"), b',');
+    }
+
+    #[test]
+    fn sniff_only_reads_first_line() {
+        // First line has pipes; second line has many commas — sniff ignores line 2
+        let sample = b"a|b|c\n1,2,3,4,5,6,7,8,9\n";
+        assert_eq!(sniff_delimiter(sample), b'|');
+    }
+
+    #[test]
+    fn read_pipe_delimited() {
+        let data = "a|b|c\n1|2|3\n";
+        let sheet = read_csv(data.as_bytes(), b'|').unwrap();
+        assert_eq!(sheet.row_count, 2);
+        assert_eq!(sheet.col_count, 3);
+        assert_eq!(
+            sheet.get_cell((0, 1)).unwrap().value,
+            CellValue::Text("b".into())
+        );
+        assert_eq!(
+            sheet.get_cell((1, 2)).unwrap().value,
+            CellValue::Number(3.0)
+        );
+    }
+
+    #[test]
+    fn write_pipe_delimited() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "a");
+        sheet.set_cell((0, 1), "b");
+        let mut buf = Vec::new();
+        write_csv(&sheet, &mut buf, b'|').unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "a|b\n");
+    }
+
+    #[test]
+    fn sniff_then_read_round_trip() {
+        let data = b"x|y|z\n1|2|3\n";
+        let delim = sniff_delimiter(data);
+        assert_eq!(delim, b'|');
+        let sheet = read_csv(data.as_ref(), delim).unwrap();
+        assert_eq!(sheet.col_count, 3);
+        assert_eq!(
+            sheet.get_cell((1, 1)).unwrap().value,
+            CellValue::Number(2.0)
+        );
     }
 }

--- a/crates/cell-sheet-core/src/io/csv.rs
+++ b/crates/cell-sheet-core/src/io/csv.rs
@@ -278,6 +278,24 @@ mod tests {
     }
 
     #[test]
+    fn sniff_respects_4kib_cap_on_long_first_line() {
+        // First line is 4097 bytes: 4096 pipes followed by one comma.
+        // Only the first 4096 bytes are inspected, so pipe wins.
+        let mut line = vec![b'|'; 4096];
+        line.push(b',');
+        line.push(b'\n');
+        assert_eq!(sniff_delimiter(&line), b'|');
+    }
+
+    #[test]
+    fn sniff_crlf_line_ending() {
+        // Windows-style CRLF — \r is not a candidate, so it's harmless;
+        // sniff should still correctly detect the pipe on the first line.
+        let sample = b"a|b|c\r\n1,2,3\n";
+        assert_eq!(sniff_delimiter(sample), b'|');
+    }
+
+    #[test]
     fn sniff_then_read_round_trip() {
         let data = b"x|y|z\n1|2|3\n";
         let delim = sniff_delimiter(data);

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -143,6 +143,7 @@ pub enum Action {
     },
     ReselectLastVisual,
     SetDelimiter(u8),
+    SetStatus(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -142,7 +142,6 @@ pub enum Action {
         backward: bool,
     },
     ReselectLastVisual,
-    #[allow(dead_code)]
     SetDelimiter(u8),
 }
 

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -142,6 +142,8 @@ pub enum Action {
         backward: bool,
     },
     ReselectLastVisual,
+    #[allow(dead_code)]
+    SetDelimiter(u8),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -40,6 +40,7 @@ pub struct App {
     pub dirty: bool,
     pub should_quit: bool,
     pub insert_buffer: String,
+    pub delimiter: u8,
     pub help_scroll: usize,
     pub help_topic: Option<String>,
     pub help_registry: HelpRegistry,
@@ -79,6 +80,7 @@ impl App {
             dirty: false,
             should_quit: false,
             insert_buffer: String::new(),
+            delimiter: b',',
             help_scroll: 0,
             help_topic: None,
             help_registry: HelpRegistry::new(),
@@ -608,6 +610,7 @@ impl App {
                     self.mode = Mode::Help;
                 }
             },
+<<<<<<< HEAD
             Action::ScrollCursorTop => {
                 self.viewport.top_on(self.cursor.0);
             }
@@ -710,6 +713,10 @@ impl App {
                 } else {
                     self.status_message = Some("No string under cursor".into());
                 }
+            }
+            Action::SetDelimiter(d) => {
+                self.delimiter = d;
+                self.status_message = Some(format!("Delimiter set to '{}'", d as char));
             }
             Action::Open(_) | Action::Resize => {}
         }
@@ -2036,6 +2043,22 @@ mod tests {
             app.status_message.as_deref(),
             Some("No string under cursor")
         );
+    }
+
+    #[test]
+    fn set_delimiter_updates_field_and_status() {
+        let mut app = App::new();
+        assert_eq!(app.delimiter, b',', "default delimiter should be comma");
+        app.process_action(Action::SetDelimiter(b'|'));
+        assert_eq!(app.delimiter, b'|');
+        assert_eq!(app.status_message.as_deref(), Some("Delimiter set to '|'"));
+    }
+
+    #[test]
+    fn set_delimiter_tab() {
+        let mut app = App::new();
+        app.process_action(Action::SetDelimiter(b'\t'));
+        assert_eq!(app.delimiter, b'\t');
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -624,7 +624,6 @@ impl App {
                     self.mode = Mode::Help;
                 }
             },
-<<<<<<< HEAD
             Action::ScrollCursorTop => {
                 self.viewport.top_on(self.cursor.0);
             }
@@ -731,6 +730,9 @@ impl App {
             Action::SetDelimiter(d) => {
                 self.delimiter = d;
                 self.status_message = Some(format!("Delimiter set to '{}'", d as char));
+            }
+            Action::SetStatus(msg) => {
+                self.status_message = Some(msg);
             }
             Action::Open(_) | Action::Resize => {}
         }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -320,6 +320,8 @@ impl App {
                 }
             }
             Action::ForceSave(path_opt) => {
+                // ForceSave intentionally bypasses both the formula-flatten warning and the
+                // non-standard-delimiter warning. The user has explicitly opted in via :w!
                 let path = path_opt.or(self.file_path.clone());
                 if let Some(path) = path {
                     let format = Self::format_from_path(&path);
@@ -2097,7 +2099,6 @@ mod tests {
         // Use a non-existent path so the actual write would fail, but the delimiter
         // warning must fire *before* the write attempt.
         app.file_path = Some(std::path::PathBuf::from("data.csv"));
-        app.file_format = FileFormat::Csv;
         app.delimiter = b'|';
         app.process_action(Action::Save(None));
         let msg = app.status_message.as_deref().unwrap_or("");
@@ -2111,7 +2112,6 @@ mod tests {
     fn save_tsv_with_non_tab_delimiter_warns() {
         let mut app = App::new();
         app.file_path = Some(std::path::PathBuf::from("data.tsv"));
-        app.file_format = FileFormat::Tsv;
         app.delimiter = b'|';
         app.process_action(Action::Save(None));
         let msg = app.status_message.as_deref().unwrap_or("");
@@ -2128,7 +2128,6 @@ mod tests {
         // The write may fail for other reasons (path doesn't exist), but the
         // error message should NOT contain "Non-standard delimiter".
         app.file_path = Some(std::path::PathBuf::from("data.csv"));
-        app.file_format = FileFormat::Csv;
         app.delimiter = b',';
         app.process_action(Action::Save(None));
         let msg = app.status_message.as_deref().unwrap_or("");
@@ -2142,7 +2141,6 @@ mod tests {
     fn force_save_csv_with_non_comma_delimiter_skips_warning() {
         let mut app = App::new();
         app.file_path = Some(std::path::PathBuf::from("data.csv"));
-        app.file_format = FileFormat::Csv;
         app.delimiter = b'|';
         // ForceSave must NOT produce the delimiter warning.
         // (The write may produce an I/O error if the path can't be written, which is fine.)

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -302,6 +302,18 @@ impl App {
                         );
                         return;
                     }
+                    let expected_delim = match format {
+                        FileFormat::Csv => b',',
+                        FileFormat::Tsv => b'\t',
+                        FileFormat::Cell => 0,
+                    };
+                    if !matches!(format, FileFormat::Cell) && self.delimiter != expected_delim {
+                        self.status_message = Some(format!(
+                            "Non-standard delimiter '{}' will be used. Use :w! to force, or save as .tsv / .psv.",
+                            self.delimiter as char
+                        ));
+                        return;
+                    }
                     self.do_save(&path, format);
                 } else {
                     self.status_message = Some("No file name".into());
@@ -737,13 +749,11 @@ impl App {
     }
 
     fn do_save(&mut self, path: &PathBuf, format: FileFormat) {
+        let delimiter = self.delimiter;
         let result = match format {
-            FileFormat::Csv => std::fs::File::create(path)
+            FileFormat::Csv | FileFormat::Tsv => std::fs::File::create(path)
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-                .and_then(|f| cell_sheet_core::io::csv::write_csv(&self.sheet, f, b',')),
-            FileFormat::Tsv => std::fs::File::create(path)
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-                .and_then(|f| cell_sheet_core::io::csv::write_csv(&self.sheet, f, b'\t')),
+                .and_then(|f| cell_sheet_core::io::csv::write_csv(&self.sheet, f, delimiter)),
             FileFormat::Cell => std::fs::File::create(path)
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
                 .and_then(|f| cell_sheet_core::io::cell_format::write_cell_format(&self.sheet, f)),
@@ -2077,5 +2087,70 @@ mod tests {
         // Formula should re-evaluate after restoration.
         let val = app.sheet.get_cell((0, 1)).map(|c| c.value.to_string());
         assert_eq!(val.as_deref(), Some("20"));
+    }
+
+    // ── Delimiter save warnings ──────────────────────────────────────────────
+
+    #[test]
+    fn save_csv_with_non_comma_delimiter_warns() {
+        let mut app = App::new();
+        // Use a non-existent path so the actual write would fail, but the delimiter
+        // warning must fire *before* the write attempt.
+        app.file_path = Some(std::path::PathBuf::from("data.csv"));
+        app.file_format = FileFormat::Csv;
+        app.delimiter = b'|';
+        app.process_action(Action::Save(None));
+        let msg = app.status_message.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("Non-standard delimiter"),
+            "expected delimiter warning, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn save_tsv_with_non_tab_delimiter_warns() {
+        let mut app = App::new();
+        app.file_path = Some(std::path::PathBuf::from("data.tsv"));
+        app.file_format = FileFormat::Tsv;
+        app.delimiter = b'|';
+        app.process_action(Action::Save(None));
+        let msg = app.status_message.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("Non-standard delimiter"),
+            "expected delimiter warning, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn save_csv_with_comma_delimiter_no_delimiter_warning() {
+        let mut app = App::new();
+        // delimiter is b',' (default) — no delimiter warning should fire.
+        // The write may fail for other reasons (path doesn't exist), but the
+        // error message should NOT contain "Non-standard delimiter".
+        app.file_path = Some(std::path::PathBuf::from("data.csv"));
+        app.file_format = FileFormat::Csv;
+        app.delimiter = b',';
+        app.process_action(Action::Save(None));
+        let msg = app.status_message.as_deref().unwrap_or("");
+        assert!(
+            !msg.contains("Non-standard delimiter"),
+            "unexpected delimiter warning: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn force_save_csv_with_non_comma_delimiter_skips_warning() {
+        let mut app = App::new();
+        app.file_path = Some(std::path::PathBuf::from("data.csv"));
+        app.file_format = FileFormat::Csv;
+        app.delimiter = b'|';
+        // ForceSave must NOT produce the delimiter warning.
+        // (The write may produce an I/O error if the path can't be written, which is fine.)
+        app.process_action(Action::ForceSave(None));
+        let msg = app.status_message.as_deref().unwrap_or("");
+        assert!(
+            !msg.contains("Non-standard delimiter"),
+            "ForceSave should bypass delimiter warning, got: {msg:?}"
+        );
     }
 }

--- a/crates/cell-sheet-tui/src/headless.rs
+++ b/crates/cell-sheet-tui/src/headless.rs
@@ -123,11 +123,7 @@ fn load(
     delimiter: u8,
 ) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
     let mut sheet = match format {
-        Format::Csv => {
-            let data = std::fs::read(path)?;
-            csv_io::read_csv(data.as_slice(), delimiter)?
-        }
-        Format::Tsv => {
+        Format::Csv | Format::Tsv => {
             let file = std::fs::File::open(path)?;
             csv_io::read_csv(file, delimiter)?
         }

--- a/crates/cell-sheet-tui/src/headless.rs
+++ b/crates/cell-sheet-tui/src/headless.rs
@@ -44,6 +44,7 @@ pub struct Options {
     pub reads: Vec<String>,
     pub evals: Vec<String>,
     pub writes: Vec<(String, String)>,
+    pub delimiter: Option<u8>,
 }
 
 impl Options {
@@ -52,12 +53,36 @@ impl Options {
     }
 }
 
+fn resolve_delimiter(
+    path: &Path,
+    format: Format,
+    explicit: Option<u8>,
+) -> Result<u8, Box<dyn std::error::Error>> {
+    if let Some(d) = explicit {
+        return Ok(d);
+    }
+    match format {
+        Format::Tsv => Ok(b'\t'),
+        Format::Cell => Ok(b','), // unused — .cell files don't use a delimiter
+        Format::Csv => {
+            use std::io::Read as _;
+            let mut buf = vec![0u8; 4096];
+            let mut file = std::fs::File::open(path)?;
+            let n = file.read(&mut buf)?;
+            Ok(csv_io::sniff_delimiter(&buf[..n]))
+        }
+    }
+}
+
 /// Run the requested headless operations and write their textual results to
 /// `out`. Errors are returned with a human-readable message; callers are
 /// responsible for emitting them to stderr and choosing an exit code.
 pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
     let format = Format::from_path(&opts.file);
-    let (mut sheet, mut deps) = load(&opts.file, format)
+    let delimiter = resolve_delimiter(&opts.file, format, opts.delimiter)
+        .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
+
+    let (mut sheet, mut deps) = load(&opts.file, format, delimiter)
         .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
 
     if !opts.writes.is_empty() {
@@ -71,7 +96,7 @@ pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
             apply_write(&mut sheet, &mut deps, pos, value);
         }
         recalculate(&mut sheet, &deps);
-        save(&opts.file, format, &sheet)
+        save(&opts.file, format, &sheet, delimiter)
             .map_err(|e| format!("failed to write {}: {e}", opts.file.display()))?;
     }
 
@@ -92,12 +117,24 @@ pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
     Ok(())
 }
 
-fn load(path: &Path, format: Format) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
-    let file = std::fs::File::open(path)?;
+fn load(
+    path: &Path,
+    format: Format,
+    delimiter: u8,
+) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
     let mut sheet = match format {
-        Format::Csv => csv_io::read_csv(file, b',')?,
-        Format::Tsv => csv_io::read_csv(file, b'\t')?,
-        Format::Cell => cell_format::read_cell_format(file)?,
+        Format::Csv => {
+            let data = std::fs::read(path)?;
+            csv_io::read_csv(data.as_slice(), delimiter)?
+        }
+        Format::Tsv => {
+            let file = std::fs::File::open(path)?;
+            csv_io::read_csv(file, delimiter)?
+        }
+        Format::Cell => {
+            let file = std::fs::File::open(path)?;
+            cell_format::read_cell_format(file)?
+        }
     };
     let mut deps = DepGraph::new();
 
@@ -115,11 +152,15 @@ fn load(path: &Path, format: Format) -> Result<(Sheet, DepGraph), Box<dyn std::e
     Ok((sheet, deps))
 }
 
-fn save(path: &Path, format: Format, sheet: &Sheet) -> Result<(), Box<dyn std::error::Error>> {
+fn save(
+    path: &Path,
+    format: Format,
+    sheet: &Sheet,
+    delimiter: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
     let file = std::fs::File::create(path)?;
     match format {
-        Format::Csv => csv_io::write_csv(sheet, file, b',')?,
-        Format::Tsv => csv_io::write_csv(sheet, file, b'\t')?,
+        Format::Csv | Format::Tsv => csv_io::write_csv(sheet, file, delimiter)?,
         Format::Cell => cell_format::write_cell_format(sheet, file)?,
     }
     Ok(())

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -40,10 +40,36 @@ struct Cli {
     /// Repeat to batch multiple writes into a single save.
     #[arg(long, value_names = ["REF", "VALUE"], num_args = 2)]
     write: Vec<String>,
+
+    /// Field delimiter character (e.g. '|', ';'). Auto-detected from file
+    /// content when omitted; .tsv files always default to tab.
+    #[arg(long, value_name = "CHAR")]
+    delimiter: Option<char>,
+}
+
+fn parse_delimiter(c: char) -> Result<u8, String> {
+    if !c.is_ascii() {
+        return Err(format!(
+            "delimiter must be a single ASCII character, got {c:?}"
+        ));
+    }
+    if c.is_alphanumeric() || c == '"' || c == '\n' || c == '\r' {
+        return Err(format!("'{c}' is not a valid field delimiter"));
+    }
+    Ok(c as u8)
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+
+    let explicit_delimiter = match cli.delimiter.map(parse_delimiter) {
+        Some(Err(msg)) => {
+            eprintln!("error: {msg}");
+            return ExitCode::from(2);
+        }
+        Some(Ok(b)) => Some(b),
+        None => None,
+    };
 
     let opts = headless::Options {
         file: cli.file.clone().unwrap_or_default(),
@@ -54,6 +80,7 @@ fn main() -> ExitCode {
             .chunks_exact(2)
             .map(|c| (c[0].clone(), c[1].clone()))
             .collect(),
+        delimiter: explicit_delimiter,
     };
 
     if opts.is_active() {
@@ -71,7 +98,7 @@ fn main() -> ExitCode {
         };
     }
 
-    match run_tui(cli.file.as_deref()) {
+    match run_tui(cli.file.as_deref(), explicit_delimiter) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("error: {e}");
@@ -80,11 +107,14 @@ fn main() -> ExitCode {
     }
 }
 
-fn run_tui(file: Option<&std::path::Path>) -> Result<(), Box<dyn std::error::Error>> {
+fn run_tui(
+    file: Option<&std::path::Path>,
+    explicit_delimiter: Option<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut app = App::new();
 
     if let Some(path) = file {
-        load_file(&mut app, path)?;
+        load_file(&mut app, path, explicit_delimiter)?;
     }
 
     enable_raw_mode()?;
@@ -101,7 +131,11 @@ fn run_tui(file: Option<&std::path::Path>) -> Result<(), Box<dyn std::error::Err
     result
 }
 
-fn load_file(app: &mut App, path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+fn load_file(
+    app: &mut App,
+    path: &std::path::Path,
+    explicit_delimiter: Option<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
     use cell_sheet_core::formula::deps::{recalculate, set_formula};
 
     let ext = path
@@ -109,31 +143,36 @@ fn load_file(app: &mut App, path: &std::path::Path) -> Result<(), Box<dyn std::e
         .and_then(|e| e.to_str())
         .unwrap_or("")
         .to_lowercase();
+
     match ext.as_str() {
-        "csv" => {
-            let file = std::fs::File::open(path)?;
-            app.sheet = cell_sheet_core::io::csv::read_csv(file, b',')?;
-            app.file_format = FileFormat::Csv;
-        }
-        "tsv" => {
-            let file = std::fs::File::open(path)?;
-            app.sheet = cell_sheet_core::io::csv::read_csv(file, b'\t')?;
-            app.file_format = FileFormat::Tsv;
-        }
         "cell" => {
             let file = std::fs::File::open(path)?;
             app.sheet = cell_sheet_core::io::cell_format::read_cell_format(file)?;
             app.file_format = FileFormat::Cell;
         }
         _ => {
-            let file = std::fs::File::open(path)?;
-            app.sheet = cell_sheet_core::io::csv::read_csv(file, b',')?;
-            app.file_format = FileFormat::Csv;
+            // Read entire file once; use the same bytes for sniffing and parsing.
+            let data = std::fs::read(path)?;
+            let delimiter = if let Some(d) = explicit_delimiter {
+                d
+            } else if ext == "tsv" {
+                b'\t'
+            } else {
+                cell_sheet_core::io::csv::sniff_delimiter(&data)
+            };
+            app.sheet = cell_sheet_core::io::csv::read_csv(data.as_slice(), delimiter)?;
+            app.file_format = if ext == "tsv" {
+                FileFormat::Tsv
+            } else {
+                FileFormat::Csv
+            };
+            app.delimiter = delimiter;
         }
     }
+
     app.file_path = Some(path.to_path_buf());
 
-    // Register formulas in the dependency graph and evaluate them
+    // Register formulas in the dependency graph and evaluate them.
     let formula_cells: Vec<_> = app
         .sheet
         .cells

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -53,7 +53,10 @@ fn parse_delimiter(c: char) -> Result<u8, String> {
             "delimiter must be a single ASCII character, got {c:?}"
         ));
     }
-    if c.is_alphanumeric() || c == '"' || c == '\n' || c == '\r' {
+    // Reject control characters (< 0x20 except tab), space, and double-quote
+    // (reserved as the CSV quoting character). Tab is allowed: it is the
+    // standard TSV delimiter.
+    if c.is_alphanumeric() || c == '"' || c == ' ' || ((c as u8) < 0x20 && c != '\t') {
         return Err(format!("'{c}' is not a valid field delimiter"));
     }
     Ok(c as u8)

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -38,7 +38,9 @@ pub fn parse_command(input: &str) -> Action {
             {
                 Action::SetDelimiter(c as u8)
             }
-            _ => Action::Noop,
+            _ => Action::SetStatus(
+                "Invalid delimiter: must be a single non-alphanumeric ASCII character (not \", \\n, \\r).".into()
+            ),
         };
     }
 
@@ -215,24 +217,39 @@ mod tests {
     }
 
     #[test]
-    fn parse_set_delimiter_empty_is_noop() {
-        assert_eq!(parse_command("set delimiter="), Action::Noop);
+    fn parse_set_delimiter_empty_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter="),
+            Action::SetStatus(_)
+        ));
     }
 
     #[test]
-    fn parse_set_delimiter_alphanumeric_is_noop() {
-        assert_eq!(parse_command("set delimiter=a"), Action::Noop);
-        assert_eq!(parse_command("set delimiter=1"), Action::Noop);
+    fn parse_set_delimiter_alphanumeric_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter=a"),
+            Action::SetStatus(_)
+        ));
+        assert!(matches!(
+            parse_command("set delimiter=1"),
+            Action::SetStatus(_)
+        ));
     }
 
     #[test]
-    fn parse_set_delimiter_multi_char_is_noop() {
-        assert_eq!(parse_command("set delimiter=||"), Action::Noop);
+    fn parse_set_delimiter_multi_char_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter=||"),
+            Action::SetStatus(_)
+        ));
     }
 
     #[test]
-    fn parse_set_delimiter_non_ascii_is_noop() {
-        assert_eq!(parse_command("set delimiter=€"), Action::Noop);
+    fn parse_set_delimiter_non_ascii_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter=€"),
+            Action::SetStatus(_)
+        ));
     }
 
     #[test]
@@ -243,9 +260,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_set_delimiter_quote_is_noop() {
-        // Double-quote must be rejected — it is the CSV quoting character
-        assert_eq!(parse_command("set delimiter=\""), Action::Noop);
+    fn parse_set_delimiter_quote_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter=\""),
+            Action::SetStatus(_)
+        ));
     }
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -27,6 +27,24 @@ fn parse_search(input: &str, direction: SearchDirection) -> Action {
 
 pub fn parse_command(input: &str) -> Action {
     let input = input.trim_start();
+
+    // Handle before trimming the end: the delimiter character may itself be
+    // whitespace (e.g. Tab), so trim_end() must not run before this check.
+    if let Some(stripped) = input.strip_prefix("set delimiter=") {
+        let mut chars = stripped.chars();
+        return match (chars.next(), chars.next()) {
+            (Some(c), None)
+                if c.is_ascii() && !c.is_alphanumeric() && c != '"' && c != '\n' && c != '\r' =>
+            {
+                Action::SetDelimiter(c as u8)
+            }
+            _ => Action::Noop,
+        };
+    }
+
+    // For all other commands, trailing whitespace is ignored (Vim behaviour).
+    let input = input.trim_end();
+
     if input == "q" {
         Action::Quit { force: false }
     } else if input == "q!" {
@@ -54,14 +72,6 @@ pub fn parse_command(input: &str) -> Action {
             Action::ShowHelp(None)
         } else {
             Action::ShowHelp(Some(topic.to_string()))
-        }
-    } else if let Some(stripped) = input.strip_prefix("set delimiter=") {
-        let mut chars = stripped.chars();
-        match (chars.next(), chars.next()) {
-            (Some(c), None) if c.is_ascii() && !c.is_alphanumeric() => {
-                Action::SetDelimiter(c as u8)
-            }
-            _ => Action::Noop,
         }
     } else {
         Action::Noop
@@ -223,6 +233,19 @@ mod tests {
     #[test]
     fn parse_set_delimiter_non_ascii_is_noop() {
         assert_eq!(parse_command("set delimiter=€"), Action::Noop);
+    }
+
+    #[test]
+    fn parse_quit_with_trailing_space() {
+        // Trailing whitespace must be tolerated (Vim behaviour)
+        assert_eq!(parse_command("q "), Action::Quit { force: false });
+        assert_eq!(parse_command("wq "), Action::Save(None));
+    }
+
+    #[test]
+    fn parse_set_delimiter_quote_is_noop() {
+        // Double-quote must be rejected — it is the CSV quoting character
+        assert_eq!(parse_command("set delimiter=\""), Action::Noop);
     }
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -33,8 +33,14 @@ pub fn parse_command(input: &str) -> Action {
     if let Some(stripped) = input.strip_prefix("set delimiter=") {
         let mut chars = stripped.chars();
         return match (chars.next(), chars.next()) {
+            // Tab (0x09) is the standard TSV delimiter and is explicitly
+            // allowed even though it is a control character (< 0x20).
             (Some(c), None)
-                if c.is_ascii() && !c.is_alphanumeric() && c != '"' && c != '\n' && c != '\r' =>
+                if c.is_ascii()
+                    && !c.is_alphanumeric()
+                    && c != '"'
+                    && c != ' '
+                    && ((c as u8) >= 0x20 || c == '\t') =>
             {
                 Action::SetDelimiter(c as u8)
             }
@@ -263,6 +269,22 @@ mod tests {
     fn parse_set_delimiter_quote_is_error() {
         assert!(matches!(
             parse_command("set delimiter=\""),
+            Action::SetStatus(_)
+        ));
+    }
+
+    #[test]
+    fn parse_set_delimiter_space_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter= "),
+            Action::SetStatus(_)
+        ));
+    }
+
+    #[test]
+    fn parse_set_delimiter_nul_is_error() {
+        assert!(matches!(
+            parse_command("set delimiter=\0"),
             Action::SetStatus(_)
         ));
     }

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -26,7 +26,7 @@ fn parse_search(input: &str, direction: SearchDirection) -> Action {
 }
 
 pub fn parse_command(input: &str) -> Action {
-    let input = input.trim();
+    let input = input.trim_start();
     if input == "q" {
         Action::Quit { force: false }
     } else if input == "q!" {
@@ -54,6 +54,14 @@ pub fn parse_command(input: &str) -> Action {
             Action::ShowHelp(None)
         } else {
             Action::ShowHelp(Some(topic.to_string()))
+        }
+    } else if let Some(stripped) = input.strip_prefix("set delimiter=") {
+        let mut chars = stripped.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) if c.is_ascii() && !c.is_alphanumeric() => {
+                Action::SetDelimiter(c as u8)
+            }
+            _ => Action::Noop,
         }
     } else {
         Action::Noop
@@ -176,6 +184,45 @@ mod tests {
             parse_command("help :w"),
             Action::ShowHelp(Some(":w".into()))
         );
+    }
+
+    #[test]
+    fn parse_set_delimiter_pipe() {
+        assert_eq!(parse_command("set delimiter=|"), Action::SetDelimiter(b'|'));
+    }
+
+    #[test]
+    fn parse_set_delimiter_semicolon() {
+        assert_eq!(parse_command("set delimiter=;"), Action::SetDelimiter(b';'));
+    }
+
+    #[test]
+    fn parse_set_delimiter_tab() {
+        assert_eq!(
+            parse_command("set delimiter=\t"),
+            Action::SetDelimiter(b'\t')
+        );
+    }
+
+    #[test]
+    fn parse_set_delimiter_empty_is_noop() {
+        assert_eq!(parse_command("set delimiter="), Action::Noop);
+    }
+
+    #[test]
+    fn parse_set_delimiter_alphanumeric_is_noop() {
+        assert_eq!(parse_command("set delimiter=a"), Action::Noop);
+        assert_eq!(parse_command("set delimiter=1"), Action::Noop);
+    }
+
+    #[test]
+    fn parse_set_delimiter_multi_char_is_noop() {
+        assert_eq!(parse_command("set delimiter=||"), Action::Noop);
+    }
+
+    #[test]
+    fn parse_set_delimiter_non_ascii_is_noop() {
+        assert_eq!(parse_command("set delimiter=€"), Action::Noop);
     }
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/crates/cell-sheet-tui/tests/headless.rs
+++ b/crates/cell-sheet-tui/tests/headless.rs
@@ -280,3 +280,13 @@ fn invalid_delimiter_exits_with_code_2() {
     assert_eq!(out.status.code(), Some(2));
     assert!(!stderr(&out).is_empty());
 }
+
+#[test]
+fn read_tsv_without_delimiter_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.tsv", "a\tb\tc\n10\t20\t30\n");
+
+    let out = run(&[path.to_str().unwrap(), "--read", "C2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "30\n");
+}

--- a/crates/cell-sheet-tui/tests/headless.rs
+++ b/crates/cell-sheet-tui/tests/headless.rs
@@ -218,3 +218,65 @@ fn missing_file_exits_nonzero() {
     assert!(!out.status.success());
     assert!(!stderr(&out).is_empty());
 }
+
+#[test]
+fn read_pipe_delimited_with_delimiter_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.psv", "a|b|c\n1|2|3\n");
+
+    let out = run(&[path.to_str().unwrap(), "--delimiter", "|", "--read", "B2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "2\n");
+}
+
+#[test]
+fn read_pipe_delimited_auto_sniff_csv_extension() {
+    // .csv extension but pipe-separated content — sniff should detect the pipe
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "a|b|c\n1|2|3\n");
+
+    let out = run(&[path.to_str().unwrap(), "--read", "B2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "2\n");
+}
+
+#[test]
+fn read_semicolon_delimited_with_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "a;b;c\n10;20;30\n");
+
+    let out = run(&[path.to_str().unwrap(), "--delimiter", ";", "--read", "C2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "30\n");
+}
+
+#[test]
+fn write_pipe_delimited_with_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.psv", "a|b\n1|2\n");
+
+    // Write a new value and check the file stays pipe-delimited
+    let out = run(&[
+        path.to_str().unwrap(),
+        "--delimiter",
+        "|",
+        "--write",
+        "A1",
+        "99",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert!(after.starts_with("99|b\n"), "got: {after:?}");
+}
+
+#[test]
+fn invalid_delimiter_exits_with_code_2() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "a,b\n");
+
+    // Alphanumeric delimiter is not valid
+    let out = run(&[path.to_str().unwrap(), "--delimiter", "a", "--read", "A1"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(!stderr(&out).is_empty());
+}

--- a/docs/superpowers/plans/2026-04-27-custom-csv-delimiter.md
+++ b/docs/superpowers/plans/2026-04-27-custom-csv-delimiter.md
@@ -1,0 +1,1050 @@
+# Custom CSV Delimiter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users open, edit, and save delimiter-separated files using any single-byte ASCII delimiter (pipe, semicolon, etc.) via a CLI flag, auto-sniff, and a `:set delimiter=X` ex-command.
+
+**Architecture:** Add a `delimiter: u8` field to `App` (default `b','`) that is resolved from the CLI flag, auto-sniff, or `:set delimiter=X` and is used by `do_save` for all CSV/TSV writes. A `sniff_delimiter` utility in `cell-sheet-core` reads the first line to pick the most frequent candidate delimiter. A save warning fires when the delimiter doesn't match the file extension's convention (mirrors the existing formula-flatten warning).
+
+**Tech Stack:** Rust, `csv` crate (already used), `clap` (already used), `tempfile` (already a dev-dependency).
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `crates/cell-sheet-core/src/io/csv.rs` | Add `pub fn sniff_delimiter(sample: &[u8]) -> u8`; add non-standard-delimiter round-trip tests |
+| `crates/cell-sheet-tui/src/action.rs` | Add `SetDelimiter(u8)` variant |
+| `crates/cell-sheet-tui/src/app.rs` | Add `delimiter: u8` field; handle `SetDelimiter`; update `Action::Save` warning; update `do_save` |
+| `crates/cell-sheet-tui/src/mode/command.rs` | Parse `:set delimiter=X` |
+| `crates/cell-sheet-tui/src/main.rs` | Add `--delimiter` CLI flag; `parse_delimiter` validator; pass delimiter to `load_file` and `run_tui` |
+| `crates/cell-sheet-tui/src/headless.rs` | Add `delimiter: Option<u8>` to `Options`; `resolve_delimiter`; pass delimiter through `load`/`save` |
+| `crates/cell-sheet-tui/tests/headless.rs` | Integration tests for `--delimiter` and auto-sniff |
+| `CHANGELOG.md` | Entry under `## Unreleased → Added` |
+
+---
+
+## Task 1: `sniff_delimiter` in `cell-sheet-core`
+
+**Files:**
+- Modify: `crates/cell-sheet-core/src/io/csv.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add inside the existing `#[cfg(test)] mod tests` block at the bottom of `crates/cell-sheet-core/src/io/csv.rs`:
+
+```rust
+#[test]
+fn sniff_pipe_delimiter() {
+    let sample = b"name|score|grade\nalice|95|A\n";
+    assert_eq!(sniff_delimiter(sample), b'|');
+}
+
+#[test]
+fn sniff_semicolon_delimiter() {
+    let sample = b"a;b;c\n1;2;3\n";
+    assert_eq!(sniff_delimiter(sample), b';');
+}
+
+#[test]
+fn sniff_tab_delimiter() {
+    let sample = b"a\tb\tc\n1\t2\t3\n";
+    assert_eq!(sniff_delimiter(sample), b'\t');
+}
+
+#[test]
+fn sniff_empty_defaults_to_comma() {
+    assert_eq!(sniff_delimiter(b""), b',');
+}
+
+#[test]
+fn sniff_tie_prefers_comma() {
+    // one comma, one pipe — comma wins ties
+    assert_eq!(sniff_delimiter(b"a,b|c\n"), b',');
+}
+
+#[test]
+fn sniff_only_reads_first_line() {
+    // First line has pipes; second line has many commas — sniff ignores line 2
+    let sample = b"a|b|c\n1,2,3,4,5,6,7,8,9\n";
+    assert_eq!(sniff_delimiter(sample), b'|');
+}
+
+#[test]
+fn read_pipe_delimited() {
+    let data = "a|b|c\n1|2|3\n";
+    let sheet = read_csv(data.as_bytes(), b'|').unwrap();
+    assert_eq!(sheet.row_count, 2);
+    assert_eq!(sheet.col_count, 3);
+    assert_eq!(
+        sheet.get_cell((0, 1)).unwrap().value,
+        CellValue::Text("b".into())
+    );
+    assert_eq!(
+        sheet.get_cell((1, 2)).unwrap().value,
+        CellValue::Number(3.0)
+    );
+}
+
+#[test]
+fn write_pipe_delimited() {
+    let mut sheet = Sheet::new();
+    sheet.set_cell((0, 0), "a");
+    sheet.set_cell((0, 1), "b");
+    let mut buf = Vec::new();
+    write_csv(&sheet, &mut buf, b'|').unwrap();
+    assert_eq!(String::from_utf8(buf).unwrap(), "a|b\n");
+}
+
+#[test]
+fn sniff_then_read_round_trip() {
+    let data = b"x|y|z\n1|2|3\n";
+    let delim = sniff_delimiter(data);
+    assert_eq!(delim, b'|');
+    let sheet = read_csv(data.as_ref(), delim).unwrap();
+    assert_eq!(sheet.col_count, 3);
+    assert_eq!(
+        sheet.get_cell((1, 1)).unwrap().value,
+        CellValue::Number(2.0)
+    );
+}
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+cargo test -p cell-sheet-core -- sniff 2>&1 | head -20
+```
+
+Expected: errors like `cannot find function sniff_delimiter`.
+
+- [ ] **Step 3: Implement `sniff_delimiter`**
+
+Add this function **before** `read_csv` in `crates/cell-sheet-core/src/io/csv.rs`:
+
+```rust
+/// Inspect the first line of `sample` (up to 4 KiB) and return the most
+/// frequent delimiter among `,`, `\t`, `|`, `;`. Ties are broken in that
+/// order (comma wins ties). Returns `b','` for empty input.
+pub fn sniff_delimiter(sample: &[u8]) -> u8 {
+    let line_end = sample
+        .iter()
+        .position(|&b| b == b'\n')
+        .unwrap_or(sample.len());
+    let line = &sample[..line_end.min(4096)];
+
+    // Iterate in preference order so the first candidate wins ties.
+    let candidates = [b',', b'\t', b'|', b';'];
+    let mut best_delim = b',';
+    let mut best_count = 0usize;
+    for &d in &candidates {
+        let count = line.iter().filter(|&&b| b == d).count();
+        if count > best_count {
+            best_count = count;
+            best_delim = d;
+        }
+    }
+    best_delim
+}
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+cargo test -p cell-sheet-core
+```
+
+Expected: all tests pass (including the nine new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cell-sheet-core/src/io/csv.rs
+git commit -m "feat: add sniff_delimiter and non-standard delimiter round-trip tests"
+```
+
+---
+
+## Task 2: `Action::SetDelimiter` and `App.delimiter`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Add inside the `#[cfg(test)] mod tests` block at the bottom of `crates/cell-sheet-tui/src/app.rs`:
+
+```rust
+#[test]
+fn set_delimiter_updates_field_and_status() {
+    let mut app = App::new();
+    assert_eq!(app.delimiter, b',', "default delimiter should be comma");
+    app.process_action(Action::SetDelimiter(b'|'));
+    assert_eq!(app.delimiter, b'|');
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Delimiter set to '|'")
+    );
+}
+
+#[test]
+fn set_delimiter_tab() {
+    let mut app = App::new();
+    app.process_action(Action::SetDelimiter(b'\t'));
+    assert_eq!(app.delimiter, b'\t');
+}
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+cargo test -p cell-sheet-tui -- set_delimiter 2>&1 | head -20
+```
+
+Expected: compile error — `SetDelimiter` not yet defined.
+
+- [ ] **Step 3: Add `SetDelimiter(u8)` to `Action`**
+
+In `crates/cell-sheet-tui/src/action.rs`, add after the `ShowHelp` line:
+
+```rust
+SetDelimiter(u8),
+```
+
+The full enum tail should look like:
+
+```rust
+    YankRow(usize),
+    ShowHelp(Option<String>),
+    SetDelimiter(u8),
+}
+```
+
+- [ ] **Step 4: Add `delimiter` field to `App`**
+
+In `crates/cell-sheet-tui/src/app.rs`, add to the `App` struct after `insert_buffer`:
+
+```rust
+pub delimiter: u8,
+```
+
+In `App::new()`, add after `insert_buffer: String::new(),`:
+
+```rust
+delimiter: b',',
+```
+
+- [ ] **Step 5: Handle `SetDelimiter` in `process_action`**
+
+In the `match action` block in `process_action`, add before the closing brace (before `Action::Open(_) | Action::Resize => {}`):
+
+```rust
+Action::SetDelimiter(d) => {
+    self.delimiter = d;
+    self.status_message = Some(format!("Delimiter set to '{}'", d as char));
+}
+```
+
+- [ ] **Step 6: Run tests and confirm they pass**
+
+```bash
+cargo test -p cell-sheet-tui
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cell-sheet-tui/src/action.rs crates/cell-sheet-tui/src/app.rs
+git commit -m "feat: add App.delimiter field and Action::SetDelimiter"
+```
+
+---
+
+## Task 3: `:set delimiter=X` command parsing
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/mode/command.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add inside the `#[cfg(test)] mod tests` block in `crates/cell-sheet-tui/src/mode/command.rs`:
+
+```rust
+#[test]
+fn parse_set_delimiter_pipe() {
+    assert_eq!(parse_command("set delimiter=|"), Action::SetDelimiter(b'|'));
+}
+
+#[test]
+fn parse_set_delimiter_semicolon() {
+    assert_eq!(parse_command("set delimiter=;"), Action::SetDelimiter(b';'));
+}
+
+#[test]
+fn parse_set_delimiter_tab() {
+    // Users can type :set delimiter=<Tab> — less likely but valid
+    assert_eq!(parse_command("set delimiter=\t"), Action::SetDelimiter(b'\t'));
+}
+
+#[test]
+fn parse_set_delimiter_empty_is_noop() {
+    assert_eq!(parse_command("set delimiter="), Action::Noop);
+}
+
+#[test]
+fn parse_set_delimiter_alphanumeric_is_noop() {
+    assert_eq!(parse_command("set delimiter=a"), Action::Noop);
+    assert_eq!(parse_command("set delimiter=1"), Action::Noop);
+}
+
+#[test]
+fn parse_set_delimiter_multi_char_is_noop() {
+    assert_eq!(parse_command("set delimiter=||"), Action::Noop);
+}
+
+#[test]
+fn parse_set_delimiter_non_ascii_is_noop() {
+    assert_eq!(parse_command("set delimiter=€"), Action::Noop);
+}
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+cargo test -p cell-sheet-tui -- parse_set_delimiter 2>&1 | head -20
+```
+
+Expected: tests fail because `parse_command("set delimiter=|")` currently returns `Action::Noop`.
+
+- [ ] **Step 3: Add parsing branch in `parse_command`**
+
+In `crates/cell-sheet-tui/src/mode/command.rs`, inside `parse_command`, add a new `else if` branch **before** the final `else { Action::Noop }`:
+
+```rust
+} else if let Some(stripped) = input.strip_prefix("set delimiter=") {
+    let mut chars = stripped.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) if c.is_ascii() && !c.is_alphanumeric() => {
+            Action::SetDelimiter(c as u8)
+        }
+        _ => Action::Noop,
+    }
+} else {
+    Action::Noop
+}
+```
+
+You also need to add the import at the top of the file (it should already be there since `Action` is imported, but make sure `SetDelimiter` is accessible through it):
+
+The existing `use crate::action::Action;` already covers this since `SetDelimiter` is a variant.
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+cargo test -p cell-sheet-tui -- command
+```
+
+Expected: all command tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cell-sheet-tui/src/mode/command.rs
+git commit -m "feat: parse :set delimiter=X ex-command"
+```
+
+---
+
+## Task 4: Save warning + `do_save` uses `self.delimiter`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `crates/cell-sheet-tui/src/app.rs`:
+
+```rust
+#[test]
+fn save_csv_with_non_comma_delimiter_warns() {
+    let mut app = App::new();
+    // No file_path — triggers "No file name". Set one.
+    // We deliberately choose a non-existent path so the actual write fails,
+    // but the delimiter warning must fire *before* the write attempt.
+    app.file_path = Some(std::path::PathBuf::from("data.csv"));
+    app.file_format = FileFormat::Csv;
+    app.delimiter = b'|';
+    app.process_action(Action::Save(None));
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        msg.contains("Non-standard delimiter"),
+        "expected delimiter warning, got: {msg:?}"
+    );
+}
+
+#[test]
+fn save_tsv_with_non_tab_delimiter_warns() {
+    let mut app = App::new();
+    app.file_path = Some(std::path::PathBuf::from("data.tsv"));
+    app.file_format = FileFormat::Tsv;
+    app.delimiter = b'|';
+    app.process_action(Action::Save(None));
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        msg.contains("Non-standard delimiter"),
+        "expected delimiter warning, got: {msg:?}"
+    );
+}
+
+#[test]
+fn save_csv_with_comma_delimiter_no_delimiter_warning() {
+    let mut app = App::new();
+    // delimiter is b',' (default) — no warning should fire.
+    // Using a path that would fail the write; the error message should NOT
+    // mention "Non-standard delimiter".
+    app.file_path = Some(std::path::PathBuf::from("data.csv"));
+    app.file_format = FileFormat::Csv;
+    app.delimiter = b',';
+    app.process_action(Action::Save(None));
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        !msg.contains("Non-standard delimiter"),
+        "unexpected delimiter warning: {msg:?}"
+    );
+}
+
+#[test]
+fn force_save_csv_with_non_comma_delimiter_skips_warning() {
+    let mut app = App::new();
+    app.file_path = Some(std::path::PathBuf::from("data.csv"));
+    app.file_format = FileFormat::Csv;
+    app.delimiter = b'|';
+    // ForceSave must not produce the delimiter warning.
+    // (It may produce an I/O error since the path may not be writable, which is fine.)
+    app.process_action(Action::ForceSave(None));
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        !msg.contains("Non-standard delimiter"),
+        "ForceSave should bypass delimiter warning, got: {msg:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+cargo test -p cell-sheet-tui -- save_csv_with_non_comma 2>&1 | head -30
+```
+
+Expected: tests fail — no warning fires yet.
+
+- [ ] **Step 3: Add delimiter warning in `Action::Save`**
+
+In `crates/cell-sheet-tui/src/app.rs`, inside `process_action`, find the `Action::Save(path_opt)` arm. After the existing formula warning block and **before** the `self.do_save(...)` call, insert:
+
+```rust
+// Warn when the active delimiter doesn't match the file extension's convention.
+let expected_delim = match format {
+    FileFormat::Csv => b',',
+    FileFormat::Tsv => b'\t',
+    FileFormat::Cell => 0, // irrelevant — guarded by the match below
+};
+if !matches!(format, FileFormat::Cell) && self.delimiter != expected_delim {
+    self.status_message = Some(format!(
+        "Non-standard delimiter '{}' will be used. Use :w! to force, or save as .tsv / .psv.",
+        self.delimiter as char
+    ));
+    return;
+}
+```
+
+The updated `Action::Save` arm should look like:
+
+```rust
+Action::Save(path_opt) => {
+    let path = path_opt.or(self.file_path.clone());
+    if let Some(path) = path {
+        let format = Self::format_from_path(&path);
+        if !matches!(format, FileFormat::Cell) && self.has_formulas() {
+            self.status_message = Some(
+                "Sheet contains formulas that will be lost. Use :w file.cell to preserve, or :w! to save as CSV anyway.".into()
+            );
+            return;
+        }
+        let expected_delim = match format {
+            FileFormat::Csv => b',',
+            FileFormat::Tsv => b'\t',
+            FileFormat::Cell => 0,
+        };
+        if !matches!(format, FileFormat::Cell) && self.delimiter != expected_delim {
+            self.status_message = Some(format!(
+                "Non-standard delimiter '{}' will be used. Use :w! to force, or save as .tsv / .psv.",
+                self.delimiter as char
+            ));
+            return;
+        }
+        self.do_save(&path, format);
+    } else {
+        self.status_message = Some("No file name".into());
+    }
+}
+```
+
+- [ ] **Step 4: Update `do_save` to use `self.delimiter`**
+
+Find `fn do_save` in `crates/cell-sheet-tui/src/app.rs`. Replace the hardcoded `b','` and `b'\t'` with `self.delimiter`:
+
+```rust
+fn do_save(&mut self, path: &PathBuf, format: FileFormat) {
+    let delimiter = self.delimiter;
+    let result = match format {
+        FileFormat::Csv | FileFormat::Tsv => std::fs::File::create(path)
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+            .and_then(|f| cell_sheet_core::io::csv::write_csv(&self.sheet, f, delimiter)),
+        FileFormat::Cell => std::fs::File::create(path)
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+            .and_then(|f| cell_sheet_core::io::cell_format::write_cell_format(&self.sheet, f)),
+    };
+
+    match result {
+        Ok(()) => {
+            self.file_path = Some(path.clone());
+            self.file_format = format;
+            self.dirty = false;
+            self.status_message = Some(format!("Written to {}", path.display()));
+        }
+        Err(e) => {
+            self.status_message = Some(format!("Error saving: {}", e));
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests and confirm they pass**
+
+```bash
+cargo test -p cell-sheet-tui
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cell-sheet-tui/src/app.rs
+git commit -m "feat: warn on non-standard delimiter when saving; do_save uses self.delimiter"
+```
+
+---
+
+## Task 5: CLI `--delimiter` flag, auto-sniff integration, and headless support
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/main.rs`
+- Modify: `crates/cell-sheet-tui/src/headless.rs`
+- Modify: `crates/cell-sheet-tui/tests/headless.rs`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add to the bottom of `crates/cell-sheet-tui/tests/headless.rs`:
+
+```rust
+#[test]
+fn read_pipe_delimited_with_delimiter_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.psv", "a|b|c\n1|2|3\n");
+
+    let out = run(&[path.to_str().unwrap(), "--delimiter", "|", "--read", "B2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "2\n");
+}
+
+#[test]
+fn read_pipe_delimited_auto_sniff_csv_extension() {
+    // .csv extension but pipe-separated content — sniff should detect the pipe
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "a|b|c\n1|2|3\n");
+
+    let out = run(&[path.to_str().unwrap(), "--read", "B2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "2\n");
+}
+
+#[test]
+fn read_semicolon_delimited_with_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "a;b;c\n10;20;30\n");
+
+    let out = run(&[path.to_str().unwrap(), "--delimiter", ";", "--read", "C2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "30\n");
+}
+
+#[test]
+fn write_pipe_delimited_with_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.psv", "a|b\n1|2\n");
+
+    // Write a new value and check the file stays pipe-delimited
+    let out = run(&[
+        path.to_str().unwrap(),
+        "--delimiter",
+        "|",
+        "--write",
+        "A1",
+        "99",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert!(after.starts_with("99|b\n"), "got: {after:?}");
+}
+
+#[test]
+fn invalid_delimiter_exits_with_code_2() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_csv(&dir, "data.csv", "a,b\n");
+
+    // Alphanumeric delimiter is not valid
+    let out = run(&[path.to_str().unwrap(), "--delimiter", "a", "--read", "A1"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(!stderr(&out).is_empty());
+}
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+cargo test -p cell-sheet-tui --test headless -- delimiter 2>&1 | head -30
+```
+
+Expected: fail — `--delimiter` flag doesn't exist yet.
+
+- [ ] **Step 3: Add `--delimiter` to `Cli` and add `parse_delimiter` helper in `main.rs`**
+
+In `crates/cell-sheet-tui/src/main.rs`, update the `Cli` struct to add the delimiter field:
+
+```rust
+#[derive(Parser)]
+#[command(name = "cell", version, about = "A terminal spreadsheet editor")]
+struct Cli {
+    /// File to open (CSV, TSV, or .cell)
+    file: Option<PathBuf>,
+
+    /// Print the computed value of a cell or range (e.g. A1, A1:B3).
+    /// Repeat to read multiple refs. Ranges render as TSV.
+    #[arg(long, value_name = "REF")]
+    read: Vec<String>,
+
+    /// Evaluate a formula against the loaded sheet without persisting.
+    /// The leading `=` is optional. Repeat to evaluate multiple expressions.
+    #[arg(long, value_name = "EXPR")]
+    eval: Vec<String>,
+
+    /// Set a cell to a value (auto-detects formula if it starts with `=`).
+    /// Repeat to batch multiple writes into a single save.
+    #[arg(long, value_names = ["REF", "VALUE"], num_args = 2)]
+    write: Vec<String>,
+
+    /// Field delimiter character (e.g. '|', ';'). Auto-detected from file
+    /// content when omitted; .tsv files always default to tab.
+    #[arg(long, value_name = "CHAR")]
+    delimiter: Option<char>,
+}
+```
+
+Add this function **before** `main()`:
+
+```rust
+fn parse_delimiter(c: char) -> Result<u8, String> {
+    if !c.is_ascii() {
+        return Err(format!("delimiter must be a single ASCII character, got {c:?}"));
+    }
+    if c.is_alphanumeric() || c == '"' || c == '\n' || c == '\r' {
+        return Err(format!("'{c}' is not a valid field delimiter"));
+    }
+    Ok(c as u8)
+}
+```
+
+- [ ] **Step 4: Resolve delimiter in `main()` and thread it through**
+
+Replace the body of `main()` in `crates/cell-sheet-tui/src/main.rs` with:
+
+```rust
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let explicit_delimiter = match cli.delimiter.map(parse_delimiter) {
+        Some(Err(msg)) => {
+            eprintln!("error: {msg}");
+            return ExitCode::from(2);
+        }
+        Some(Ok(b)) => Some(b),
+        None => None,
+    };
+
+    let opts = headless::Options {
+        file: cli.file.clone().unwrap_or_default(),
+        reads: cli.read,
+        evals: cli.eval,
+        writes: cli
+            .write
+            .chunks_exact(2)
+            .map(|c| (c[0].clone(), c[1].clone()))
+            .collect(),
+        delimiter: explicit_delimiter,
+    };
+
+    if opts.is_active() {
+        if cli.file.is_none() {
+            eprintln!("error: a FILE argument is required for --read/--eval/--write");
+            return ExitCode::from(2);
+        }
+        let mut stdout = io::stdout().lock();
+        return match headless::run(&opts, &mut stdout) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(msg) => {
+                eprintln!("error: {msg}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    match run_tui(cli.file.as_deref(), explicit_delimiter) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Update `run_tui` and `load_file` signatures in `main.rs`**
+
+Replace `run_tui` with:
+
+```rust
+fn run_tui(
+    file: Option<&std::path::Path>,
+    explicit_delimiter: Option<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::new();
+
+    if let Some(path) = file {
+        load_file(&mut app, path, explicit_delimiter)?;
+    }
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run_loop(&mut terminal, &mut app);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+
+    result
+}
+```
+
+Replace `load_file` with:
+
+```rust
+fn load_file(
+    app: &mut App,
+    path: &std::path::Path,
+    explicit_delimiter: Option<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use cell_sheet_core::formula::deps::{recalculate, set_formula};
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    match ext.as_str() {
+        "cell" => {
+            let file = std::fs::File::open(path)?;
+            app.sheet = cell_sheet_core::io::cell_format::read_cell_format(file)?;
+            app.file_format = FileFormat::Cell;
+            // delimiter is irrelevant for .cell; leave app.delimiter at its default
+        }
+        _ => {
+            // Read entire file once; use bytes both for sniffing and parsing.
+            let data = std::fs::read(path)?;
+            let delimiter = if let Some(d) = explicit_delimiter {
+                d
+            } else if ext == "tsv" {
+                b'\t'
+            } else {
+                cell_sheet_core::io::csv::sniff_delimiter(&data)
+            };
+            app.sheet = cell_sheet_core::io::csv::read_csv(data.as_slice(), delimiter)?;
+            app.file_format = if ext == "tsv" {
+                FileFormat::Tsv
+            } else {
+                FileFormat::Csv
+            };
+            app.delimiter = delimiter;
+        }
+    }
+
+    app.file_path = Some(path.to_path_buf());
+
+    // Register formulas in the dependency graph and evaluate them.
+    let formula_cells: Vec<_> = app
+        .sheet
+        .cells
+        .iter()
+        .filter(|(_, cell)| cell.raw.starts_with('='))
+        .map(|(pos, cell)| (*pos, cell.raw.clone()))
+        .collect();
+    for (pos, raw) in formula_cells {
+        set_formula(&mut app.sheet, &mut app.deps, pos, &raw);
+    }
+    recalculate(&mut app.sheet, &app.deps);
+
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Update `headless::Options` and `headless::run`**
+
+In `crates/cell-sheet-tui/src/headless.rs`:
+
+Add `delimiter` to `Options`:
+
+```rust
+#[derive(Debug)]
+pub struct Options {
+    pub file: PathBuf,
+    pub reads: Vec<String>,
+    pub evals: Vec<String>,
+    pub writes: Vec<(String, String)>,
+    pub delimiter: Option<u8>,
+}
+```
+
+Add a `resolve_delimiter` helper after the `Format` impl block:
+
+```rust
+fn resolve_delimiter(
+    path: &Path,
+    format: Format,
+    explicit: Option<u8>,
+) -> Result<u8, Box<dyn std::error::Error>> {
+    if let Some(d) = explicit {
+        return Ok(d);
+    }
+    match format {
+        Format::Tsv => Ok(b'\t'),
+        Format::Cell => Ok(b','), // unused — .cell files don't use a delimiter
+        Format::Csv => {
+            // Read only a small sample for sniffing — avoid a full second read.
+            use std::io::Read as _;
+            let mut buf = vec![0u8; 4096];
+            let mut file = std::fs::File::open(path)?;
+            let n = file.read(&mut buf)?;
+            Ok(csv_io::sniff_delimiter(&buf[..n]))
+        }
+    }
+}
+```
+
+Replace the `load` function with:
+
+```rust
+fn load(
+    path: &Path,
+    format: Format,
+    delimiter: u8,
+) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
+    let mut sheet = match format {
+        Format::Csv => {
+            let data = std::fs::read(path)?;
+            csv_io::read_csv(data.as_slice(), delimiter)?
+        }
+        Format::Tsv => {
+            let file = std::fs::File::open(path)?;
+            csv_io::read_csv(file, delimiter)?
+        }
+        Format::Cell => {
+            let file = std::fs::File::open(path)?;
+            cell_format::read_cell_format(file)?
+        }
+    };
+    let mut deps = DepGraph::new();
+
+    let formula_cells: Vec<_> = sheet
+        .cells
+        .iter()
+        .filter(|(_, cell)| cell.raw.starts_with('='))
+        .map(|(pos, cell)| (*pos, cell.raw.clone()))
+        .collect();
+    for (pos, raw) in formula_cells {
+        set_formula(&mut sheet, &mut deps, pos, &raw);
+    }
+    recalculate(&mut sheet, &deps);
+
+    Ok((sheet, deps))
+}
+```
+
+Replace the `save` function with:
+
+```rust
+fn save(
+    path: &Path,
+    format: Format,
+    sheet: &Sheet,
+    delimiter: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let file = std::fs::File::create(path)?;
+    match format {
+        Format::Csv | Format::Tsv => csv_io::write_csv(sheet, file, delimiter)?,
+        Format::Cell => cell_format::write_cell_format(sheet, file)?,
+    }
+    Ok(())
+}
+```
+
+Replace the `run` function with:
+
+```rust
+pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
+    let format = Format::from_path(&opts.file);
+    let delimiter = resolve_delimiter(&opts.file, format, opts.delimiter)
+        .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
+
+    let (mut sheet, mut deps) = load(&opts.file, format, delimiter)
+        .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
+
+    if !opts.writes.is_empty() {
+        for (idx, (ref_str, value)) in opts.writes.iter().enumerate() {
+            let pos = parse_single_ref(ref_str).ok_or_else(|| {
+                format!(
+                    "invalid cell reference for --write #{}: {ref_str:?}",
+                    idx + 1
+                )
+            })?;
+            apply_write(&mut sheet, &mut deps, pos, value);
+        }
+        recalculate(&mut sheet, &deps);
+        save(&opts.file, format, &sheet, delimiter)
+            .map_err(|e| format!("failed to write {}: {e}", opts.file.display()))?;
+    }
+
+    for ref_str in &opts.reads {
+        let rendered = render_read(&sheet, ref_str)?;
+        writeln!(out, "{rendered}").map_err(|e| format!("write error: {e}"))?;
+    }
+
+    for expr in &opts.evals {
+        let formula = expr.strip_prefix('=').unwrap_or(expr);
+        let value = eval::evaluate(formula, &sheet);
+        if let CellValue::Error(err) = &value {
+            return Err(format!("evaluation error in {expr:?}: {err}"));
+        }
+        writeln!(out, "{value}").map_err(|e| format!("write error: {e}"))?;
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 7: Run all tests**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass, including the five new integration tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cell-sheet-tui/src/main.rs \
+        crates/cell-sheet-tui/src/headless.rs \
+        crates/cell-sheet-tui/tests/headless.rs
+git commit -m "feat: add --delimiter flag, auto-sniff, and headless delimiter support"
+```
+
+---
+
+## Task 6: Final verification and CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Format and lint**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+```
+
+Expected: no warnings, no errors. Fix any clippy lints that appear before moving on. Common ones to watch for:
+- Unused `use std::io::Read as _;` if the import wasn't needed
+- `match format { Format::Csv | Format::Tsv => ... }` — ensure the wildcard arm doesn't produce a dead-code warning
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass across both crates.
+
+- [ ] **Step 3: Add CHANGELOG entry**
+
+Open `CHANGELOG.md` and add under `## Unreleased` → `### Added`:
+
+```markdown
+### Added
+- Custom field delimiter support: `--delimiter '|'` CLI flag, auto-detection from
+  file content, and `:set delimiter=X` ex-command. Writing with a non-standard
+  delimiter to a `.csv` or `.tsv` file shows a warning; use `:w!` to override.
+  Resolves #20.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add CHANGELOG entry for custom delimiter support (#20)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec requirement | Task |
+|---|---|
+| `sniff_delimiter` function in `csv.rs` | Task 1 |
+| Round-trip tests with `b'|'` and `b';'` | Task 1 |
+| `App.delimiter: u8` field (default `b','`) | Task 2 |
+| `Action::SetDelimiter(u8)` | Task 2 |
+| `process_action` handles `SetDelimiter` | Task 2 |
+| `:set delimiter=X` command parsing | Task 3 |
+| Validation: empty/multi-char/alphanumeric → `Noop` | Task 3 |
+| Save warning on non-standard delimiter | Task 4 |
+| `ForceSave` bypasses warning | Task 4 |
+| `do_save` uses `self.delimiter` | Task 4 |
+| `--delimiter <CHAR>` CLI flag | Task 5 |
+| `parse_delimiter` validator (non-ASCII, alphanumeric rejected) | Task 5 |
+| `load_file` auto-sniffs `.csv` and unknown extensions | Task 5 |
+| `.tsv` always uses `b'\t'` (no sniff) | Task 5 |
+| `headless::Options.delimiter` | Task 5 |
+| Headless `load`/`save` use resolved delimiter | Task 5 |
+| Integration tests for `--delimiter` flag | Task 5 |
+| Integration test for auto-sniff | Task 5 |
+| CHANGELOG entry | Task 6 |

--- a/docs/superpowers/specs/2026-04-27-custom-csv-delimiter-design.md
+++ b/docs/superpowers/specs/2026-04-27-custom-csv-delimiter-design.md
@@ -1,0 +1,169 @@
+# Custom CSV Delimiter — Design Spec
+
+**Issue:** [#20](https://github.com/garritfra/cell/issues/20)  
+**Date:** 2026-04-27  
+**Status:** Approved, ready for implementation
+
+---
+
+## Background
+
+The core I/O layer (`cell-sheet-core/src/io/csv.rs`) already accepts an arbitrary `delimiter: u8` in both `read_csv` and `write_csv`. The gap is purely user-facing: the delimiter is currently derived solely from the file extension (`.csv` → `,`, `.tsv` → `\t`, everything else → `,`) with no override mechanism.
+
+HN feedback requested pipe (`|`) support for files that use `|` to avoid issues with comma-containing cells.
+
+---
+
+## Goals
+
+1. **CLI flag** — `cell data.psv --delimiter '|'` (works in both TUI and headless mode)
+2. **Auto-sniff** — detect `|`, `;`, `\t` automatically when the extension is ambiguous or the flag is absent
+3. **`:set delimiter=|`** — ex-command to change the active delimiter for the current buffer in the TUI; persisted on next `:w`
+
+---
+
+## Data Model
+
+### `App` (cell-sheet-tui)
+
+Add one field:
+
+```rust
+pub delimiter: u8,  // default b','
+```
+
+This is orthogonal to `FileFormat` — `FileFormat` answers "does this format preserve formulas?" while `delimiter` answers "what byte separates fields?" A pipe-delimited file is still `FileFormat::Csv` as far as formula-preservation goes.
+
+### `Action` (cell-sheet-tui)
+
+Add one variant:
+
+```rust
+SetDelimiter(u8),
+```
+
+### `headless::Options` (cell-sheet-tui)
+
+Add one field:
+
+```rust
+pub delimiter: Option<u8>,  // None = auto-sniff
+```
+
+### `Cli` (cell-sheet-tui `main.rs`)
+
+Add one argument:
+
+```rust
+/// Field delimiter character (e.g. '|', ';'). Defaults to auto-detect from extension or content sniffing.
+#[arg(long, value_name = "CHAR")]
+delimiter: Option<char>,
+```
+
+---
+
+## Auto-Sniff
+
+### Location
+
+`cell-sheet-core/src/io/csv.rs` — a standalone public function:
+
+```rust
+pub fn sniff_delimiter(sample: &[u8]) -> u8
+```
+
+### Algorithm
+
+1. Read the first line of input (up to 4 KB).
+2. Count occurrences of each candidate delimiter: `','`, `'\t'`, `'|'`, `';'`.
+3. Return the one with the highest count.
+4. Ties break in that order (comma wins ties — it is the most common CSV delimiter).
+5. Return `b','` if the sample is empty.
+
+### When Sniffing Is Triggered
+
+| Condition | Behavior |
+|---|---|
+| `--delimiter` flag provided | Use flag value; skip sniffing |
+| Extension is `.tsv` | Use `b'\t'`; skip sniffing |
+| Extension is `.cell` | Not applicable (non-CSV format) |
+| Extension is `.csv`, no flag | Sniff — may override comma default for pipe/semicolon files |
+| Unknown extension, no flag | Sniff |
+
+---
+
+## CLI Surface
+
+```
+cell data.psv --delimiter '|'
+cell data.csv --delimiter ';' --read A1
+```
+
+- The `char` value is validated at startup: must be a printable, non-alphanumeric ASCII byte. Invalid input exits with code 2 and a human-readable error.
+- The resolved delimiter is stored in `app.delimiter` (TUI) or carried through `headless::Options` (headless).
+- Headless writes use the delimiter silently (no interactive warning).
+
+---
+
+## TUI: `:set delimiter=X`
+
+- Parsed in `command.rs`: `:set delimiter=X` where `X` is a single character.
+- Produces `Action::SetDelimiter(b'X')`.
+- `process_action` sets `app.delimiter = X` and writes `"Delimiter set to '|'"` to the status bar.
+- Does **not** re-parse the currently loaded file — only affects the next save.
+- Validation: if `X` is absent, multi-byte, or alphanumeric, show a status bar error and leave state unchanged.
+
+---
+
+## Save Behavior
+
+### Warning on non-standard delimiter to `.csv`
+
+In `App::do_save` (non-force path), if:
+- `format == FileFormat::Csv`, **and**
+- `self.delimiter != b','`
+
+Emit:
+
+> `"Non-standard delimiter '|' will be used. Use :w! to force, or save as .tsv / .psv."`
+
+`:w!` / `ForceSave` bypasses the warning and writes with the active delimiter.
+
+This mirrors the existing formula-flatten warning pattern.
+
+### `.tsv` files
+
+If the active delimiter is not `b'\t'` and the path ends in `.tsv`, the same warning fires (saving a comma-delimited file as `.tsv` is equally odd).
+
+---
+
+## Error Handling
+
+| Scenario | Response |
+|---|---|
+| `--delimiter` with multi-byte or alphanumeric char | Exit code 2, error to stderr |
+| `:set delimiter=` with no/invalid char | Status bar error, no state change |
+| Sniff on empty file | Default to `b','` |
+
+---
+
+## Testing
+
+### `cell-sheet-core`
+
+- `sniff_delimiter` unit tests: pipe-heavy → `b'|'`, semicolon-heavy → `b';'`, tab-heavy → `b'\t'`, empty → `b','`, tie → `b','`
+- `read_csv` / `write_csv` round-trip with `b'|'` and `b';'`
+
+### `cell-sheet-tui`
+
+- `command.rs`: `parse_command("set delimiter=|")` → `Action::SetDelimiter(b'|')`; invalid inputs → `Action::Noop`
+- `app.rs`: `Action::SetDelimiter` sets the field; saving `.csv` with non-comma delimiter triggers warning; `ForceSave` bypasses it; `.tsv` with non-tab delimiter also warns
+- Headless integration test: write a pipe-delimited file, read it back with `--delimiter '|'`, assert cell values
+
+---
+
+## Non-Goals
+
+- Re-parsing the open buffer when `:set delimiter` changes (out of scope; close and reopen the file to change how it was read)
+- Supporting multi-character delimiters
+- Configuring the quote character


### PR DESCRIPTION
## Summary

- Adds `--delimiter '|'` CLI flag (validated: single ASCII, non-alphanumeric, non-quote) for both TUI and headless mode
- Auto-detects delimiter from file content when the flag is omitted (sniffs the first line for `,`, `\t`, `|`, `;`; comma wins ties); `.tsv` always defaults to `\t`
- Adds `:set delimiter=X` ex-command; invalid input shows a status bar error
- Warns when saving to `.csv`/`.tsv` with a non-standard delimiter; `:w!` overrides
- `do_save` and headless `save` now use the active `App.delimiter` instead of hardcoded bytes

## Test plan

- [ ] `cargo test` passes (220 tests across core + TUI unit + headless integration)
- [ ] `cargo clippy --workspace --all-targets --all-features` passes clean
- [ ] `cell data.psv --delimiter '|' --read B2` returns the correct value
- [ ] `cell data.csv --read B2` on a pipe-delimited `.csv` auto-sniffs and returns the correct value
- [ ] `:set delimiter=|` followed by `:w` shows the warning; `:w!` writes the file with `|`
- [ ] `:set delimiter=a` shows a status bar error
- [ ] `--delimiter a` exits with code 2

Resolves #20.

Made with [Cursor](https://cursor.com)