### PR TITLE
feat: normal mode '.' to repeat last change (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Normal mode `.` repeats the last cell-mutating change at the current cursor
+  position, vim-style. Works after `x`, `dd`, `d` (visual), `p`/`P`, and any
+  edit committed from Insert mode. `u` and `Ctrl-r` do not overwrite the repeat
+  register ([#63](https://github.com/garritfra/cell/pull/63))
 - Command-mode history: in the `:` prompt, `↑` / `↓` cycle through
   previously executed commands (oldest to newest). The in-progress input is
   saved and restored when stepping past the newest entry. History is

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -194,6 +194,15 @@ pub static NORMAL_ENTRIES: &[HelpEntry] = &[
         detail: "Paste the register contents above the current row (for row/block\nregisters) or into the current cell (for cell registers).\nFormula references are adjusted automatically.",
     },
     HelpEntry {
+        tags: &["."],
+        category: HelpCategory::Normal,
+        summary: "Repeat last change",
+        detail: "Re-apply the last cell-mutating operation at the current cursor \
+                 position. Works after x, dd, p, P, and any edit committed from \
+                 Insert mode (i/a/c + Esc or Enter). u and Ctrl-r do not affect \
+                 the repeat register.",
+    },
+    HelpEntry {
         tags: &["u"],
         category: HelpCategory::Normal,
         summary: "Undo",

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -198,7 +198,7 @@ pub static NORMAL_ENTRIES: &[HelpEntry] = &[
         category: HelpCategory::Normal,
         summary: "Repeat last change",
         detail: "Re-apply the last cell-mutating operation at the current cursor \
-                 position. Works after x, dd, p, P, and any edit committed from \
+                 position. Works after x, dd, d (visual), p, P, and any edit committed from \
                  Insert mode (i/a/c + Esc or Enter). u and Ctrl-r do not affect \
                  the repeat register.",
     },

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -157,6 +157,8 @@ pub enum Action {
     ReselectLastVisual,
     SetDelimiter(u8),
     SetStatus(String),
+    /// Re-apply the last recorded cell-mutating operation at the current cursor.
+    RepeatLastChange,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -211,6 +211,7 @@ impl App {
                     self.sheet.clear_cell(pos);
                     self.dirty = true;
                 }
+                self.last_change = Some(Action::ClearCell(pos));
             }
             Action::ChangeCell(pos) => {
                 let old_raw = self
@@ -578,6 +579,7 @@ impl App {
                     self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
                     self.dirty = true;
                 }
+                self.last_change = Some(Action::DeleteRow { start, count });
             }
             Action::Paste(pos) | Action::PasteBefore(pos) => {
                 let is_after = matches!(action, Action::Paste(_));
@@ -2635,6 +2637,42 @@ mod tests {
         app.process_action(Action::RepeatLastChange);
         assert_eq!(
             app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+            Some("x")
+        );
+    }
+
+    #[test]
+    fn dot_repeats_clear_cell() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "a".into()));
+        app.process_action(Action::EditCell((0, 1), "b".into()));
+        app.process_action(Action::ClearCell((0, 0)));
+        app.cursor = (0, 1);
+        app.process_action(Action::RepeatLastChange);
+        assert!(app.sheet.get_cell((0, 1)).is_none());
+    }
+
+    #[test]
+    fn dot_repeats_dd_at_new_row() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "a".into()));
+        app.process_action(Action::EditCell((1, 0), "b".into()));
+        app.process_action(Action::DeleteRow { start: 0, count: 1 });
+        app.cursor = (1, 0);
+        app.process_action(Action::RepeatLastChange);
+        assert!(app.sheet.get_cell((1, 0)).is_none());
+    }
+
+    #[test]
+    fn dot_after_undo_does_not_undo_again() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "x".into()));
+        app.process_action(Action::Undo);
+        assert!(app.sheet.get_cell((0, 0)).is_none());
+        app.cursor = (0, 0);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
             Some("x")
         );
     }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -56,6 +56,7 @@ pub struct App {
     /// The in-progress command line saved when the user first presses ↑,
     /// restored when they press ↓ past the most recent entry.
     pub command_history_scratch: String,
+    pub last_change: Option<Action>,
 }
 
 const JUMP_LIST_CAP: usize = 100;
@@ -99,6 +100,7 @@ impl App {
             command_history: Vec::new(),
             command_history_idx: None,
             command_history_scratch: String::new(),
+            last_change: None,
         }
     }
 
