### PR TITLE
feat: command-mode history (arrow up/down to cycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Command-mode history: in the `:` prompt, `↑` / `↓` cycle through
+  previously executed commands (oldest to newest). The in-progress input is
+  saved and restored when stepping past the newest entry. History is
+  session-only and consecutive duplicates are skipped
+  ([#62](https://github.com/garritfra/cell/pull/62))
 - Vim-style numeric count prefix in normal mode: type digits before a motion or
   operator to repeat or scale it. `5j` moves five rows down, `10G` jumps to row
   10, `5gg` jumps to row 5 from the top, `3dd` deletes three rows (line-wise,

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -48,6 +48,14 @@ pub struct App {
     pub jump_list: Vec<CellPos>,
     pub jump_idx: usize,
     pub last_visual: Option<LastVisual>,
+    /// Previously executed colon commands, oldest first.
+    pub command_history: Vec<String>,
+    /// Index into `command_history` while the user is cycling with ↑/↓.
+    /// `None` means the user is not currently browsing history.
+    pub command_history_idx: Option<usize>,
+    /// The in-progress command line saved when the user first presses ↑,
+    /// restored when they press ↓ past the most recent entry.
+    pub command_history_scratch: String,
 }
 
 const JUMP_LIST_CAP: usize = 100;
@@ -88,6 +96,9 @@ impl App {
             jump_list: Vec::new(),
             jump_idx: 0,
             last_visual: None,
+            command_history: Vec::new(),
+            command_history_idx: None,
+            command_history_scratch: String::new(),
         }
     }
 
@@ -169,6 +180,8 @@ impl App {
                 if mode == Mode::Command {
                     self.command_kind = CommandKind::Colon;
                     self.command_line.clear();
+                    self.command_history_idx = None;
+                    self.command_history_scratch.clear();
                 }
                 self.mode = mode;
             }
@@ -375,6 +388,8 @@ impl App {
                     SearchDirection::Backward => CommandKind::Question,
                 };
                 self.search_origin = Some(self.cursor);
+                self.command_history_idx = None;
+                self.command_history_scratch.clear();
                 self.mode = Mode::Command;
             }
             Action::SearchIncremental { pattern, direction } => {

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -347,6 +347,17 @@ fn run_loop(
                                 let kind = app.command_kind;
                                 let is_wq =
                                     matches!(kind, CommandKind::Colon) && cmd.trim() == "wq";
+                                // Push non-empty colon commands to history,
+                                // avoiding consecutive duplicates.
+                                if matches!(kind, CommandKind::Colon) && !cmd.trim().is_empty() {
+                                    if app.command_history.last().map(|s| s.as_str())
+                                        != Some(cmd.trim())
+                                    {
+                                        app.command_history.push(cmd.trim().to_string());
+                                    }
+                                }
+                                app.command_history_idx = None;
+                                app.command_history_scratch.clear();
                                 let parsed = submit(kind, &cmd);
                                 app.command_line.clear();
                                 if is_wq {
@@ -359,11 +370,51 @@ fn run_loop(
                                 parsed
                             }
                             CommandAction::Cancel => {
+                                app.command_history_idx = None;
+                                app.command_history_scratch.clear();
                                 if search_dir.is_some() {
                                     Action::CancelSearch
                                 } else {
                                     app.command_line.clear();
                                     Action::ChangeMode(Mode::Normal)
+                                }
+                            }
+                            CommandAction::HistoryPrev => {
+                                if app.command_history.is_empty() {
+                                    Action::Noop
+                                } else {
+                                    let new_idx = match app.command_history_idx {
+                                        None => {
+                                            // Save current in-progress text before browsing.
+                                            app.command_history_scratch =
+                                                app.command_line.clone();
+                                            app.command_history.len() - 1
+                                        }
+                                        Some(i) => i.saturating_sub(1),
+                                    };
+                                    app.command_history_idx = Some(new_idx);
+                                    app.command_line =
+                                        app.command_history[new_idx].clone();
+                                    Action::Noop
+                                }
+                            }
+                            CommandAction::HistoryNext => {
+                                match app.command_history_idx {
+                                    None => Action::Noop,
+                                    Some(i) => {
+                                        if i + 1 < app.command_history.len() {
+                                            let new_idx = i + 1;
+                                            app.command_history_idx = Some(new_idx);
+                                            app.command_line =
+                                                app.command_history[new_idx].clone();
+                                        } else {
+                                            // Past the newest entry — restore scratch.
+                                            app.command_history_idx = None;
+                                            app.command_line =
+                                                app.command_history_scratch.clone();
+                                        }
+                                        Action::Noop
+                                    }
                                 }
                             }
                             CommandAction::Noop => Action::Noop,

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -349,12 +349,12 @@ fn run_loop(
                                     matches!(kind, CommandKind::Colon) && cmd.trim() == "wq";
                                 // Push non-empty colon commands to history,
                                 // avoiding consecutive duplicates.
-                                if matches!(kind, CommandKind::Colon) && !cmd.trim().is_empty() {
-                                    if app.command_history.last().map(|s| s.as_str())
+                                if matches!(kind, CommandKind::Colon)
+                                    && !cmd.trim().is_empty()
+                                    && app.command_history.last().map(|s| s.as_str())
                                         != Some(cmd.trim())
-                                    {
-                                        app.command_history.push(cmd.trim().to_string());
-                                    }
+                                {
+                                    app.command_history.push(cmd.trim().to_string());
                                 }
                                 app.command_history_idx = None;
                                 app.command_history_scratch.clear();
@@ -386,15 +386,13 @@ fn run_loop(
                                     let new_idx = match app.command_history_idx {
                                         None => {
                                             // Save current in-progress text before browsing.
-                                            app.command_history_scratch =
-                                                app.command_line.clone();
+                                            app.command_history_scratch = app.command_line.clone();
                                             app.command_history.len() - 1
                                         }
                                         Some(i) => i.saturating_sub(1),
                                     };
                                     app.command_history_idx = Some(new_idx);
-                                    app.command_line =
-                                        app.command_history[new_idx].clone();
+                                    app.command_line = app.command_history[new_idx].clone();
                                     Action::Noop
                                 }
                             }
@@ -405,13 +403,11 @@ fn run_loop(
                                         if i + 1 < app.command_history.len() {
                                             let new_idx = i + 1;
                                             app.command_history_idx = Some(new_idx);
-                                            app.command_line =
-                                                app.command_history[new_idx].clone();
+                                            app.command_line = app.command_history[new_idx].clone();
                                         } else {
                                             // Past the newest entry — restore scratch.
                                             app.command_history_idx = None;
-                                            app.command_line =
-                                                app.command_history_scratch.clone();
+                                            app.command_line = app.command_history_scratch.clone();
                                         }
                                         Action::Noop
                                     }

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -101,6 +101,8 @@ pub fn handle_command_key(key: KeyEvent, command_buffer: &str) -> CommandAction 
         KeyCode::Esc => CommandAction::Cancel,
         KeyCode::Enter => CommandAction::Execute(command_buffer.to_string()),
         KeyCode::Backspace => CommandAction::Backspace,
+        KeyCode::Up => CommandAction::HistoryPrev,
+        KeyCode::Down => CommandAction::HistoryNext,
         KeyCode::Char(c) => CommandAction::InsertChar(c),
         _ => CommandAction::Noop,
     }
@@ -113,6 +115,8 @@ pub enum CommandAction {
     Backspace,
     Execute(String),
     Cancel,
+    HistoryPrev,
+    HistoryNext,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `command_history`, `command_history_idx`, and `command_history_scratch` fields to `App` to track session-scoped colon-command history
- Maps `↑`/`↓` arrow keys to new `CommandAction::HistoryPrev` / `HistoryNext` variants in `mode/command.rs`
- Handles history navigation in the `Mode::Command` arm of `run_loop`: `↑` walks backward (saving the in-progress input on first press), `↓` walks forward and restores the scratch input when stepping past the newest entry
- History is populated on `Enter` for non-empty colon commands, skipping consecutive duplicates; Esc resets the index

Closes #54

## Test plan

- [x] `cargo build` — clean compile
- [x] `cargo test` — all 352 tests pass
- [x] Manual testing: execute several `:w`, `:q` commands, then use ↑/↓ to cycle through them; verify the in-progress text is restored on ↓ past the end

Made with [Cursor](https://cursor.com)