### PR TITLE
feat: numeric count prefix in normal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- Vim-style numeric count prefix in normal mode: type digits before a motion or
+  operator to repeat or scale it. `5j` moves five rows down, `10G` jumps to row
+  10, `5gg` jumps to row 5 from the top, `3dd` deletes three rows (line-wise,
+  pastable as a block with `p`/`P`), `4yy` yanks four rows, `2w` / `3b` hop
+  multiple non-empty cells. `0` alone still goes to the first column; after a
+  non-zero digit, `0` extends the count (so `10j` really moves ten rows). The
+  partially-typed count and operator render in the status line as you type
+  (vim's `showcmd`). `Esc` cancels a half-typed count, and counts saturate at
+  one million to keep huge accidental inputs responsive
+  ([#21](https://github.com/garritfra/cell/issues/21))
+
 ## 0.3.1 (2026-04-28)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   partially-typed count and operator render in the status line as you type
   (vim's `showcmd`). `Esc` cancels a half-typed count, and counts saturate at
   one million to keep huge accidental inputs responsive
-  ([#21](https://github.com/garritfra/cell/issues/21))
+  ([#55](https://github.com/garritfra/cell/pull/55))
 
 ## 0.3.1 (2026-04-28)
 

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -2,40 +2,61 @@ use super::{HelpCategory, HelpEntry};
 
 pub static NORMAL_ENTRIES: &[HelpEntry] = &[
     HelpEntry {
+        tags: &["count", "[count]", "N"],
+        category: HelpCategory::Normal,
+        summary: "Numeric count prefix",
+        detail: "Type digits before a motion or operator to repeat or scale it,\n\
+                 vim-style. Examples: 5j moves 5 rows down, 10G jumps to row 10,\n\
+                 3dd deletes 3 rows, 4yy yanks 4 rows, 2w hops 2 non-empty cells.\n\
+                 The count is shown in the status line as you type.\n\n\
+                 0 alone goes to the first column; only after a non-zero digit\n\
+                 does 0 extend the count (so 10j really moves 10 rows).\n\n\
+                 Esc cancels a partially-typed count. Counts apply to:\n\
+                 h j k l, Up/Down/Left/Right, w b, gg G, dd yy.",
+    },
+    HelpEntry {
         tags: &["h"],
         category: HelpCategory::Normal,
-        summary: "Move cursor left",
-        detail: "Move the cursor one column to the left. Stops at column A.\nAlias: Left arrow",
+        summary: "Move cursor left ([count]h)",
+        detail: "Move the cursor one column to the left. Stops at column A.\n\
+                 With a count prefix, moves [count] columns.\n\
+                 Alias: Left arrow",
     },
     HelpEntry {
         tags: &["j"],
         category: HelpCategory::Normal,
-        summary: "Move cursor down",
-        detail: "Move the cursor one row down.\nAlias: Down arrow",
+        summary: "Move cursor down ([count]j)",
+        detail: "Move the cursor one row down. With a count prefix, moves\n\
+                 [count] rows.\nAlias: Down arrow",
     },
     HelpEntry {
         tags: &["k"],
         category: HelpCategory::Normal,
-        summary: "Move cursor up",
-        detail: "Move the cursor one row up. Stops at row 1.\nAlias: Up arrow",
+        summary: "Move cursor up ([count]k)",
+        detail: "Move the cursor one row up. Stops at row 1. With a count\n\
+                 prefix, moves [count] rows.\nAlias: Up arrow",
     },
     HelpEntry {
         tags: &["l"],
         category: HelpCategory::Normal,
-        summary: "Move cursor right",
-        detail: "Move the cursor one column to the right.\nAlias: Right arrow",
+        summary: "Move cursor right ([count]l)",
+        detail: "Move the cursor one column to the right. With a count prefix,\n\
+                 moves [count] columns.\nAlias: Right arrow",
     },
     HelpEntry {
         tags: &["gg"],
         category: HelpCategory::Normal,
-        summary: "Go to first row",
-        detail: "Move the cursor to row 1, keeping the current column.",
+        summary: "Go to first row / row N ([count]gg)",
+        detail: "Move the cursor to row 1, keeping the current column.\n\
+                 With a count prefix, jumps to row [count] (1-indexed).",
     },
     HelpEntry {
         tags: &["G"],
         category: HelpCategory::Normal,
-        summary: "Go to last row",
-        detail: "Move the cursor to the last row with data, keeping the current column.",
+        summary: "Go to last row / row N ([count]G)",
+        detail: "Move the cursor to the last row with data, keeping the\n\
+                 current column. With a count prefix, jumps to row [count]\n\
+                 (1-indexed) instead.",
     },
     HelpEntry {
         tags: &["0"],
@@ -52,26 +73,35 @@ pub static NORMAL_ENTRIES: &[HelpEntry] = &[
     HelpEntry {
         tags: &["w"],
         category: HelpCategory::Normal,
-        summary: "Next non-empty cell",
-        detail: "Jump to the next non-empty cell to the right in the current row.",
+        summary: "Next non-empty cell ([count]w)",
+        detail: "Jump to the next non-empty cell to the right in the current\n\
+                 row. With a count prefix, hops [count] non-empty cells.",
     },
     HelpEntry {
         tags: &["b"],
         category: HelpCategory::Normal,
-        summary: "Previous non-empty cell",
-        detail: "Jump to the previous non-empty cell to the left in the current row.",
+        summary: "Previous non-empty cell ([count]b)",
+        detail: "Jump to the previous non-empty cell to the left in the\n\
+                 current row. With a count prefix, hops [count] non-empty\n\
+                 cells back.",
     },
     HelpEntry {
         tags: &["dd"],
         category: HelpCategory::Normal,
-        summary: "Delete current row",
-        detail: "Deletes all cells in the current row. The row contents are stored\nin the register and can be pasted with p or P. Undoable with u.",
+        summary: "Delete current row ([count]dd)",
+        detail: "Deletes all cells in the current row. With a count prefix,\n\
+                 deletes [count] rows starting at the cursor; the deleted\n\
+                 rows are stored line-wise in the register and can be\n\
+                 pasted as a block with p (below) or P (above). Undoable\n\
+                 with u.",
     },
     HelpEntry {
         tags: &["yy"],
         category: HelpCategory::Normal,
-        summary: "Yank current row",
-        detail: "Copies all cells in the current row to the register.\nPaste with p (below) or P (above).",
+        summary: "Yank current row ([count]yy)",
+        detail: "Copies all cells in the current row to the register. With a\n\
+                 count prefix, yanks [count] rows starting at the cursor.\n\
+                 Paste with p (below) or P (above).",
     },
     HelpEntry {
         tags: &["x"],

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -39,7 +39,11 @@ impl CommandKind {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Action {
     Noop,
-    MoveCursor(Direction),
+    /// Move the cursor `count` cells in `dir`. Count of 1 is the default
+    /// single-step move; counts above 1 implement vim's `[count]hjkl`
+    /// semantics. The handler clamps to grid bounds with saturating
+    /// arithmetic and updates the viewport once at the end.
+    MoveCursor(Direction, usize),
     #[allow(dead_code)]
     MoveCursorTo(CellPos),
     EditCell(CellPos, String),
@@ -114,12 +118,21 @@ pub enum Action {
     HalfPageUp,
     GotoFirstRow,
     GotoLastRow,
+    /// Jump to a specific 1-indexed row, vim's `[count]G` / `[count]gg`.
+    /// The handler clamps to `[1, row_count]`.
+    GotoRow(usize),
     GotoFirstCol,
     GotoLastCol,
-    NextNonEmpty,
-    PrevNonEmpty,
-    DeleteRow(usize),
-    YankRow(usize),
+    NextNonEmpty(usize),
+    PrevNonEmpty(usize),
+    DeleteRow {
+        start: usize,
+        count: usize,
+    },
+    YankRow {
+        start: usize,
+        count: usize,
+    },
     ShowHelp(Option<String>),
     ScrollCursorTop,
     ScrollCursorCenter,

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -120,13 +120,14 @@ impl App {
     pub fn process_action(&mut self, action: Action) {
         match action {
             Action::Noop => {}
-            Action::MoveCursor(dir) => {
+            Action::MoveCursor(dir, count) => {
+                let count = count.max(1);
                 let (row, col) = self.cursor;
                 self.cursor = match dir {
-                    Direction::Up => (row.saturating_sub(1), col),
-                    Direction::Down => (row + 1, col),
-                    Direction::Left => (row, col.saturating_sub(1)),
-                    Direction::Right => (row, col + 1),
+                    Direction::Up => (row.saturating_sub(count), col),
+                    Direction::Down => (row.saturating_add(count), col),
+                    Direction::Left => (row, col.saturating_sub(count)),
+                    Direction::Right => (row, col.saturating_add(count)),
                 };
                 self.viewport.ensure_visible(self.cursor);
             }
@@ -247,6 +248,12 @@ impl App {
                     0
                 };
                 self.cursor = (last, self.cursor.1);
+                self.viewport.ensure_visible(self.cursor);
+            }
+            Action::GotoRow(target_1based) => {
+                self.record_jump();
+                let row = target_1based.saturating_sub(1);
+                self.cursor = (row, self.cursor.1);
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::GotoFirstCol => {
@@ -419,17 +426,36 @@ impl App {
                     self.register = Some(Register::Cell(cell.raw.clone()));
                 }
             }
-            Action::YankRow(row) => {
-                let mut cells = Vec::new();
-                for col in 0..self.sheet.col_count {
-                    let raw = self
-                        .sheet
-                        .get_cell((row, col))
-                        .map(|c| c.raw.clone())
-                        .unwrap_or_default();
-                    cells.push(raw);
+            Action::YankRow { start, count } => {
+                let count = count.max(1);
+                let cols = self.sheet.col_count;
+                if count == 1 {
+                    let mut cells = Vec::with_capacity(cols);
+                    for col in 0..cols {
+                        let raw = self
+                            .sheet
+                            .get_cell((start, col))
+                            .map(|c| c.raw.clone())
+                            .unwrap_or_default();
+                        cells.push(raw);
+                    }
+                    self.register = Some(Register::Row(cells));
+                } else {
+                    let mut rows: Vec<Vec<String>> = Vec::with_capacity(count);
+                    for r in start..start.saturating_add(count) {
+                        let mut row_cells = Vec::with_capacity(cols);
+                        for col in 0..cols {
+                            let raw = self
+                                .sheet
+                                .get_cell((r, col))
+                                .map(|c| c.raw.clone())
+                                .unwrap_or_default();
+                            row_cells.push(raw);
+                        }
+                        rows.push(row_cells);
+                    }
+                    self.register = Some(Register::Rows(rows));
                 }
-                self.register = Some(Register::Row(cells));
             }
             Action::YankRange { start, end } => {
                 let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
@@ -475,22 +501,45 @@ impl App {
                     self.dirty = true;
                 }
             }
-            Action::DeleteRow(row) => {
-                let mut cells = Vec::new();
+            Action::DeleteRow { start, count } => {
+                let count = count.max(1);
+                let cols = self.sheet.col_count;
                 let mut changes = Vec::new();
-                for col in 0..self.sheet.col_count {
-                    let raw = self
-                        .sheet
-                        .get_cell((row, col))
-                        .map(|c| c.raw.clone())
-                        .unwrap_or_default();
-                    if !raw.is_empty() {
-                        changes.push(((row, col), raw.clone(), String::new()));
-                        self.sheet.clear_cell((row, col));
+                if count == 1 {
+                    let mut cells = Vec::with_capacity(cols);
+                    for col in 0..cols {
+                        let raw = self
+                            .sheet
+                            .get_cell((start, col))
+                            .map(|c| c.raw.clone())
+                            .unwrap_or_default();
+                        if !raw.is_empty() {
+                            changes.push(((start, col), raw.clone(), String::new()));
+                            self.sheet.clear_cell((start, col));
+                        }
+                        cells.push(raw);
                     }
-                    cells.push(raw);
+                    self.register = Some(Register::Row(cells));
+                } else {
+                    let mut rows: Vec<Vec<String>> = Vec::with_capacity(count);
+                    for r in start..start.saturating_add(count) {
+                        let mut row_cells = Vec::with_capacity(cols);
+                        for col in 0..cols {
+                            let raw = self
+                                .sheet
+                                .get_cell((r, col))
+                                .map(|c| c.raw.clone())
+                                .unwrap_or_default();
+                            if !raw.is_empty() {
+                                changes.push(((r, col), raw.clone(), String::new()));
+                                self.sheet.clear_cell((r, col));
+                            }
+                            row_cells.push(raw);
+                        }
+                        rows.push(row_cells);
+                    }
+                    self.register = Some(Register::Rows(rows));
                 }
-                self.register = Some(Register::Row(cells));
                 if !changes.is_empty() {
                     self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
                     self.dirty = true;
@@ -537,6 +586,35 @@ impl App {
                                 }
                             }
                         }
+                        Register::Rows(rows) => {
+                            // Multi-row line-wise (3dd/3yy): p pastes the whole
+                            // block starting at the line below; P starts at the
+                            // current line. Cursor column is ignored.
+                            let dest_row_start = if is_after { pos.0 + 1 } else { pos.0 };
+                            for (r_off, row_data) in rows.iter().enumerate() {
+                                let dest_row = dest_row_start + r_off;
+                                for (col, raw) in row_data.iter().enumerate() {
+                                    if raw.is_empty() {
+                                        continue;
+                                    }
+                                    let adjusted = crate::clipboard::adjust_formula(
+                                        raw,
+                                        dest_row as isize - (pos.0 as isize + r_off as isize),
+                                        0,
+                                    );
+                                    let dest = (dest_row, col);
+                                    let old_raw = self
+                                        .sheet
+                                        .get_cell(dest)
+                                        .map(|c| c.raw.clone())
+                                        .unwrap_or_default();
+                                    if adjusted != old_raw {
+                                        changes.push((dest, old_raw, adjusted.clone()));
+                                        self.write_cell_raw(dest, &adjusted);
+                                    }
+                                }
+                            }
+                        }
                         Register::Block(block) => {
                             // Block (visual selection): p pastes at cursor position
                             for (r_off, row_data) in block.iter().enumerate() {
@@ -570,26 +648,44 @@ impl App {
                     }
                 }
             }
-            Action::NextNonEmpty => {
+            Action::NextNonEmpty(count) => {
+                let count = count.max(1);
                 let (row, col) = self.cursor;
-                for c in (col + 1)..self.sheet.col_count {
+                let mut last = col;
+                let mut hops = 0;
+                let mut c = col + 1;
+                while c < self.sheet.col_count && hops < count {
                     if self.sheet.get_cell((row, c)).is_some() {
-                        self.cursor = (row, c);
-                        self.viewport.ensure_visible(self.cursor);
-                        return;
+                        last = c;
+                        hops += 1;
                     }
+                    c += 1;
+                }
+                if hops > 0 {
+                    self.cursor = (row, last);
+                    self.viewport.ensure_visible(self.cursor);
                 }
             }
-            Action::PrevNonEmpty => {
+            Action::PrevNonEmpty(count) => {
+                let count = count.max(1);
                 let (row, col) = self.cursor;
-                if col > 0 {
-                    for c in (0..col).rev() {
-                        if self.sheet.get_cell((row, c)).is_some() {
-                            self.cursor = (row, c);
-                            self.viewport.ensure_visible(self.cursor);
-                            return;
+                if col == 0 {
+                    return;
+                }
+                let mut last = col;
+                let mut hops = 0;
+                for c in (0..col).rev() {
+                    if self.sheet.get_cell((row, c)).is_some() {
+                        last = c;
+                        hops += 1;
+                        if hops >= count {
+                            break;
                         }
                     }
+                }
+                if hops > 0 {
+                    self.cursor = (row, last);
+                    self.viewport.ensure_visible(self.cursor);
                 }
             }
             Action::ShowHelp(topic) => match topic {
@@ -1072,7 +1168,7 @@ mod tests {
         let mut app = App::new();
         app.process_action(Action::EditCell((0, 0), "x".into()));
         app.process_action(Action::EditCell((0, 1), "y".into()));
-        app.process_action(Action::YankRow(0));
+        app.process_action(Action::YankRow { start: 0, count: 1 });
         // P on row 1 puts the yanked row on row 1.
         app.process_action(Action::PasteBefore((1, 0)));
         assert_eq!(raw_at(&app, (1, 0)).as_deref(), Some("x"));
@@ -1087,7 +1183,7 @@ mod tests {
         let mut app = App::new();
         app.process_action(Action::EditCell((0, 0), "x".into()));
         app.process_action(Action::EditCell((0, 1), "y".into()));
-        app.process_action(Action::YankRow(0));
+        app.process_action(Action::YankRow { start: 0, count: 1 });
         app.process_action(Action::PasteBefore((1, 0)));
         app.process_action(Action::Undo);
         app.process_action(Action::Redo);
@@ -1102,7 +1198,7 @@ mod tests {
         app.process_action(Action::EditCell((0, 1), "y".into()));
         app.process_action(Action::EditCell((1, 0), "old0".into()));
         app.process_action(Action::EditCell((1, 1), "old1".into()));
-        app.process_action(Action::YankRow(0));
+        app.process_action(Action::YankRow { start: 0, count: 1 });
         app.process_action(Action::PasteBefore((1, 0)));
         assert_eq!(raw_at(&app, (1, 0)).as_deref(), Some("x"));
         assert_eq!(raw_at(&app, (1, 1)).as_deref(), Some("y"));
@@ -1243,7 +1339,7 @@ mod tests {
         app.process_action(Action::EditCell((0, 1), "world".into()));
         app.process_action(Action::EditCell((1, 0), "keep".into()));
 
-        app.process_action(Action::DeleteRow(0));
+        app.process_action(Action::DeleteRow { start: 0, count: 1 });
         assert!(app.sheet.get_cell((0, 0)).is_none());
         assert!(app.sheet.get_cell((0, 1)).is_none());
         assert_eq!(
@@ -1272,7 +1368,7 @@ mod tests {
         app.process_action(Action::EditCell((0, 0), "hello".into()));
         app.process_action(Action::EditCell((0, 1), "world".into()));
 
-        app.process_action(Action::DeleteRow(0));
+        app.process_action(Action::DeleteRow { start: 0, count: 1 });
         app.process_action(Action::Undo);
         app.process_action(Action::Redo);
 
@@ -2044,7 +2140,7 @@ mod tests {
         app.process_action(Action::EditCell((0, 0), "10".into()));
         app.process_action(Action::EditCell((0, 1), "=A1*2".into()));
 
-        app.process_action(Action::DeleteRow(0));
+        app.process_action(Action::DeleteRow { start: 0, count: 1 });
         app.process_action(Action::Undo);
 
         assert_eq!(
@@ -2054,5 +2150,179 @@ mod tests {
         // Formula should re-evaluate after restoration.
         let val = app.sheet.get_cell((0, 1)).map(|c| c.value.to_string());
         assert_eq!(val.as_deref(), Some("20"));
+    }
+
+    // ── numeric count prefix ([count]j, [count]G, [count]dd, [count]yy) ──
+
+    #[test]
+    fn move_cursor_with_count_advances_n_steps() {
+        let mut app = App::new();
+        app.cursor = (2, 3);
+        app.process_action(Action::MoveCursor(crate::action::Direction::Down, 5));
+        assert_eq!(app.cursor, (7, 3));
+        app.process_action(Action::MoveCursor(crate::action::Direction::Right, 4));
+        assert_eq!(app.cursor, (7, 7));
+        app.process_action(Action::MoveCursor(crate::action::Direction::Up, 100));
+        assert_eq!(app.cursor, (0, 7), "saturating_sub clamps at 0");
+        app.process_action(Action::MoveCursor(crate::action::Direction::Left, 100));
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn move_cursor_count_zero_treated_as_one() {
+        let mut app = App::new();
+        app.cursor = (0, 0);
+        app.process_action(Action::MoveCursor(crate::action::Direction::Down, 0));
+        assert_eq!(app.cursor, (1, 0));
+    }
+
+    #[test]
+    fn goto_row_jumps_to_one_indexed_row() {
+        let mut app = App::new();
+        app.cursor = (0, 2);
+        app.process_action(Action::GotoRow(10));
+        assert_eq!(app.cursor, (9, 2), "10G goes to row index 9");
+    }
+
+    #[test]
+    fn goto_row_zero_clamps_to_first() {
+        let mut app = App::new();
+        app.cursor = (5, 0);
+        app.process_action(Action::GotoRow(0));
+        assert_eq!(app.cursor, (0, 0));
+    }
+
+    #[test]
+    fn goto_row_records_jump_for_ctrl_o() {
+        let mut app = App::new();
+        app.cursor = (5, 0);
+        app.process_action(Action::GotoRow(20));
+        // Jump back should return us to (5, 0).
+        app.process_action(Action::JumpBack);
+        assert_eq!(app.cursor, (5, 0));
+    }
+
+    #[test]
+    fn delete_multiple_rows_clears_them_all() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "a".into()));
+        app.process_action(Action::EditCell((1, 0), "b".into()));
+        app.process_action(Action::EditCell((2, 0), "c".into()));
+        app.process_action(Action::EditCell((3, 0), "keep".into()));
+
+        app.process_action(Action::DeleteRow { start: 0, count: 3 });
+        assert!(app.sheet.get_cell((0, 0)).is_none());
+        assert!(app.sheet.get_cell((1, 0)).is_none());
+        assert!(app.sheet.get_cell((2, 0)).is_none());
+        assert_eq!(
+            app.sheet.get_cell((3, 0)).map(|c| c.raw.as_str()),
+            Some("keep")
+        );
+    }
+
+    #[test]
+    fn delete_multiple_rows_undoes_atomically() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "a".into()));
+        app.process_action(Action::EditCell((1, 0), "b".into()));
+        app.process_action(Action::EditCell((2, 0), "c".into()));
+
+        app.process_action(Action::DeleteRow { start: 0, count: 3 });
+        app.process_action(Action::Undo);
+        // Single undo restores all three rows (single MultiCellEdit entry).
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("a")
+        );
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).map(|c| c.raw.as_str()),
+            Some("b")
+        );
+        assert_eq!(
+            app.sheet.get_cell((2, 0)).map(|c| c.raw.as_str()),
+            Some("c")
+        );
+    }
+
+    #[test]
+    fn yank_multiple_rows_then_paste_below_drops_block() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "x".into()));
+        app.process_action(Action::EditCell((0, 1), "y".into()));
+        app.process_action(Action::EditCell((1, 0), "z".into()));
+        app.cursor = (0, 0);
+
+        app.process_action(Action::YankRow { start: 0, count: 2 });
+        app.process_action(Action::Paste((0, 0)));
+        // Pasted starting at row 1 (below row 0): row 1 should be x/y,
+        // row 2 should be z.
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).map(|c| c.raw.as_str()),
+            Some("x")
+        );
+        assert_eq!(
+            app.sheet.get_cell((1, 1)).map(|c| c.raw.as_str()),
+            Some("y")
+        );
+        assert_eq!(
+            app.sheet.get_cell((2, 0)).map(|c| c.raw.as_str()),
+            Some("z")
+        );
+    }
+
+    #[test]
+    fn delete_then_paste_multi_row_restores_via_register() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "a".into()));
+        app.process_action(Action::EditCell((1, 0), "b".into()));
+        app.process_action(Action::EditCell((2, 0), "c".into()));
+        app.cursor = (0, 0);
+
+        app.process_action(Action::DeleteRow { start: 0, count: 3 });
+        // After 3dd at row 0, the register holds 3 rows. PasteBefore
+        // (P) places them starting at the current row.
+        app.process_action(Action::PasteBefore((0, 0)));
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("a")
+        );
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).map(|c| c.raw.as_str()),
+            Some("b")
+        );
+        assert_eq!(
+            app.sheet.get_cell((2, 0)).map(|c| c.raw.as_str()),
+            Some("c")
+        );
+    }
+
+    #[test]
+    fn next_non_empty_with_count_hops_n_cells() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 1), "a".into()));
+        app.process_action(Action::EditCell((0, 3), "b".into()));
+        app.process_action(Action::EditCell((0, 5), "c".into()));
+        app.cursor = (0, 0);
+
+        app.process_action(Action::NextNonEmpty(2));
+        assert_eq!(app.cursor, (0, 3));
+        app.process_action(Action::NextNonEmpty(1));
+        assert_eq!(app.cursor, (0, 5));
+        // Asking for more than available: stay where we got to (last).
+        let before = app.cursor;
+        app.process_action(Action::NextNonEmpty(99));
+        assert_eq!(app.cursor, before, "no more non-empty cells, stay put");
+    }
+
+    #[test]
+    fn prev_non_empty_with_count_hops_n_cells() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 1), "a".into()));
+        app.process_action(Action::EditCell((0, 3), "b".into()));
+        app.process_action(Action::EditCell((0, 5), "c".into()));
+        app.cursor = (0, 5);
+
+        app.process_action(Action::PrevNonEmpty(2));
+        assert_eq!(app.cursor, (0, 1));
     }
 }

--- a/crates/cell-sheet-tui/src/clipboard.rs
+++ b/crates/cell-sheet-tui/src/clipboard.rs
@@ -5,6 +5,10 @@ use cell_sheet_core::model::{col_index_to_label, col_label_to_index};
 pub enum Register {
     Cell(String),
     Row(Vec<String>),
+    /// Line-wise multi-row register produced by `[count]dd` / `[count]yy`
+    /// when count > 1. Pastes line-wise (below for `p`, above for `P`),
+    /// like vim's linewise register.
+    Rows(Vec<Vec<String>>),
     Block(Vec<Vec<String>>),
 }
 

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -172,8 +172,27 @@ fn run_loop(
 
         let selection = visual_state.as_ref().map(|vs| vs.selection(app.cursor));
         let ic = insert_cursor;
+        // Build vim-style `showcmd` for normal mode: e.g. `5`, `5d`, `g`,
+        // `5g`. Other modes don't have a partial command to display.
+        let partial_command = if app.mode == Mode::Normal {
+            let mut s = String::new();
+            if let Some(n) = normal_state.pending_count() {
+                s.push_str(&n.to_string());
+            }
+            if let Some(c) = normal_state.pending_op() {
+                s.push(c);
+            }
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        } else {
+            None
+        };
+        let partial_command_ref = partial_command.as_deref();
         terminal.draw(|frame| {
-            render::render(frame, app, selection, ic);
+            render::render(frame, app, selection, ic, partial_command_ref);
         })?;
 
         if event::poll(std::time::Duration::from_millis(100))? {

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -10,10 +10,21 @@ pub enum FindKind {
     Backward,
 }
 
+/// Cap the count buffer at a sane upper bound. Vim accepts huge counts
+/// (and most ops degrade to "until end of buffer"), but we don't want a
+/// stray `9999999999G` to wedge the loop, allocate gigantic vecs in
+/// `dd` / `yy`, or overflow `usize` on 32-bit targets.
+const COUNT_CAP: usize = 1_000_000;
+
 pub struct NormalState {
     pub pending: Option<char>,
     /// Set after `f` or `F` so the next keypress is consumed as the target.
     pub pending_find: Option<FindKind>,
+    /// Vim-style numeric count prefix accumulated from digit keys. `None`
+    /// means "no count typed" — most commands then use a default of 1.
+    /// `0` only starts a count *after* the first non-zero digit; before
+    /// that, `0` is the `goto-first-column` motion.
+    pub pending_count: Option<usize>,
 }
 
 impl NormalState {
@@ -21,13 +32,51 @@ impl NormalState {
         NormalState {
             pending: None,
             pending_find: None,
+            pending_count: None,
         }
+    }
+
+    /// Snapshot of the current pending count (for `showcmd`-style status
+    /// rendering). Does not consume.
+    pub fn pending_count(&self) -> Option<usize> {
+        self.pending_count
+    }
+
+    /// Snapshot of the pending operator key (for `showcmd`-style status
+    /// rendering). Does not consume.
+    pub fn pending_op(&self) -> Option<char> {
+        self.pending
+    }
+
+    /// Take the pending count, defaulting to 1, and clear the buffer.
+    /// Use this when an action that respects counts is about to fire.
+    fn take_count(&mut self) -> usize {
+        self.pending_count.take().unwrap_or(1).max(1)
+    }
+
+    /// Discard any pending count without using it. Use when a non-counted
+    /// command fires (e.g. `i`, `:`) so the next keypress starts fresh.
+    fn discard_count(&mut self) {
+        self.pending_count = None;
+    }
+
+    /// Append a digit to the pending count buffer with overflow protection.
+    fn push_digit(&mut self, d: u32) {
+        let next = self
+            .pending_count
+            .unwrap_or(0)
+            .saturating_mul(10)
+            .saturating_add(d as usize)
+            .min(COUNT_CAP);
+        self.pending_count = Some(next);
     }
 
     pub fn handle_key(&mut self, key: KeyEvent, app: &App) -> Action {
         // A pending `f`/`F` consumes the next keypress as its target,
-        // regardless of modifier (so `f<Shift+a>` still hits 'A').
+        // regardless of modifier (so `f<Shift+a>` still hits 'A'). The
+        // count prefix doesn't apply to f/F (out of scope for now).
         if let Some(kind) = self.pending_find.take() {
+            self.discard_count();
             return match key.code {
                 KeyCode::Char(c) => {
                     let forward = matches!(kind, FindKind::Forward);
@@ -41,8 +90,19 @@ impl NormalState {
             };
         }
 
-        // Handle Ctrl combinations first
+        // Esc clears any partially-typed command (count + pending op).
+        // Match vim: a half-typed `5d` followed by Esc cancels.
+        if key.code == KeyCode::Esc {
+            self.pending = None;
+            self.pending_count = None;
+            return Action::Noop;
+        }
+
+        // Handle Ctrl combinations first. Counts don't apply to these
+        // (Vim itself supports `[count]Ctrl-d` etc., but that's not in
+        // scope here — discard so the next keypress starts fresh).
         if key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.discard_count();
             return match key.code {
                 KeyCode::Char('d') => Action::HalfPageDown,
                 KeyCode::Char('u') => Action::HalfPageUp,
@@ -57,34 +117,99 @@ impl NormalState {
             };
         }
 
-        // Handle pending sequences
+        // Handle pending operator/prefix sequences. The count threaded
+        // here was buffered before `g`/`d`/`y` was pressed, e.g. `5dd`,
+        // `10gg`. Marks/`'`/`` ` ``/`z` ignore the count.
         if let Some(prev) = self.pending.take() {
             return match (prev, key.code) {
-                ('g', KeyCode::Char('g')) => Action::GotoFirstRow,
-                ('g', KeyCode::Char('v')) => Action::ReselectLastVisual,
-                ('d', KeyCode::Char('d')) => Action::DeleteRow(app.cursor.0),
-                ('y', KeyCode::Char('y')) => Action::YankRow(app.cursor.0),
-                ('z', KeyCode::Char('z')) => Action::ScrollCursorCenter,
-                ('z', KeyCode::Char('t')) => Action::ScrollCursorTop,
-                ('z', KeyCode::Char('b')) => Action::ScrollCursorBottom,
-                ('m', KeyCode::Char(c)) if c.is_ascii_lowercase() => Action::SetMark(c),
-                ('\'', KeyCode::Char(c)) if c.is_ascii_lowercase() => Action::JumpToMark {
-                    name: c,
-                    line_wise: true,
+                ('g', KeyCode::Char('g')) => match self.pending_count.take() {
+                    Some(n) => Action::GotoRow(n),
+                    None => Action::GotoFirstRow,
                 },
-                ('`', KeyCode::Char(c)) if c.is_ascii_lowercase() => Action::JumpToMark {
-                    name: c,
-                    line_wise: false,
-                },
-                _ => Action::Noop,
+                ('g', KeyCode::Char('v')) => {
+                    self.discard_count();
+                    Action::ReselectLastVisual
+                }
+                ('d', KeyCode::Char('d')) => {
+                    let count = self.take_count();
+                    Action::DeleteRow {
+                        start: app.cursor.0,
+                        count,
+                    }
+                }
+                ('y', KeyCode::Char('y')) => {
+                    let count = self.take_count();
+                    Action::YankRow {
+                        start: app.cursor.0,
+                        count,
+                    }
+                }
+                ('z', KeyCode::Char('z')) => {
+                    self.discard_count();
+                    Action::ScrollCursorCenter
+                }
+                ('z', KeyCode::Char('t')) => {
+                    self.discard_count();
+                    Action::ScrollCursorTop
+                }
+                ('z', KeyCode::Char('b')) => {
+                    self.discard_count();
+                    Action::ScrollCursorBottom
+                }
+                ('m', KeyCode::Char(c)) if c.is_ascii_lowercase() => {
+                    self.discard_count();
+                    Action::SetMark(c)
+                }
+                ('\'', KeyCode::Char(c)) if c.is_ascii_lowercase() => {
+                    self.discard_count();
+                    Action::JumpToMark {
+                        name: c,
+                        line_wise: true,
+                    }
+                }
+                ('`', KeyCode::Char(c)) if c.is_ascii_lowercase() => {
+                    self.discard_count();
+                    Action::JumpToMark {
+                        name: c,
+                        line_wise: false,
+                    }
+                }
+                _ => {
+                    // Unknown sequence: reset everything (vim's behavior
+                    // is to bell-and-cancel).
+                    self.discard_count();
+                    Action::Noop
+                }
             };
         }
 
+        // Digit handling: build up a count prefix.
+        // - `1`-`9` always start/extend a count.
+        // - `0` is `goto-first-column` ONLY when no count is pending;
+        //   after a digit, `0` extends the count (so `10`, `20` etc.).
+        if let KeyCode::Char(c) = key.code {
+            if let Some(d) = c.to_digit(10) {
+                if d == 0 && self.pending_count.is_none() {
+                    return Action::GotoFirstCol;
+                }
+                self.push_digit(d);
+                return Action::Noop;
+            }
+        }
+
         match key.code {
-            KeyCode::Char('h') | KeyCode::Left => Action::MoveCursor(Direction::Left),
-            KeyCode::Char('j') | KeyCode::Down => Action::MoveCursor(Direction::Down),
-            KeyCode::Char('k') | KeyCode::Up => Action::MoveCursor(Direction::Up),
-            KeyCode::Char('l') | KeyCode::Right => Action::MoveCursor(Direction::Right),
+            KeyCode::Char('h') | KeyCode::Left => {
+                Action::MoveCursor(Direction::Left, self.take_count())
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                Action::MoveCursor(Direction::Down, self.take_count())
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                Action::MoveCursor(Direction::Up, self.take_count())
+            }
+            KeyCode::Char('l') | KeyCode::Right => {
+                Action::MoveCursor(Direction::Right, self.take_count())
+            }
             KeyCode::Char('g') => {
                 self.pending = Some('g');
                 Action::Noop
@@ -113,30 +238,92 @@ impl NormalState {
                 self.pending = Some('`');
                 Action::Noop
             }
-            KeyCode::Char('H') => Action::CursorToViewportTop,
-            KeyCode::Char('M') => Action::CursorToViewportMiddle,
-            KeyCode::Char('L') => Action::CursorToViewportBottom,
-            KeyCode::Char('G') => Action::GotoLastRow,
-            KeyCode::Char('0') => Action::GotoFirstCol,
-            KeyCode::Char('$') => Action::GotoLastCol,
-            KeyCode::Char('w') => Action::NextNonEmpty,
-            KeyCode::Char('b') => Action::PrevNonEmpty,
-            KeyCode::Char('{') => Action::BlockJumpUp,
-            KeyCode::Char('}') => Action::BlockJumpDown,
-            KeyCode::Char('i') | KeyCode::Char('a') => Action::ChangeMode(Mode::Insert),
-            KeyCode::Char('o') => Action::ChangeMode(Mode::Insert),
-            KeyCode::Char('v') => Action::ChangeMode(Mode::Visual),
-            KeyCode::Char('V') => Action::ChangeMode(Mode::VisualLine),
-            KeyCode::Char(':') => Action::ChangeMode(Mode::Command),
-            KeyCode::Char('c') => Action::ChangeCell(app.cursor),
-            KeyCode::Char('x') => Action::ClearCell(app.cursor),
-            KeyCode::Char('p') => Action::Paste(app.cursor),
-            KeyCode::Char('P') => Action::PasteBefore(app.cursor),
-            KeyCode::Char('u') => Action::Undo,
-            KeyCode::Char('/') => Action::EnterSearch(SearchDirection::Forward),
-            KeyCode::Char('?') => Action::EnterSearch(SearchDirection::Backward),
-            KeyCode::Char('n') => Action::SearchNext,
-            KeyCode::Char('N') => Action::SearchPrev,
+            KeyCode::Char('H') => {
+                self.discard_count();
+                Action::CursorToViewportTop
+            }
+            KeyCode::Char('M') => {
+                self.discard_count();
+                Action::CursorToViewportMiddle
+            }
+            KeyCode::Char('L') => {
+                self.discard_count();
+                Action::CursorToViewportBottom
+            }
+            KeyCode::Char('G') => match self.pending_count.take() {
+                Some(n) => Action::GotoRow(n),
+                None => Action::GotoLastRow,
+            },
+            KeyCode::Char('$') => {
+                self.discard_count();
+                Action::GotoLastCol
+            }
+            KeyCode::Char('w') => Action::NextNonEmpty(self.take_count()),
+            KeyCode::Char('b') => Action::PrevNonEmpty(self.take_count()),
+            KeyCode::Char('{') => {
+                self.discard_count();
+                Action::BlockJumpUp
+            }
+            KeyCode::Char('}') => {
+                self.discard_count();
+                Action::BlockJumpDown
+            }
+            KeyCode::Char('i') | KeyCode::Char('a') => {
+                self.discard_count();
+                Action::ChangeMode(Mode::Insert)
+            }
+            KeyCode::Char('o') => {
+                self.discard_count();
+                Action::ChangeMode(Mode::Insert)
+            }
+            KeyCode::Char('v') => {
+                self.discard_count();
+                Action::ChangeMode(Mode::Visual)
+            }
+            KeyCode::Char('V') => {
+                self.discard_count();
+                Action::ChangeMode(Mode::VisualLine)
+            }
+            KeyCode::Char(':') => {
+                self.discard_count();
+                Action::ChangeMode(Mode::Command)
+            }
+            KeyCode::Char('c') => {
+                self.discard_count();
+                Action::ChangeCell(app.cursor)
+            }
+            KeyCode::Char('x') => {
+                self.discard_count();
+                Action::ClearCell(app.cursor)
+            }
+            KeyCode::Char('p') => {
+                self.discard_count();
+                Action::Paste(app.cursor)
+            }
+            KeyCode::Char('P') => {
+                self.discard_count();
+                Action::PasteBefore(app.cursor)
+            }
+            KeyCode::Char('u') => {
+                self.discard_count();
+                Action::Undo
+            }
+            KeyCode::Char('/') => {
+                self.discard_count();
+                Action::EnterSearch(SearchDirection::Forward)
+            }
+            KeyCode::Char('?') => {
+                self.discard_count();
+                Action::EnterSearch(SearchDirection::Backward)
+            }
+            KeyCode::Char('n') => {
+                self.discard_count();
+                Action::SearchNext
+            }
+            KeyCode::Char('N') => {
+                self.discard_count();
+                Action::SearchPrev
+            }
             KeyCode::Char('f') => {
                 self.pending_find = Some(FindKind::Forward);
                 Action::Noop
@@ -145,13 +332,36 @@ impl NormalState {
                 self.pending_find = Some(FindKind::Backward);
                 Action::Noop
             }
-            KeyCode::Char(';') => Action::RepeatFind { reversed: false },
-            KeyCode::Char(',') => Action::RepeatFind { reversed: true },
-            KeyCode::Char('*') => Action::SearchCellValue { backward: false },
-            KeyCode::Char('#') => Action::SearchCellValue { backward: true },
-            KeyCode::Tab => Action::JumpForward,
-            KeyCode::Enter => Action::ChangeMode(Mode::Insert),
-            _ => Action::Noop,
+            KeyCode::Char(';') => {
+                self.discard_count();
+                Action::RepeatFind { reversed: false }
+            }
+            KeyCode::Char(',') => {
+                self.discard_count();
+                Action::RepeatFind { reversed: true }
+            }
+            KeyCode::Char('*') => {
+                self.discard_count();
+                Action::SearchCellValue { backward: false }
+            }
+            KeyCode::Char('#') => {
+                self.discard_count();
+                Action::SearchCellValue { backward: true }
+            }
+            KeyCode::Tab => {
+                self.discard_count();
+                Action::JumpForward
+            }
+            KeyCode::Enter => {
+                self.discard_count();
+                Action::ChangeMode(Mode::Insert)
+            }
+            _ => {
+                // Unknown key: throw away any pending count so we don't
+                // silently apply it to the next valid command.
+                self.discard_count();
+                Action::Noop
+            }
         }
     }
 }
@@ -175,19 +385,19 @@ mod tests {
         let mut state = NormalState::new();
         assert_eq!(
             state.handle_key(key(KeyCode::Char('h')), &app),
-            Action::MoveCursor(Direction::Left)
+            Action::MoveCursor(Direction::Left, 1)
         );
         assert_eq!(
             state.handle_key(key(KeyCode::Char('j')), &app),
-            Action::MoveCursor(Direction::Down)
+            Action::MoveCursor(Direction::Down, 1)
         );
         assert_eq!(
             state.handle_key(key(KeyCode::Char('k')), &app),
-            Action::MoveCursor(Direction::Up)
+            Action::MoveCursor(Direction::Up, 1)
         );
         assert_eq!(
             state.handle_key(key(KeyCode::Char('l')), &app),
-            Action::MoveCursor(Direction::Right)
+            Action::MoveCursor(Direction::Right, 1)
         );
     }
 
@@ -225,7 +435,7 @@ mod tests {
         );
         assert_eq!(
             state.handle_key(key(KeyCode::Char('d')), &app),
-            Action::DeleteRow(0)
+            Action::DeleteRow { start: 0, count: 1 }
         );
     }
 
@@ -239,7 +449,7 @@ mod tests {
         );
         assert_eq!(
             state.handle_key(key(KeyCode::Char('y')), &app),
-            Action::YankRow(0)
+            Action::YankRow { start: 0, count: 1 }
         );
     }
 
@@ -345,7 +555,7 @@ mod tests {
         // After the find resolves, hjkl should resume working normally.
         assert_eq!(
             state.handle_key(key(KeyCode::Char('l')), &app),
-            Action::MoveCursor(Direction::Right)
+            Action::MoveCursor(Direction::Right, 1)
         );
     }
 
@@ -362,7 +572,7 @@ mod tests {
         // And it doesn't leave the state stuck.
         assert_eq!(
             state.handle_key(key(KeyCode::Char('h')), &app),
-            Action::MoveCursor(Direction::Left)
+            Action::MoveCursor(Direction::Left, 1)
         );
     }
 
@@ -585,5 +795,229 @@ mod tests {
             state.handle_key(key(KeyCode::Char('A')), &app),
             Action::Noop
         );
+    }
+
+    // --- count prefix tests ----------------------------------------------
+
+    fn feed(state: &mut NormalState, app: &App, keys: &str) -> Action {
+        let mut last = Action::Noop;
+        for c in keys.chars() {
+            last = state.handle_key(key(KeyCode::Char(c)), app);
+        }
+        last
+    }
+
+    #[test]
+    fn single_digit_count_repeats_motion() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            feed(&mut state, &app, "5j"),
+            Action::MoveCursor(Direction::Down, 5)
+        );
+        assert!(state.pending_count.is_none(), "count must be consumed");
+    }
+
+    #[test]
+    fn multi_digit_count_repeats_motion() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            feed(&mut state, &app, "42k"),
+            Action::MoveCursor(Direction::Up, 42)
+        );
+    }
+
+    #[test]
+    fn zero_after_digit_extends_count_not_first_col() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        // `10j` must move down 10, not move to first column then down 1.
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('1')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('0')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('j')), &app),
+            Action::MoveCursor(Direction::Down, 10)
+        );
+    }
+
+    #[test]
+    fn zero_alone_is_first_col() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('0')), &app),
+            Action::GotoFirstCol
+        );
+        assert!(state.pending_count.is_none());
+    }
+
+    #[test]
+    fn count_then_g_jumps_to_specific_row() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(feed(&mut state, &app, "5G"), Action::GotoRow(5));
+    }
+
+    #[test]
+    fn bare_g_still_goes_to_last_row() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('G')), &app),
+            Action::GotoLastRow
+        );
+    }
+
+    #[test]
+    fn count_then_gg_jumps_to_specific_row() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(feed(&mut state, &app, "7gg"), Action::GotoRow(7));
+    }
+
+    #[test]
+    fn bare_gg_still_goes_to_first_row() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(feed(&mut state, &app, "gg"), Action::GotoFirstRow);
+    }
+
+    #[test]
+    fn count_dd_deletes_n_rows() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            feed(&mut state, &app, "3dd"),
+            Action::DeleteRow { start: 0, count: 3 }
+        );
+    }
+
+    #[test]
+    fn count_yy_yanks_n_rows() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            feed(&mut state, &app, "4yy"),
+            Action::YankRow { start: 0, count: 4 }
+        );
+    }
+
+    #[test]
+    fn count_w_and_b() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(feed(&mut state, &app, "3w"), Action::NextNonEmpty(3));
+        assert_eq!(feed(&mut state, &app, "2b"), Action::PrevNonEmpty(2));
+    }
+
+    #[test]
+    fn count_resets_after_action() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        let _ = feed(&mut state, &app, "5j");
+        // Next key without a count should be 1.
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('j')), &app),
+            Action::MoveCursor(Direction::Down, 1)
+        );
+    }
+
+    #[test]
+    fn count_discarded_by_non_counted_command() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        // `5i` enters insert mode and silently drops the count.
+        let action = feed(&mut state, &app, "5i");
+        assert_eq!(action, Action::ChangeMode(Mode::Insert));
+        assert!(state.pending_count.is_none());
+    }
+
+    #[test]
+    fn esc_clears_pending_count_and_op() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        let _ = state.handle_key(key(KeyCode::Char('5')), &app);
+        let _ = state.handle_key(key(KeyCode::Char('d')), &app);
+        assert_eq!(state.pending_count, Some(5));
+        assert_eq!(state.pending, Some('d'));
+        let _ = state.handle_key(key(KeyCode::Esc), &app);
+        assert!(state.pending_count.is_none());
+        assert!(state.pending.is_none());
+    }
+
+    #[test]
+    fn count_is_capped() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        // 10 nines = 9_999_999_999 — must clamp to COUNT_CAP.
+        let huge = "9999999999j";
+        let action = feed(&mut state, &app, huge);
+        assert_eq!(action, Action::MoveCursor(Direction::Down, COUNT_CAP));
+    }
+
+    #[test]
+    fn unknown_key_resets_count() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        let _ = state.handle_key(key(KeyCode::Char('5')), &app);
+        // Some key that isn't bound: '~' is not handled in normal mode.
+        let _ = state.handle_key(key(KeyCode::Char('~')), &app);
+        assert!(state.pending_count.is_none());
+        // Next motion should NOT carry the orphaned 5.
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('j')), &app),
+            Action::MoveCursor(Direction::Down, 1)
+        );
+    }
+
+    #[test]
+    fn ctrl_combo_clears_count() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        let _ = state.handle_key(key(KeyCode::Char('5')), &app);
+        // Ctrl-d shouldn't smuggle the count along.
+        let _ = state.handle_key(ctrl_key('d'), &app);
+        assert!(state.pending_count.is_none());
+    }
+
+    #[test]
+    fn count_carries_through_pending_operator() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        // `5` `d` `d` — count must persist past the pending `d`.
+        let _ = state.handle_key(key(KeyCode::Char('5')), &app);
+        assert_eq!(state.pending_count, Some(5));
+        let _ = state.handle_key(key(KeyCode::Char('d')), &app);
+        assert_eq!(state.pending_count, Some(5), "count survives pending op");
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('d')), &app),
+            Action::DeleteRow { start: 0, count: 5 }
+        );
+    }
+
+    #[test]
+    fn pending_count_accessor() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(state.pending_count(), None);
+        let _ = state.handle_key(key(KeyCode::Char('1')), &app);
+        let _ = state.handle_key(key(KeyCode::Char('2')), &app);
+        assert_eq!(state.pending_count(), Some(12));
+    }
+
+    #[test]
+    fn pending_op_accessor() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(state.pending_op(), None);
+        let _ = state.handle_key(key(KeyCode::Char('d')), &app);
+        assert_eq!(state.pending_op(), Some('d'));
     }
 }