@@ -168,6 +170,7 @@ impl App {
                 mark_dirty(&mut self.sheet, &self.deps, pos);
                 recalculate(&mut self.sheet, &self.deps);
                 self.dirty = true;
+                self.last_change = Some(Action::EditCell(pos, raw));
             }
             Action::ChangeMode(mode) => {
                 if mode == Mode::Insert {
@@ -845,8 +848,38 @@ impl App {
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }
-            Action::RepeatLastChange => {}
+            Action::RepeatLastChange => {
+                if let Some(change) = self.last_change.clone() {
+                    let saved = self.last_change.clone();
+                    let rebound = self.rebind_change_to_cursor(change);
+                    self.process_action(rebound);
+                    self.last_change = saved;
+                }
+            }
             Action::Open(_) | Action::Resize => {}
+        }
+    }
+
+    fn rebind_change_to_cursor(&self, action: Action) -> Action {
+        let cursor = self.cursor;
+        match action {
+            Action::EditCell(_, raw) => Action::EditCell(cursor, raw),
+            Action::ClearCell(_) => Action::ClearCell(cursor),
+            Action::ClearRange { start, end } => {
+                let dr = end.0.saturating_sub(start.0);
+                let dc = end.1.saturating_sub(start.1);
+                Action::ClearRange {
+                    start: cursor,
+                    end: (cursor.0 + dr, cursor.1 + dc),
+                }
+            }
+            Action::DeleteRow { count, .. } => Action::DeleteRow {
+                start: cursor.0,
+                count,
+            },
+            Action::Paste(_) => Action::Paste(cursor),
+            Action::PasteBefore(_) => Action::PasteBefore(cursor),
+            _ => action,
         }
     }
 
@@ -2566,6 +2599,43 @@ mod tests {
         assert!(
             !msg.contains("Non-standard delimiter"),
             "ForceSave should bypass delimiter warning, got: {msg:?}"
+        );
+    }
+
+    // ── dot-repeat (#33) ────────────────────────────────────────────────────
+
+    #[test]
+    fn dot_with_no_last_change_is_noop() {
+        let mut app = App::new();
+        app.cursor = (2, 3);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(app.cursor, (2, 3));
+        assert!(app.sheet.get_cell((2, 3)).is_none());
+    }
+
+    #[test]
+    fn dot_repeats_edit_cell_at_new_cursor() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "x".into()));
+        app.cursor = (0, 1);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("x")
+        );
+    }
+
+    #[test]
+    fn dot_preserves_last_change_for_next_dot() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "x".into()));
+        app.cursor = (0, 1);
+        app.process_action(Action::RepeatLastChange);
+        app.cursor = (0, 2);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(
+            app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+            Some("x")
         );
     }
 }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -2698,6 +2698,20 @@ mod tests {
     }
 
     #[test]
+    fn dot_repeats_paste_before() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::YankCell((0, 0)));
+        app.process_action(Action::PasteBefore((0, 1)));
+        app.cursor = (0, 2);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(
+            app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+            Some("hello")
+        );
+    }
+
+    #[test]
     fn dot_repeats_clear_range_with_same_shape() {
         let mut app = App::new();
         app.process_action(Action::EditCell((0, 0), "a".into()));

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -535,6 +535,7 @@ impl App {
                     recalculate(&mut self.sheet, &self.deps);
                     self.dirty = true;
                 }
+                self.last_change = Some(Action::ClearRange { start, end });
             }
             Action::DeleteRow { start, count } => {
                 let count = count.max(1);
@@ -682,6 +683,11 @@ impl App {
                         recalculate(&mut self.sheet, &self.deps);
                         self.dirty = true;
                     }
+                }
+                if is_after {
+                    self.last_change = Some(Action::Paste(pos));
+                } else {
+                    self.last_change = Some(Action::PasteBefore(pos));
                 }
             }
             Action::NextNonEmpty(count) => {
@@ -2675,5 +2681,38 @@ mod tests {
             app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
             Some("x")
         );
+    }
+
+    #[test]
+    fn dot_repeats_paste() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::YankCell((0, 0)));
+        app.process_action(Action::Paste((0, 1)));
+        app.cursor = (0, 2);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(
+            app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn dot_repeats_clear_range_with_same_shape() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "a".into()));
+        app.process_action(Action::EditCell((0, 1), "b".into()));
+        app.process_action(Action::EditCell((1, 0), "c".into()));
+        app.process_action(Action::EditCell((1, 1), "d".into()));
+        // Clear 1×2 range at row 0
+        app.process_action(Action::ClearRange {
+            start: (0, 0),
+            end: (0, 1),
+        });
+        // Dot at (1, 0) should clear (1,0)–(1,1)
+        app.cursor = (1, 0);
+        app.process_action(Action::RepeatLastChange);
+        assert!(app.sheet.get_cell((1, 0)).is_none());
+        assert!(app.sheet.get_cell((1, 1)).is_none());
     }
 }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -849,11 +849,11 @@ impl App {
                 self.status_message = Some(msg);
             }
             Action::RepeatLastChange => {
-                if let Some(change) = self.last_change.clone() {
-                    let saved = self.last_change.clone();
+                if let Some(change) = self.last_change.take() {
+                    let saved = change.clone();
                     let rebound = self.rebind_change_to_cursor(change);
                     self.process_action(rebound);
-                    self.last_change = saved;
+                    self.last_change = Some(saved);
                 }
             }
             Action::Open(_) | Action::Resize => {}

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -845,6 +845,7 @@ impl App {
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }
+            Action::RepeatLastChange => {}
             Action::Open(_) | Action::Resize => {}
         }
     }

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -456,6 +456,10 @@ impl NormalState {
                 self.discard_count();
                 Action::ChangeMode(Mode::Insert)
             }
