### PR TITLE
feat: add criterion benchmark suite for cell-sheet-core (closes #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace --all-features
+
+  bench:
+    name: Bench (compile-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo bench --no-run -p cell-sheet-core

--- a/BENCH.md
+++ b/BENCH.md
@@ -1,0 +1,39 @@
+# Benchmarks
+
+Benchmarks live in `crates/cell-sheet-core/benches/core.rs` and use
+[criterion](https://github.com/bheisler/criterion.rs).
+
+## Running
+
+```sh
+# Full suite
+cargo bench -p cell-sheet-core
+
+# Single benchmark by name
+cargo bench -p cell-sheet-core -- csv_load_100k
+```
+
+HTML reports are written to `target/criterion/` after each run.
+
+## Suite
+
+| Benchmark | What it measures |
+|---|---|
+| `csv_load_100k` | `read_csv` on a 100 000-row × 26-col in-memory CSV |
+| `formula_recalc_10k` | `recalculate` with 10 000 dirty formula cells (each `=A{n}+1`) |
+| `mark_dirty_chain` | BFS dirty propagation on a 1 000-cell linear dependency chain |
+| `recalculate_wide_dag` | Topological sort on 1 000 cells all referencing a single source cell |
+| `range_sum_10k` | `SUM(A1:A10000)` parse and evaluation |
+
+## Results
+
+Fill in this table locally after running the suite. Include your machine
+spec and the date so results are comparable across PRs.
+
+| Benchmark | Mean | Machine | Date |
+|---|---|---|---|
+| csv_load_100k | | | |
+| formula_recalc_10k | | | |
+| mark_dirty_chain | | | |
+| recalculate_wide_dag | | | |
+| range_sum_10k | | | |

--- a/BENCH.md
+++ b/BENCH.md
@@ -20,7 +20,7 @@ HTML reports are written to `target/criterion/` after each run.
 | Benchmark | What it measures |
 |---|---|
 | `csv_load_100k` | `read_csv` on a 100 000-row × 26-col in-memory CSV |
-| `formula_recalc_10k` | `recalculate` with 10 000 dirty formula cells (each `=A{n}+1`) |
+| `formula_recalc_10k` | `recalculate` on 10 000 independent formula cells (each `=A{n}+1`); stresses topological sort and eval throughput |
 | `mark_dirty_chain` | BFS dirty propagation on a 1 000-cell linear dependency chain |
 | `recalculate_wide_dag` | Topological sort on 1 000 cells all referencing a single source cell |
 | `range_sum_10k` | `SUM(A1:A10000)` parse and evaluation |
@@ -32,8 +32,8 @@ spec and the date so results are comparable across PRs.
 
 | Benchmark | Mean | Machine | Date |
 |---|---|---|---|
-| csv_load_100k | | | |
-| formula_recalc_10k | | | |
-| mark_dirty_chain | | | |
-| recalculate_wide_dag | | | |
-| range_sum_10k | | | |
+| csv_load_100k | 444 ms | Apple M4 Pro / macOS 26.4.1 | 2026-04-28 |
+| formula_recalc_10k | 5.78 ms | Apple M4 Pro / macOS 26.4.1 | 2026-04-28 |
+| mark_dirty_chain | 74.9 µs | Apple M4 Pro / macOS 26.4.1 | 2026-04-28 |
+| recalculate_wide_dag | 438 µs | Apple M4 Pro / macOS 26.4.1 | 2026-04-28 |
+| range_sum_10k | 594 µs | Apple M4 Pro / macOS 26.4.1 | 2026-04-28 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   `csv_load_100k`, `formula_recalc_10k`, `mark_dirty_chain`,
   `recalculate_wide_dag`, `range_sum_10k`. CI compiles the suite on every
   push to prevent API-breakage regressions. See `BENCH.md` for how to run
-  and record results. Closes #7.
+  and record results
+  ([#61](https://github.com/garritfra/cell/pull/61)).
 
 ## 0.3.1 (2026-04-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   file content, and `:set delimiter=X` ex-command. Writing with a non-standard
   delimiter to a `.csv` or `.tsv` file shows a warning; use `:w!` to override.
   Resolves #20.
+- Criterion benchmark suite in `cell-sheet-core` (`cargo bench -p cell-sheet-core`):
+  `csv_load_100k`, `formula_recalc_10k`, `mark_dirty_chain`,
+  `recalculate_wide_dag`, `range_sum_10k`. CI compiles the suite on every
+  push to prevent API-breakage regressions. See `BENCH.md` for how to run
+  and record results. Closes #7.
 
 ## 0.3.1 (2026-04-28)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -143,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,9 +173,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cell-sheet-core"
 version = "0.3.1"
 dependencies = [
+ "criterion",
  "csv",
  "pretty_assertions",
 ]
@@ -181,6 +213,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -261,6 +320,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +405,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -483,6 +608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +676,17 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -630,6 +772,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -856,12 +1007,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -983,6 +1150,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1278,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -1135,13 +1330,33 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1217,6 +1432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1505,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1518,6 +1748,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,7 +1787,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1595,6 +1835,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1701,6 +1951,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2047,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1902,6 +2171,26 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/cell-sheet-core/Cargo.toml
+++ b/crates/cell-sheet-core/Cargo.toml
@@ -14,3 +14,8 @@ csv = "1.3"
 
 [dev-dependencies]
 pretty_assertions = "1"
+criterion = "0.8"
+
+[[bench]]
+name = "core"
+harness = false

--- a/crates/cell-sheet-core/benches/core.rs
+++ b/crates/cell-sheet-core/benches/core.rs
@@ -1,23 +1,117 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::hint::black_box;
+use std::io::Cursor;
 
-fn bench_csv_load_100k(_c: &mut Criterion) {
-    todo!()
+use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use cell_sheet_core::io::csv::read_csv;
+use cell_sheet_core::model::{col_index_to_label, Sheet};
+
+fn bench_csv_load_100k(c: &mut Criterion) {
+    let mut csv = String::new();
+    for row in 0u64..100_000 {
+        for col in 0u64..26 {
+            if col > 0 {
+                csv.push(',');
+            }
+            csv.push_str(&(row * 26 + col).to_string());
+        }
+        csv.push('\n');
+    }
+    let csv_bytes = csv.into_bytes();
+
+    c.bench_function("csv_load_100k", |b| {
+        b.iter(|| {
+            let reader = Cursor::new(black_box(&csv_bytes));
+            black_box(read_csv(reader, b',').unwrap())
+        })
+    });
 }
 
-fn bench_formula_recalc_10k(_c: &mut Criterion) {
-    todo!()
+fn bench_formula_recalc_10k(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    for row in 0..10_000usize {
+        sheet.set_cell((row, 0), &row.to_string());
+        let formula = format!("=A{}+1", row + 1);
+        set_formula(&mut sheet, &mut deps, (row, 1), &formula);
+    }
+
+    c.bench_function("formula_recalc_10k", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| {
+                recalculate(&mut s, &d);
+                black_box(())
+            },
+            BatchSize::PerIteration,
+        )
+    });
 }
 
-fn bench_mark_dirty_chain(_c: &mut Criterion) {
-    todo!()
+fn bench_mark_dirty_chain(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    sheet.set_cell((0, 0), "1");
+    for col in 1..1000usize {
+        let prev_label = col_index_to_label(col - 1);
+        let formula = format!("={}1+1", prev_label);
+        set_formula(&mut sheet, &mut deps, (0, col), &formula);
+    }
+    // Clear dirty flags so mark_dirty has real BFS work to do on every iteration.
+    // Without this, cells are already dirty=true from set_formula and mark_dirty
+    // would short-circuit immediately.
+    recalculate(&mut sheet, &deps);
+
+    c.bench_function("mark_dirty_chain", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| {
+                mark_dirty(&mut s, &d, (0, 0));
+                black_box(())
+            },
+            BatchSize::PerIteration,
+        )
+    });
 }
 
-fn bench_recalculate_wide_dag(_c: &mut Criterion) {
-    todo!()
+fn bench_recalculate_wide_dag(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    sheet.set_cell((0, 0), "1");
+    for col in 1..=1000usize {
+        set_formula(&mut sheet, &mut deps, (0, col), "=A1+1");
+    }
+
+    c.bench_function("recalculate_wide_dag", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| {
+                recalculate(&mut s, &d);
+                black_box(())
+            },
+            BatchSize::PerIteration,
+        )
+    });
 }
 
-fn bench_range_sum_10k(_c: &mut Criterion) {
-    todo!()
+fn bench_range_sum_10k(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    for row in 0..10_000usize {
+        sheet.set_cell((row, 0), &row.to_string());
+    }
+    set_formula(&mut sheet, &mut deps, (0, 1), "=SUM(A1:A10000)");
+
+    c.bench_function("range_sum_10k", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| {
+                recalculate(&mut s, &d);
+                black_box(())
+            },
+            BatchSize::PerIteration,
+        )
+    });
 }
 
 criterion_group!(

--- a/crates/cell-sheet-core/benches/core.rs
+++ b/crates/cell-sheet-core/benches/core.rs
@@ -1,0 +1,31 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_csv_load_100k(_c: &mut Criterion) {
+    todo!()
+}
+
+fn bench_formula_recalc_10k(_c: &mut Criterion) {
+    todo!()
+}
+
+fn bench_mark_dirty_chain(_c: &mut Criterion) {
+    todo!()
+}
+
+fn bench_recalculate_wide_dag(_c: &mut Criterion) {
+    todo!()
+}
+
+fn bench_range_sum_10k(_c: &mut Criterion) {
+    todo!()
+}
+
+criterion_group!(
+    benches,
+    bench_csv_load_100k,
+    bench_formula_recalc_10k,
+    bench_mark_dirty_chain,
+    bench_recalculate_wide_dag,
+    bench_range_sum_10k,
+);
+criterion_main!(benches);

--- a/crates/cell-sheet-core/src/formula/deps.rs
+++ b/crates/cell-sheet-core/src/formula/deps.rs
@@ -5,6 +5,7 @@ use crate::formula::eval;
 use crate::formula::parser;
 use crate::model::{CellError, CellPos, CellValue, Sheet};
 
+#[derive(Debug, Clone)]
 pub struct DepGraph {
     pub dependents: HashMap<CellPos, HashSet<CellPos>>,
     pub dependencies: HashMap<CellPos, HashSet<CellPos>>,

--- a/crates/cell-sheet-core/src/model.rs
+++ b/crates/cell-sheet-core/src/model.rs
@@ -60,6 +60,7 @@ pub struct Cell {
     pub dirty: bool,
 }
 
+#[derive(Debug, Clone)]
 pub struct Sheet {
     pub cells: HashMap<CellPos, Cell>,
     pub col_widths: Vec<u16>,

--- a/docs/superpowers/plans/2026-04-28-criterion-benchmarks.md
+++ b/docs/superpowers/plans/2026-04-28-criterion-benchmarks.md
@@ -1,0 +1,468 @@
+# Criterion Benchmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a criterion benchmark suite to `cell-sheet-core` covering CSV loading, formula recalculation, BFS dirty propagation, topological-sort throughput, and range evaluation.
+
+**Architecture:** Single `benches/core.rs` file with five benchmarks registered in one `criterion_group!`. Setup state is isolated per iteration using `iter_batched`. CI compiles the benchmarks but does not run them. `Sheet`, `Cell`, and `DepGraph` get `#[derive(Clone)]` so benchmarks can clone pre-built state in setup closures.
+
+**Tech Stack:** Rust, criterion 0.8, existing `cell-sheet-core` public API (`read_csv`, `set_formula`, `mark_dirty`, `recalculate`).
+
+---
+
+## File map
+
+| File | Action |
+|---|---|
+| `crates/cell-sheet-core/src/model.rs` | Add `Clone` to `Cell` and `Sheet` |
+| `crates/cell-sheet-core/src/formula/deps.rs` | Add `Clone` to `DepGraph` |
+| `crates/cell-sheet-core/Cargo.toml` | Add `criterion` dev-dep + `[[bench]]` entry |
+| `crates/cell-sheet-core/benches/core.rs` | New — all five benchmarks |
+| `.github/workflows/ci.yml` | New `bench` job: `cargo bench --no-run -p cell-sheet-core` |
+| `BENCH.md` | New — how to run, descriptions, results table |
+| `CHANGELOG.md` | Entry under `## Unreleased > Added` |
+
+---
+
+## Task 1: Add `Clone` to `Sheet`, `Cell`, and `DepGraph`
+
+**Files:**
+- Modify: `crates/cell-sheet-core/src/model.rs`
+- Modify: `crates/cell-sheet-core/src/formula/deps.rs`
+
+- [ ] **Step 1: Add `Clone` to `Cell` in `model.rs`**
+
+  Find the `Cell` struct (around line 56). Change:
+
+  ```rust
+  #[derive(Debug, Clone)]
+  pub struct Cell {
+  ```
+
+  It currently has `#[derive(Debug, Clone)]` — confirm it already does. If `Clone` is missing, add it. Run:
+
+  ```sh
+  grep -n 'struct Cell' crates/cell-sheet-core/src/model.rs
+  grep -n 'struct Sheet' crates/cell-sheet-core/src/model.rs
+  grep -n 'struct DepGraph' crates/cell-sheet-core/src/formula/deps.rs
+  ```
+
+  Then check each `#[derive(...)]` line above those structs and add `Clone` wherever it is absent.
+
+  The correct derive lines after the change:
+
+  ```rust
+  // model.rs — Cell
+  #[derive(Debug, Clone)]
+  pub struct Cell { ... }
+
+  // model.rs — Sheet
+  #[derive(Debug, Clone)]
+  pub struct Sheet { ... }
+
+  // deps.rs — DepGraph
+  #[derive(Debug, Clone)]
+  pub struct DepGraph { ... }
+  ```
+
+  `DepGraph` currently has no `#[derive]` at all — add the attribute above its `pub struct DepGraph` line:
+
+  ```rust
+  #[derive(Debug, Clone)]
+  pub struct DepGraph {
+      pub dependents: HashMap<CellPos, HashSet<CellPos>>,
+      pub dependencies: HashMap<CellPos, HashSet<CellPos>>,
+  }
+  ```
+
+- [ ] **Step 2: Verify compilation**
+
+  ```sh
+  cargo build -p cell-sheet-core
+  ```
+
+  Expected: compiles with no errors or warnings.
+
+- [ ] **Step 3: Run tests to confirm nothing broke**
+
+  ```sh
+  cargo test -p cell-sheet-core
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+  ```sh
+  git add crates/cell-sheet-core/src/model.rs \
+          crates/cell-sheet-core/src/formula/deps.rs
+  git commit -m "chore: derive Clone for Sheet, Cell, DepGraph (needed for benches)"
+  ```
+
+---
+
+## Task 2: Add criterion dependency and create the bench skeleton
+
+**Files:**
+- Modify: `crates/cell-sheet-core/Cargo.toml`
+- Create: `crates/cell-sheet-core/benches/core.rs`
+
+- [ ] **Step 1: Add criterion to `Cargo.toml`**
+
+  In `crates/cell-sheet-core/Cargo.toml`, add to `[dev-dependencies]`:
+
+  ```toml
+  criterion = "0.8"
+  ```
+
+  And add the bench entry (at the bottom of the file, after `[dev-dependencies]`):
+
+  ```toml
+  [[bench]]
+  name = "core"
+  harness = false
+  ```
+
+  The `harness = false` is required because criterion provides its own `main`.
+
+- [ ] **Step 2: Create `benches/core.rs` with skeleton**
+
+  Create `crates/cell-sheet-core/benches/core.rs`:
+
+  ```rust
+  use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+  use std::io::Cursor;
+
+  use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+  use cell_sheet_core::io::csv::read_csv;
+  use cell_sheet_core::model::{col_index_to_label, Sheet};
+
+  fn bench_csv_load_100k(c: &mut Criterion) {
+      todo!()
+  }
+
+  fn bench_formula_recalc_10k(c: &mut Criterion) {
+      todo!()
+  }
+
+  fn bench_mark_dirty_chain(c: &mut Criterion) {
+      todo!()
+  }
+
+  fn bench_recalculate_wide_dag(c: &mut Criterion) {
+      todo!()
+  }
+
+  fn bench_range_sum_10k(c: &mut Criterion) {
+      todo!()
+  }
+
+  criterion_group!(
+      benches,
+      bench_csv_load_100k,
+      bench_formula_recalc_10k,
+      bench_mark_dirty_chain,
+      bench_recalculate_wide_dag,
+      bench_range_sum_10k,
+  );
+  criterion_main!(benches);
+  ```
+
+- [ ] **Step 3: Confirm the skeleton compiles (not runs)**
+
+  ```sh
+  cargo bench --no-run -p cell-sheet-core
+  ```
+
+  Expected: compiles successfully. (It will panic at runtime because of `todo!()`, but compile is all we need to verify the wiring.)
+
+- [ ] **Step 4: Commit**
+
+  ```sh
+  git add crates/cell-sheet-core/Cargo.toml \
+          crates/cell-sheet-core/benches/core.rs
+  git commit -m "chore: add criterion dependency and bench skeleton"
+  ```
+
+---
+
+## Task 3: Implement all five benchmarks
+
+**Files:**
+- Modify: `crates/cell-sheet-core/benches/core.rs`
+
+Replace each `todo!()` stub with the implementation below. Replace the entire file with:
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use std::io::Cursor;
+
+use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use cell_sheet_core::io::csv::read_csv;
+use cell_sheet_core::model::{col_index_to_label, Sheet};
+
+fn bench_csv_load_100k(c: &mut Criterion) {
+    let mut csv = String::new();
+    for row in 0u64..100_000 {
+        for col in 0u64..26 {
+            if col > 0 {
+                csv.push(',');
+            }
+            csv.push_str(&(row * 26 + col).to_string());
+        }
+        csv.push('\n');
+    }
+    let csv_bytes = csv.into_bytes();
+
+    c.bench_function("csv_load_100k", |b| {
+        b.iter(|| {
+            let reader = Cursor::new(black_box(&csv_bytes));
+            black_box(read_csv(reader, b',').unwrap())
+        })
+    });
+}
+
+fn bench_formula_recalc_10k(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    for row in 0..10_000usize {
+        sheet.set_cell((row, 0), &row.to_string());
+        let formula = format!("=A{}+1", row + 1);
+        set_formula(&mut sheet, &mut deps, (row, 1), &formula);
+    }
+
+    c.bench_function("formula_recalc_10k", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| black_box(recalculate(&mut s, &d)),
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+fn bench_mark_dirty_chain(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    sheet.set_cell((0, 0), "1");
+    for col in 1..1000usize {
+        let prev_label = col_index_to_label(col - 1);
+        let formula = format!("={}1+1", prev_label);
+        set_formula(&mut sheet, &mut deps, (0, col), &formula);
+    }
+    // Clear dirty flags so mark_dirty has real BFS work to do on every iteration.
+    // Without this, cells are already dirty=true from set_formula and mark_dirty
+    // would short-circuit immediately.
+    recalculate(&mut sheet, &deps);
+
+    c.bench_function("mark_dirty_chain", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| black_box(mark_dirty(&mut s, &d, (0, 0))),
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+fn bench_recalculate_wide_dag(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    sheet.set_cell((0, 0), "1");
+    for col in 1..=1000usize {
+        set_formula(&mut sheet, &mut deps, (0, col), "=A1+1");
+    }
+
+    c.bench_function("recalculate_wide_dag", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| black_box(recalculate(&mut s, &d)),
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+fn bench_range_sum_10k(c: &mut Criterion) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    for row in 0..10_000usize {
+        sheet.set_cell((row, 0), &row.to_string());
+    }
+    set_formula(&mut sheet, &mut deps, (0, 1), "=SUM(A1:A10000)");
+
+    c.bench_function("range_sum_10k", |b| {
+        b.iter_batched(
+            || (sheet.clone(), deps.clone()),
+            |(mut s, d)| black_box(recalculate(&mut s, &d)),
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_csv_load_100k,
+    bench_formula_recalc_10k,
+    bench_mark_dirty_chain,
+    bench_recalculate_wide_dag,
+    bench_range_sum_10k,
+);
+criterion_main!(benches);
+```
+
+- [ ] **Step 1: Write the benchmark implementations** (replace the whole file as above)
+
+- [ ] **Step 2: Check formatting and lints**
+
+  ```sh
+  cargo fmt --all
+  cargo clippy --workspace --all-targets --all-features
+  ```
+
+  Expected: no errors, no warnings.
+
+- [ ] **Step 3: Run the benchmark suite**
+
+  ```sh
+  cargo bench -p cell-sheet-core
+  ```
+
+  Expected: all five benchmarks complete and print timing output similar to:
+
+  ```
+  csv_load_100k           time:   [...]
+  formula_recalc_10k      time:   [...]
+  mark_dirty_chain        time:   [...]
+  recalculate_wide_dag    time:   [...]
+  range_sum_10k           time:   [...]
+  ```
+
+  No panics, no `#[...]` errors. If criterion reports a warming-up message that is normal.
+
+- [ ] **Step 4: Commit**
+
+  ```sh
+  git add crates/cell-sheet-core/benches/core.rs
+  git commit -m "feat: add criterion benchmark suite for cell-sheet-core"
+  ```
+
+---
+
+## Task 4: Update CI to compile benchmarks
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a `bench` job**
+
+  In `.github/workflows/ci.yml`, append the following job after the `build` job:
+
+  ```yaml
+    bench:
+      name: Bench (compile-only)
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v5
+        - uses: dtolnay/rust-toolchain@stable
+        - uses: Swatinem/rust-cache@v2
+        - run: cargo bench --no-run -p cell-sheet-core
+  ```
+
+  The indentation must match the other jobs (two-space indent for the job name, four-space for `steps`, six-space for each step).
+
+- [ ] **Step 2: Verify the YAML is valid**
+
+  ```sh
+  cat .github/workflows/ci.yml
+  ```
+
+  Confirm the file is well-formed by eye — four peer-level jobs (`fmt`, `clippy`, `test`, `build`, `bench`) under `jobs:`.
+
+- [ ] **Step 3: Commit**
+
+  ```sh
+  git add .github/workflows/ci.yml
+  git commit -m "ci: compile cell-sheet-core benchmarks in CI"
+  ```
+
+---
+
+## Task 5: Write BENCH.md, update CHANGELOG, and verify
+
+**Files:**
+- Create: `BENCH.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Create `BENCH.md`**
+
+  Create at repo root:
+
+  ````markdown
+  # Benchmarks
+
+  Benchmarks live in `crates/cell-sheet-core/benches/core.rs` and use
+  [criterion](https://github.com/bheisler/criterion.rs).
+
+  ## Running
+
+  ```sh
+  # Full suite
+  cargo bench -p cell-sheet-core
+
+  # Single benchmark by name
+  cargo bench -p cell-sheet-core -- csv_load_100k
+  ```
+
+  HTML reports are written to `target/criterion/` after each run.
+
+  ## Suite
+
+  | Benchmark | What it measures |
+  |---|---|
+  | `csv_load_100k` | `read_csv` on a 100 000-row × 26-col in-memory CSV |
+  | `formula_recalc_10k` | `recalculate` with 10 000 dirty formula cells (each `=A{n}+1`) |
+  | `mark_dirty_chain` | BFS dirty propagation on a 1 000-cell linear dependency chain |
+  | `recalculate_wide_dag` | Topological sort on 1 000 cells all referencing a single source cell |
+  | `range_sum_10k` | `SUM(A1:A10000)` parse and evaluation |
+
+  ## Results
+
+  Fill in this table locally after running the suite. Include your machine
+  spec and the date so results are comparable across PRs.
+
+  | Benchmark | Mean | Machine | Date |
+  |---|---|---|---|
+  | csv_load_100k | | | |
+  | formula_recalc_10k | | | |
+  | mark_dirty_chain | | | |
+  | recalculate_wide_dag | | | |
+  | range_sum_10k | | | |
+  ````
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+  Under `## Unreleased`, inside the `### Added` block, append:
+
+  ```markdown
+  - Criterion benchmark suite in `cell-sheet-core` (`cargo bench -p cell-sheet-core`):
+    `csv_load_100k`, `formula_recalc_10k`, `mark_dirty_chain`,
+    `recalculate_wide_dag`, `range_sum_10k`. CI compiles the suite on every
+    push to prevent API-breakage regressions. See `BENCH.md` for how to run
+    and record results. Closes #7.
+  ```
+
+- [ ] **Step 3: Final verification**
+
+  ```sh
+  cargo fmt --all
+  cargo clippy --workspace --all-targets --all-features
+  cargo test
+  cargo bench --no-run -p cell-sheet-core
+  ```
+
+  All four must pass clean with no warnings.
+
+- [ ] **Step 4: Commit**
+
+  ```sh
+  git add BENCH.md CHANGELOG.md
+  git commit -m "docs: add BENCH.md and changelog entry for benchmark suite (closes #7)"
+  ```

--- a/docs/superpowers/specs/2026-04-28-criterion-benchmarks-design.md
+++ b/docs/superpowers/specs/2026-04-28-criterion-benchmarks-design.md
@@ -1,0 +1,94 @@
+# Design: criterion benchmarks for cell-sheet-core
+
+**Date:** 2026-04-28  
+**Issue:** [#7](https://github.com/garritfra/cell/issues/7)  
+**Status:** Approved
+
+## Problem
+
+Without performance numbers there is no way to detect regressions or identify
+bottlenecks as the sheet grows. The issue asks for a baseline benchmark suite
+covering the core hotspots: CSV loading, formula recalculation, dependency-graph
+BFS propagation, topological-sort throughput, and range expansion.
+
+## Approach
+
+Single benchmark file using `criterion` — the de-facto Rust benchmark harness.
+All five benchmarks live in `crates/cell-sheet-core/benches/core.rs` registered
+in one `criterion_group!`. No library source changes; the existing public API
+(`read_csv`, `set_formula`, `mark_dirty`, `recalculate`) is sufficient.
+
+CI compiles the benchmarks (`cargo bench --no-run -p cell-sheet-core`) but does
+not run them — timing varies across machines and is not a reliable CI gate.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `crates/cell-sheet-core/Cargo.toml` | Add `criterion` dev-dependency; add `[[bench]]` entry |
+| `crates/cell-sheet-core/benches/core.rs` | New — all five benchmarks |
+| `.github/workflows/ci.yml` | Add `cargo bench --no-run -p cell-sheet-core` step |
+| `BENCH.md` | New — how to run, what each bench measures, results table |
+| `CHANGELOG.md` | Entry under `## Unreleased > Added` |
+
+## Benchmarks
+
+### `csv_load_100k`
+
+Measures `read_csv` on a 100k-row × 26-col CSV built entirely in memory.
+Setup constructs the CSV bytes once; each criterion iteration passes a
+`std::io::Cursor` to `read_csv`. Isolates the CSV parsing and `Sheet`
+construction path.
+
+### `formula_recalc_10k`
+
+Measures end-to-end `set_formula` + `mark_dirty` + `recalculate` for 10k
+formula cells each referencing the cell to their left
+(`B1=A1+1`, `B2=A2+1`, …). Setup pre-populates column A with plain numeric
+values. Each iteration sets all formula cells and recalculates.
+
+### `mark_dirty_chain`
+
+Measures BFS dirty-propagation depth on a linear dependency chain 1000 cells
+deep (`B1=A1+1`, `C1=B1+1`, …, 1000 nodes). Setup builds the chain once.
+Each iteration touches `A1` (sets it to a new value) and calls `mark_dirty`.
+
+### `recalculate_wide_dag`
+
+Measures topological-sort throughput on a wide fan-in DAG: 1000 cells in row 1
+all referencing `A1`. Setup builds the DAG once. Each iteration updates `A1`
+and calls `recalculate`.
+
+### `range_sum_10k`
+
+Measures `SUM(A1:A10000)` parse and evaluation. Setup populates 10k numeric
+values in column A and sets `B1` to `=SUM(A1:A10000)`. Each iteration calls
+`recalculate`.
+
+## Implementation notes
+
+- Use `criterion::black_box` on all inputs/outputs to prevent dead-code
+  elimination.
+- Use `iter_batched` (or `iter_with_setup`) so setup cost is excluded from
+  measurements.
+- `criterion` requires a `harness = false` flag in the `[[bench]]` entry
+  because it provides its own `main`.
+
+## BENCH.md content
+
+Short reference document at the repo root:
+
+- How to run the full suite: `cargo bench -p cell-sheet-core`
+- How to run one benchmark: `cargo bench -p cell-sheet-core -- csv_load_100k`
+- One-sentence description of each benchmark
+- Results table with columns: `Benchmark | Mean | Machine | Date` — left empty
+  for contributors to fill in locally
+
+## Acceptance criteria
+
+- `cargo bench -p cell-sheet-core` runs all five benchmarks cleanly.
+- `cargo bench --no-run -p cell-sheet-core` added to CI and passes.
+- `BENCH.md` committed.
+- `CHANGELOG.md` updated.
+- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features`,
+  and `cargo test` all pass.


### PR DESCRIPTION
## Summary

- Adds five criterion benchmarks to `cell-sheet-core`: `csv_load_100k`, `formula_recalc_10k`, `mark_dirty_chain`, `recalculate_wide_dag`, `range_sum_10k`
- CI compile-only check added (`cargo bench --no-run -p cell-sheet-core`) so benchmark code can't silently bitrot
- `BENCH.md` committed with baseline numbers (Apple M4 Pro, 2026-04-28) so future PRs have a comparison point

## Details

- `#[derive(Clone)]` added to `Sheet` and `DepGraph` (needed by `iter_batched` setup closures)
- Uses `BatchSize::PerIteration` to give each iteration a fresh clone of pre-built state, correctly isolating mutations (dirty flags, evaluated values) between runs
- `bench_mark_dirty_chain` calls `recalculate` once before the loop to clear dirty flags — without it `mark_dirty`'s BFS short-circuits on the `if !c.dirty` guard and the bench would be a no-op

## Test Plan

- [ ] `cargo bench -p cell-sheet-core` — all five benchmarks run and print timings
- [ ] `cargo bench --no-run -p cell-sheet-core` — compiles cleanly under `RUSTFLAGS=-Dwarnings`
- [ ] `cargo test` — all existing tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features` — no warnings

Closes #7.

Made with [Cursor](https://cursor.com)