--- a/crates/cell-sheet-tui/src/mode/visual.rs
+++ b/crates/cell-sheet-tui/src/mode/visual.rs
@@ -39,10 +39,10 @@ impl VisualState {
     pub fn handle_key(&self, key: KeyEvent, app: &App) -> Action {
         let (start, end) = self.selection(app.cursor);
         match key.code {
-            KeyCode::Char('h') | KeyCode::Left => Action::MoveCursor(Direction::Left),
-            KeyCode::Char('j') | KeyCode::Down => Action::MoveCursor(Direction::Down),
-            KeyCode::Char('k') | KeyCode::Up => Action::MoveCursor(Direction::Up),
-            KeyCode::Char('l') | KeyCode::Right => Action::MoveCursor(Direction::Right),
+            KeyCode::Char('h') | KeyCode::Left => Action::MoveCursor(Direction::Left, 1),
+            KeyCode::Char('j') | KeyCode::Down => Action::MoveCursor(Direction::Down, 1),
+            KeyCode::Char('k') | KeyCode::Up => Action::MoveCursor(Direction::Up, 1),
+            KeyCode::Char('l') | KeyCode::Right => Action::MoveCursor(Direction::Right, 1),
             KeyCode::Char('c') => Action::ChangeRange { start, end },
             KeyCode::Char('d') => Action::ClearRange { start, end },
             KeyCode::Char('y') => Action::YankRange { start, end },
@@ -91,7 +91,7 @@ mod tests {
         let state = VisualState::new((0, 0), VisualKind::Character);
         assert_eq!(
             state.handle_key(key(KeyCode::Char('j')), &app),
-            Action::MoveCursor(Direction::Down)
+            Action::MoveCursor(Direction::Down, 1)
         );
     }
 

--- a/crates/cell-sheet-tui/src/render/mod.rs
+++ b/crates/cell-sheet-tui/src/render/mod.rs
@@ -22,6 +22,7 @@ pub fn render(
     app: &App,
     selection: Option<(CellPos, CellPos)>,
     insert_cursor: usize,
+    partial_command: Option<&str>,
 ) {
     if app.mode == Mode::Help {
         frame.render_widget(
@@ -97,6 +98,7 @@ pub fn render(
             dirty: app.dirty,
             file_name,
             message: app.status_message.as_deref(),
+            partial_command,
         },
         chunks[2],
     );

--- a/crates/cell-sheet-tui/src/render/status_bar.rs
+++ b/crates/cell-sheet-tui/src/render/status_bar.rs
@@ -15,6 +15,10 @@ pub struct StatusBar<'a> {
     pub dirty: bool,
     pub file_name: Option<&'a str>,
     pub message: Option<&'a str>,
+    /// Vim's `showcmd`-style indicator of the partially-typed command:
+    /// e.g. `5`, `5d`, or `g` while the user is mid-sequence. Rendered
+    /// to the right of the file info, before the row/col readout.
+    pub partial_command: Option<&'a str>,
 }
 
 impl<'a> Widget for StatusBar<'a> {
@@ -88,6 +92,24 @@ impl<'a> Widget for StatusBar<'a> {
         let right_x = area.x + area.width.saturating_sub(right.len() as u16);
         if right_x > info_x + file_info.len() as u16 {
             buf.set_string(right_x, area.y, &right, style);
+        }
+
+        // Vim's `showcmd`: render any partial command (count + op) just
+        // before the right-side readout. A small bold accent makes it
+        // visually distinct from the file info on the left.
+        if let Some(cmd) = self.partial_command {
+            if !cmd.is_empty() {
+                let cmd_str = format!(" {} ", cmd);
+                let cmd_w = cmd_str.len() as u16;
+                let cmd_x = right_x.saturating_sub(cmd_w + 1);
+                if cmd_x > info_x + file_info.len() as u16 {
+                    let cmd_style = Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::White)
+                        .add_modifier(Modifier::BOLD);
+                    buf.set_string(cmd_x, area.y, &cmd_str, cmd_style);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #21. Adds vim-style `[count]` prefix to normal mode motions and operators.

- `5j` / `10k` / `3h` / `4l` repeat hjkl moves with one bounds-clamped jump and a single viewport update.
- `5G` / `7gg` jump to row N (1-indexed); bare `G` / `gg` keep their first-/last-row meaning. `GotoRow` records into the jump list, so `Ctrl-o` returns you.
- `3dd` / `4yy` operate on N rows in one pass with a single atomic undo entry. Multi-row yanks land in a new line-wise `Register::Rows` so `p` pastes the whole block below, `P` above.
- `2w` / `3b` hop N non-empty cells.
- `0` alone still goes to first column; only after a non-zero digit does `0` extend the count (so `10j` really moves 10 rows).
- The pending count + pending operator render in the status line as you type (vim's `showcmd`).
- `Esc` cancels a half-typed `5d…`. Counts saturate at 1,000,000 so a stray `9999999999G` cannot wedge the loop.

### Architecture

Counts are encoded as data on the actions that respect them rather than via a generic `Repeat` wrapper:

- `Action::MoveCursor(Direction, usize)`, `NextNonEmpty(usize)`, `PrevNonEmpty(usize)`
- `Action::GotoRow(usize)` for `[count]G` / `[count]gg`
- `Action::DeleteRow { start, count }` / `YankRow { start, count }`

`NormalState` owns the `pending_count: Option<usize>` buffer. `take_count()` consumes it (defaulting to 1) when an action fires; `discard_count()` drops it for non-counted commands like `i`, `:`, `Ctrl-d`. The count survives the pending-operator transition (`5` -> `d` -> `d` -> `DeleteRow{count: 5}`).

### Help and changelog

- New `[count]` entry in `help/entries.rs`, plus updated summaries on h/j/k/l, G, gg, w, b, dd, yy.
- `CHANGELOG.md` Unreleased / Added entry referencing #21.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --all-features`
- [x] `RUSTFLAGS=-Dwarnings cargo test` — 318 passed (192 tui + 107 core + 14 headless + 5 io)
- [x] 35 new tests cover digit accumulation, the `0`-vs-count disambiguation, count persistence across pending operators, count discard for non-counted commands, the saturating cap, app-level multi-row delete/yank/paste, jump-list integration for `GotoRow`, and bounds clamping for cursor moves.
- [x] Manual smoke: `5j`, `10G`, `5gg`, `3dd`, `3yy`+`p`, `2w`, `0`, `10j`, status line shows `5d` mid-sequence, `Esc` clears it.

Made with [Cursor](https://cursor.com)