+            KeyCode::Char('.') => {
+                self.discard_count();
+                Action::RepeatLastChange
+            }
             _ => {
                 // Unknown key: throw away any pending count so we don't
                 // silently apply it to the next valid command.
@@ -883,6 +887,16 @@ mod tests {
         assert_eq!(
             state.handle_key(key(KeyCode::Tab), &app),
             Action::JumpForward
+        );
+    }
+
+    #[test]
+    fn dot_emits_repeat_last_change() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('.')), &app),
+            Action::RepeatLastChange
         );
     }
 

--- a/docs/superpowers/plans/2026-04-28-dot-repeat-last-change.md
+++ b/docs/superpowers/plans/2026-04-28-dot-repeat-last-change.md
@@ -1,0 +1,532 @@
+# Dot Repeat Last Change Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Vim's `.` (dot) command — re-apply the last cell-mutating operation at the current cursor position.
+
+**Architecture:** A new `RepeatLastChange` `Action` variant is added to the action enum. `App` gains a `last_change: Option<Action>` field that is updated inside `process_action` for each cell-mutating arm. On replay, a `rebind_change_to_cursor` helper substitutes the current cursor into the stored action before re-dispatching; the saved value is restored afterward so consecutive `.` presses all repeat the same original operation.
+
+**Tech Stack:** Rust, no new dependencies. All tests are unit tests inside the existing `#[cfg(test)]` modules.
+
+---
+
+## Background: how the codebase is organised
+
+- `crates/cell-sheet-tui/src/action.rs` — the `Action` enum; every user-visible operation is a variant. Add new variants here.
+- `crates/cell-sheet-tui/src/app.rs` — `App` struct + `process_action`. All sheet mutations happen here. Tests live in a `#[cfg(test)]` module at the bottom of this file.
+- `crates/cell-sheet-tui/src/mode/normal.rs` — `NormalState::handle_key` returns an `Action`. Tests live in `#[cfg(test)]` at the bottom.
+- `crates/cell-sheet-core/src/help/entries.rs` — static slices of `HelpEntry` values that power `:help`. `NORMAL_ENTRIES` is the slice for normal-mode bindings.
+- `CHANGELOG.md` — add to `## Unreleased → Added`.
+
+---
+
+## File map
+
+| File | What changes |
+|---|---|
+| `crates/cell-sheet-tui/src/action.rs` | Add `RepeatLastChange` variant |
+| `crates/cell-sheet-tui/src/app.rs` | Add `last_change` field; `rebind_change_to_cursor`; `RepeatLastChange` arm; record in 6 mutating arms |
+| `crates/cell-sheet-tui/src/mode/normal.rs` | Map `'.'` → `Action::RepeatLastChange` |
+| `crates/cell-sheet-core/src/help/entries.rs` | Add `HelpEntry` for `.` |
+| `CHANGELOG.md` | Unreleased entry |
+
+---
+
+## Task 1: Add `RepeatLastChange` to `Action` and map `'.'` in Normal mode
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/normal.rs`
+
+- [ ] **Step 1: Write the failing test in `normal.rs`**
+
+  Open `crates/cell-sheet-tui/src/mode/normal.rs`. Inside the `#[cfg(test)]` module, after the existing `tab_jumps_forward` test, add:
+
+  ```rust
+  #[test]
+  fn dot_emits_repeat_last_change() {
+      let app = App::new();
+      let mut state = NormalState::new();
+      assert_eq!(
+          state.handle_key(key(KeyCode::Char('.')), &app),
+          Action::RepeatLastChange
+      );
+  }
+  ```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_emits_repeat_last_change
+  ```
+
+  Expected: compile error — `Action::RepeatLastChange` does not exist yet.
+
+- [ ] **Step 3: Add `RepeatLastChange` to the `Action` enum**
+
+  Open `crates/cell-sheet-tui/src/action.rs`. After the `SetStatus` variant (last line before the closing `}`), add:
+
+  ```rust
+  /// Re-apply the last recorded cell-mutating operation at the current cursor.
+  RepeatLastChange,
+  ```
+
+  The enum already has `#[derive(Debug, Clone, PartialEq)]` so no derive changes are needed.
+
+- [ ] **Step 4: Map `'.'` in `NormalState::handle_key`**
+
+  Open `crates/cell-sheet-tui/src/mode/normal.rs`. In the big `match key.code { ... }` block inside `handle_key`, add a new arm just before the final `_ =>` catch-all:
+
+  ```rust
+  KeyCode::Char('.') => {
+      self.discard_count();
+      Action::RepeatLastChange
+  }
+  ```
+
+- [ ] **Step 5: Handle `RepeatLastChange` in `process_action` (stub)**
+
+  Open `crates/cell-sheet-tui/src/app.rs`. In `process_action`, the final arm is `Action::Open(_) | Action::Resize => {}`. Add a new arm just before it:
+
+  ```rust
+  Action::RepeatLastChange => {}
+  ```
+
+  This silences the "non-exhaustive patterns" compiler error. The real implementation comes in Task 2.
+
+- [ ] **Step 6: Run the test to confirm it passes**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_emits_repeat_last_change
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+  ```sh
+  git add crates/cell-sheet-tui/src/action.rs \
+          crates/cell-sheet-tui/src/mode/normal.rs \
+          crates/cell-sheet-tui/src/app.rs
+  git commit -m "feat: add RepeatLastChange action and bind '.' in normal mode"
+  ```
+
+---
+
+## Task 2: `last_change` field, `rebind_change_to_cursor`, and `EditCell` recording
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+
+- [ ] **Step 1: Write the failing tests in `app.rs`**
+
+  Open `crates/cell-sheet-tui/src/app.rs`. Inside the `#[cfg(test)]` module, after the last existing test, add:
+
+  ```rust
+  // ── dot-repeat (#33) ────────────────────────────────────────────────────
+
+  #[test]
+  fn dot_with_no_last_change_is_noop() {
+      let mut app = App::new();
+      app.cursor = (2, 3);
+      app.process_action(Action::RepeatLastChange);
+      assert_eq!(app.cursor, (2, 3));
+      assert!(app.sheet.get_cell((2, 3)).is_none());
+  }
+
+  #[test]
+  fn dot_repeats_edit_cell_at_new_cursor() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "x".into()));
+      app.cursor = (0, 1);
+      app.process_action(Action::RepeatLastChange);
+      assert_eq!(
+          app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+          Some("x")
+      );
+  }
+
+  #[test]
+  fn dot_preserves_last_change_for_next_dot() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "x".into()));
+      app.cursor = (0, 1);
+      app.process_action(Action::RepeatLastChange);
+      app.cursor = (0, 2);
+      app.process_action(Action::RepeatLastChange);
+      assert_eq!(
+          app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+          Some("x")
+      );
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_repeats_edit_cell_at_new_cursor
+  ```
+
+  Expected: FAIL — `dot_repeats_edit_cell_at_new_cursor` asserts `Some("x")` but gets `None`.
+
+- [ ] **Step 3: Add `last_change` field to `App`**
+
+  In the `App` struct definition, after `pub last_visual: Option<LastVisual>,`, add:
+
+  ```rust
+  pub last_change: Option<Action>,
+  ```
+
+  In `App::new()`, after `last_visual: None,`, add:
+
+  ```rust
+  last_change: None,
+  ```
+
+- [ ] **Step 4: Add `rebind_change_to_cursor`**
+
+  In the `impl App` block, just before the `fn format_from_path` function, add:
+
+  ```rust
+  fn rebind_change_to_cursor(&self, action: Action) -> Action {
+      let cursor = self.cursor;
+      match action {
+          Action::EditCell(_, raw) => Action::EditCell(cursor, raw),
+          Action::ClearCell(_) => Action::ClearCell(cursor),
+          Action::ClearRange { start, end } => {
+              let dr = end.0.saturating_sub(start.0);
+              let dc = end.1.saturating_sub(start.1);
+              Action::ClearRange {
+                  start: cursor,
+                  end: (cursor.0 + dr, cursor.1 + dc),
+              }
+          }
+          Action::DeleteRow { count, .. } => Action::DeleteRow {
+              start: cursor.0,
+              count,
+          },
+          Action::Paste(_) => Action::Paste(cursor),
+          Action::PasteBefore(_) => Action::PasteBefore(cursor),
+          _ => action,
+      }
+  }
+  ```
+
+- [ ] **Step 5: Implement the `RepeatLastChange` arm**
+
+  Replace the stub `Action::RepeatLastChange => {}` added in Task 1 with:
+
+  ```rust
+  Action::RepeatLastChange => {
+      if let Some(change) = self.last_change.clone() {
+          let saved = self.last_change.clone();
+          let rebound = self.rebind_change_to_cursor(change);
+          self.process_action(rebound);
+          self.last_change = saved;
+      }
+  }
+  ```
+
+- [ ] **Step 6: Record `last_change` in the `EditCell` arm**
+
+  The `EditCell` arm ends with `self.dirty = true;`. Directly after that line, add:
+
+  ```rust
+  self.last_change = Some(Action::EditCell(pos, raw));
+  ```
+
+  `pos` is `Copy` (`(usize, usize)`). `raw` is a `String` that was only borrowed (via `&raw`) throughout the arm body, so it is still owned here.
+
+- [ ] **Step 7: Run the tests to confirm they pass**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_with_no_last_change_is_noop dot_repeats_edit_cell_at_new_cursor dot_preserves_last_change_for_next_dot
+  ```
+
+  Expected: all three PASS.
+
+- [ ] **Step 8: Commit**
+
+  ```sh
+  git add crates/cell-sheet-tui/src/app.rs
+  git commit -m "feat: add last_change field and implement dot-repeat for EditCell"
+  ```
+
+---
+
+## Task 3: Record `last_change` for `ClearCell` and `DeleteRow`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+  In the `#[cfg(test)]` module in `app.rs`, after the tests from Task 2, add:
+
+  ```rust
+  #[test]
+  fn dot_repeats_clear_cell() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "a".into()));
+      app.process_action(Action::EditCell((0, 1), "b".into()));
+      app.process_action(Action::ClearCell((0, 0)));
+      app.cursor = (0, 1);
+      app.process_action(Action::RepeatLastChange);
+      assert!(app.sheet.get_cell((0, 1)).is_none());
+  }
+
+  #[test]
+  fn dot_repeats_dd_at_new_row() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "a".into()));
+      app.process_action(Action::EditCell((1, 0), "b".into()));
+      app.process_action(Action::DeleteRow { start: 0, count: 1 });
+      app.cursor = (1, 0);
+      app.process_action(Action::RepeatLastChange);
+      assert!(app.sheet.get_cell((1, 0)).is_none());
+  }
+
+  #[test]
+  fn dot_after_undo_does_not_undo_again() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "x".into()));
+      app.process_action(Action::Undo);
+      assert!(app.sheet.get_cell((0, 0)).is_none());
+      app.cursor = (0, 0);
+      app.process_action(Action::RepeatLastChange);
+      assert_eq!(
+          app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+          Some("x")
+      );
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_repeats_clear_cell dot_repeats_dd_at_new_row dot_after_undo_does_not_undo_again
+  ```
+
+  Expected: `dot_repeats_clear_cell` and `dot_repeats_dd_at_new_row` FAIL (no last_change recorded). `dot_after_undo_does_not_undo_again` FAIL.
+
+- [ ] **Step 3: Record `last_change` in the `ClearCell` arm**
+
+  The `ClearCell` arm ends just after the `if !old_raw.is_empty() { ... }` block. After the closing `}` of that block, add:
+
+  ```rust
+  self.last_change = Some(Action::ClearCell(pos));
+  ```
+
+  `pos` is `Copy`. It is recorded unconditionally (even if the cell was already empty) to match Vim's behaviour.
+
+- [ ] **Step 4: Record `last_change` in the `DeleteRow` arm**
+
+  The `DeleteRow` arm ends with the `if !changes.is_empty() { ... }` block. After that block's closing `}`, add:
+
+  ```rust
+  self.last_change = Some(Action::DeleteRow { start, count });
+  ```
+
+  Both `start` and `count` are `usize` (`Copy`).
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_repeats_clear_cell dot_repeats_dd_at_new_row dot_after_undo_does_not_undo_again
+  ```
+
+  Expected: all three PASS.
+
+- [ ] **Step 6: Commit**
+
+  ```sh
+  git add crates/cell-sheet-tui/src/app.rs
+  git commit -m "feat: record last_change for ClearCell and DeleteRow"
+  ```
+
+---
+
+## Task 4: Record `last_change` for `ClearRange`, `Paste`, `PasteBefore`
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+  In the `#[cfg(test)]` module in `app.rs`, after the tests from Task 3, add:
+
+  ```rust
+  #[test]
+  fn dot_repeats_paste() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "hello".into()));
+      app.process_action(Action::YankCell((0, 0)));
+      app.process_action(Action::Paste((0, 1)));
+      app.cursor = (0, 2);
+      app.process_action(Action::RepeatLastChange);
+      assert_eq!(
+          app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+          Some("hello")
+      );
+  }
+
+  #[test]
+  fn dot_repeats_clear_range_with_same_shape() {
+      let mut app = App::new();
+      app.process_action(Action::EditCell((0, 0), "a".into()));
+      app.process_action(Action::EditCell((0, 1), "b".into()));
+      app.process_action(Action::EditCell((1, 0), "c".into()));
+      app.process_action(Action::EditCell((1, 1), "d".into()));
+      // Clear 1×2 range at row 0
+      app.process_action(Action::ClearRange { start: (0, 0), end: (0, 1) });
+      // Dot at (1, 0) should clear (1,0)–(1,1)
+      app.cursor = (1, 0);
+      app.process_action(Action::RepeatLastChange);
+      assert!(app.sheet.get_cell((1, 0)).is_none());
+      assert!(app.sheet.get_cell((1, 1)).is_none());
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_repeats_paste dot_repeats_clear_range_with_same_shape
+  ```
+
+  Expected: both FAIL.
+
+- [ ] **Step 3: Record `last_change` in the `ClearRange` arm**
+
+  The `ClearRange` arm ends with the `if !changes.is_empty() { ... }` block. After that block's closing `}`, add:
+
+  ```rust
+  self.last_change = Some(Action::ClearRange { start, end });
+  ```
+
+  Both `start` and `end` are `(usize, usize)` (`Copy`).
+
+- [ ] **Step 4: Record `last_change` in the `Paste` / `PasteBefore` arm**
+
+  The combined `Action::Paste(pos) | Action::PasteBefore(pos)` arm already computes `let is_after = ...` at the top and ends after the `}` that closes the `if let Some(reg) = ...` block. After that closing `}`, add:
+
+  ```rust
+  if is_after {
+      self.last_change = Some(Action::Paste(pos));
+  } else {
+      self.last_change = Some(Action::PasteBefore(pos));
+  }
+  ```
+
+  `pos` is `Copy`; `is_after` is already in scope.
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+  ```sh
+  cargo test -p cell-sheet-tui dot_repeats_paste dot_repeats_clear_range_with_same_shape
+  ```
+
+  Expected: both PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+  ```sh
+  cargo test
+  ```
+
+  Expected: all tests pass (no regressions).
+
+- [ ] **Step 7: Commit**
+
+  ```sh
+  git add crates/cell-sheet-tui/src/app.rs
+  git commit -m "feat: record last_change for ClearRange, Paste, PasteBefore"
+  ```
+
+---
+
+## Task 5: Help entry and CHANGELOG
+
+**Files:**
+- Modify: `crates/cell-sheet-core/src/help/entries.rs`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add `HelpEntry` for `.` to `NORMAL_ENTRIES`**
+
+  Open `crates/cell-sheet-core/src/help/entries.rs`. In `NORMAL_ENTRIES`, find the `HelpEntry` for `"u"` (Undo). Add the following entry **before** the `"u"` entry (keeps the logical flow: edits → dot → undo):
+
+  ```rust
+  HelpEntry {
+      tags: &["."],
+      category: HelpCategory::Normal,
+      summary: "Repeat last change",
+      detail: "Re-apply the last cell-mutating operation at the current cursor \
+               position. Works after x, dd, p, P, and any edit committed from \
+               Insert mode (i/a/c + Esc or Enter). u and Ctrl-r do not affect \
+               the repeat register.",
+  },
+  ```
+
+- [ ] **Step 2: Add CHANGELOG entry**
+
+  Open `CHANGELOG.md`. Under `## Unreleased → ### Added`, add:
+
+  ```markdown
+  - Normal mode `.` repeats the last cell-mutating change at the current cursor
+    position, vim-style. Works after `x`, `dd`, `p`/`P`, and any edit committed
+    from Insert mode. `u` and `Ctrl-r` do not overwrite the repeat register
+    ([#33](https://github.com/garritfra/cell/issues/33))
+  ```
+
+- [ ] **Step 3: Verify `:help .` resolves correctly**
+
+  The `HelpRegistry` is built from the static slices at startup. A quick compile-and-test is enough to confirm registration:
+
+  ```sh
+  cargo test -p cell-sheet-tui show_help_valid_topic
+  ```
+
+  Expected: PASS (this test was already passing; it exercises the registry lookup path).
+
+- [ ] **Step 4: Commit**
+
+  ```sh
+  git add crates/cell-sheet-core/src/help/entries.rs CHANGELOG.md
+  git commit -m "docs: add help entry and changelog for dot-repeat (#33)"
+  ```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Format**
+
+  ```sh
+  cargo fmt --all
+  ```
+
+  Expected: no output (already formatted, or formats cleanly).
+
+- [ ] **Step 2: Clippy**
+
+  ```sh
+  cargo clippy --workspace --all-targets --all-features
+  ```
+
+  Expected: no warnings (CI runs with `RUSTFLAGS=-Dwarnings`).
+
+- [ ] **Step 3: Full test suite**
+
+  ```sh
+  cargo test
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 4: Commit formatting fixes if any**
+
+  If `cargo fmt` produced changes:
+
+  ```sh
+  git add -u
+  git commit -m "chore: fmt"
+  ```

--- a/docs/superpowers/specs/2026-04-28-dot-repeat-last-change-design.md
+++ b/docs/superpowers/specs/2026-04-28-dot-repeat-last-change-design.md
@@ -1,0 +1,152 @@
+# Design: Normal mode `.` — repeat last change (issue #33)
+
+**Date:** 2026-04-28  
+**Issue:** [#33](https://github.com/garritfra/cell/issues/33)
+
+---
+
+## Goal
+
+Implement Vim's `.` (dot) command in Normal mode: re-apply the most recently recorded cell-mutating operation at the current cursor position. `xj.j.j.` walks down a column clearing each cell. `dd` then `j.` deletes the next row.
+
+## Out of scope
+
+- `[count].` to repeat N times (not mentioned in issue)
+- `ChangeRange` (complex multi-cell insert-mode operation; not listed in issue scope)
+- Macro-style multi-step recording (separate RFC per the issue)
+
+---
+
+## Data model
+
+### New field in `App`
+
+```rust
+pub last_change: Option<Action>,
+```
+
+Initialised to `None` in `App::new()`. Holds the most recent cell-mutating action in its original form (original cursor position included). The cursor position is rebound at replay time, not at record time, so pressing `.` multiple times at different positions all work correctly.
+
+### Actions that record `last_change`
+
+Recorded inside `process_action` at the end of each matching arm:
+
+| Action | Trigger |
+|---|---|
+| `EditCell(pos, raw)` | Esc / Enter out of Insert mode (covers `i`, `a`, `c`, `Enter`) |
+| `ClearCell(pos)` | `x` |
+| `ClearRange { start, end }` | Visual-mode `d` |
+| `DeleteRow { start, count }` | `dd` / `[count]dd` |
+| `Paste(pos)` | `p` |
+| `PasteBefore(pos)` | `P` |
+
+### Actions that do NOT update `last_change`
+
+- `Undo`, `Redo` — per the issue specification
+- `RepeatLastChange` (`.`) — the saved value is restored after the recursive dispatch, so consecutive `.` all repeat the same original operation
+- `ChangeCell` — not recorded directly; the `EditCell` that insert-mode exit emits is what gets stored
+
+---
+
+## New `Action` variant
+
+```rust
+/// Replay the last recorded cell-mutating change at the current cursor.
+RepeatLastChange,
+```
+
+Added to `action.rs`.
+
+---
+
+## Rebinding logic
+
+`rebind_change_to_cursor` is a private method on `App` that substitutes the current cursor before replay:
+
+| Stored action | Rebound to cursor |
+|---|---|
+| `EditCell(_, raw)` | `EditCell(cursor, raw)` |
+| `ClearCell(_)` | `ClearCell(cursor)` |
+| `ClearRange{start, end}` | `ClearRange{start: cursor, end: cursor + (end − start)}` |
+| `DeleteRow{_, count}` | `DeleteRow{start: cursor.row, count}` |
+| `Paste(_)` | `Paste(cursor)` |
+| `PasteBefore(_)` | `PasteBefore(cursor)` |
+
+For anything else (should not happen), the action is passed through unchanged.
+
+---
+
+## Replay guard
+
+The `RepeatLastChange` arm in `process_action`:
+
+```rust
+Action::RepeatLastChange => {
+    if let Some(change) = self.last_change.clone() {
+        let saved = self.last_change.clone();
+        let rebound = self.rebind_change_to_cursor(change);
+        self.process_action(rebound);  // may overwrite last_change
+        self.last_change = saved;      // restore so next . repeats same op
+    }
+}
+```
+
+---
+
+## Key binding
+
+In `mode/normal.rs`, `handle_key`:
+
+```rust
+KeyCode::Char('.') => {
+    self.discard_count();
+    Action::RepeatLastChange
+}
+```
+
+---
+
+## Help entry
+
+Added to `NORMAL_ENTRIES` in `crates/cell-sheet-core/src/help/entries.rs`:
+
+```rust
+HelpEntry {
+    tags: &["."],
+    category: HelpCategory::Normal,
+    summary: "Repeat last change",
+    detail: "Re-apply the last cell-mutating operation at the current cursor \
+             position. Works with x, dd, p, P, and any edit committed from \
+             Insert mode. u and Ctrl-r do not affect the repeat register.",
+},
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `crates/cell-sheet-tui/src/action.rs` | Add `RepeatLastChange` variant |
+| `crates/cell-sheet-tui/src/app.rs` | Add `last_change` field; `rebind_change_to_cursor`; `RepeatLastChange` arm; record in 6 mutating arms |
+| `crates/cell-sheet-tui/src/mode/normal.rs` | Map `'.'` → `Action::RepeatLastChange` |
+| `crates/cell-sheet-core/src/help/entries.rs` | Add `HelpEntry` for `.` |
+| `CHANGELOG.md` | Add entry under `## Unreleased → Added` |
+
+---
+
+## Tests
+
+All tests live in `crates/cell-sheet-tui/src/app.rs` (unit) and `crates/cell-sheet-tui/src/mode/normal.rs` (key binding).
+
+### `app.rs` tests
+
+1. **`dot_repeats_edit_cell_at_new_cursor`** — Edit `(0,0)` to `"x"`, move cursor to `(0,1)`, dispatch `RepeatLastChange` → `(0,1)` contains `"x"`.
+2. **`dot_repeats_dd_at_new_row`** — `DeleteRow{start:0, count:1}` at row 0 with data, move cursor to row 1 with data, dispatch `RepeatLastChange` → row 1 is now empty.
+3. **`dot_after_undo_does_not_undo_again`** — Edit `(0,0)` to `"x"`, undo, dispatch `RepeatLastChange` → cell becomes `"x"` again (not undone a second time).
+4. **`dot_with_no_last_change_is_noop`** — Fresh `App`, dispatch `RepeatLastChange` → no panic, cursor unchanged.
+5. **`dot_preserves_last_change_for_next_dot`** — Edit, move, `.`, move, `.` → all three positions contain `"x"`.
+
+### `normal.rs` test
+
+6. **`dot_emits_repeat_last_change`** — `'.'` key → `Action::RepeatLastChange`.


### PR DESCRIPTION
## Summary

- Adds `Action::RepeatLastChange` and binds `.` in Normal mode — re-applies the last cell-mutating operation at the current cursor position, vim-style
- Introduces `last_change: Option<Action>` on `App`; recorded after `x`, `dd`, `d` (visual), `p`, `P`, and any edit committed from Insert mode (`i`/`a`/`c` + Esc or Enter)
- `rebind_change_to_cursor` substitutes the current cursor at replay time so `xj.j.j.` walks down a column clearing cells; `ClearRange` preserves the original selection shape

## Test plan

- [ ] Edit a cell, move cursor, press `.` → new cell gets same content
- [ ] `dd` on a row, `j.` → next row deleted
- [ ] `u` then `.` → re-applies the original edit (does not undo again)
- [ ] `:help .` resolves correctly in-app
- [ ] `cargo fmt --all && cargo clippy --workspace --all-targets --all-features && cargo test` all pass

Closes #33

Made with [Cursor](https://cursor.com)