### PR TITLE
feat: case ops on cell text (~, guu, gUU, g~~, visual u/U/~)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Case operations on cell text: `~` toggles the case of the first character
+  and advances the cursor one column; `guu` lowercases the entire cell; `gUU`
+  uppercases the entire cell; `g~~` toggles the case of every character. In
+  Visual mode, `u` / `U` / `~` apply the corresponding operation to every
+  selected cell. Formula cells are always skipped — the status line reports a
+  message instead. All operations are undoable with `u`
+  ([#38](https://github.com/garritfra/cell/pull/38))
 - Normal mode `.` repeats the last cell-mutating change at the current cursor
   position, vim-style. Works after `x`, `dd`, `d` (visual), `p`/`P`, and any
   edit committed from Insert mode. `u` and `Ctrl-r` do not overwrite the repeat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   Visual mode, `u` / `U` / `~` apply the corresponding operation to every
   selected cell. Formula cells are always skipped — the status line reports a
   message instead. All operations are undoable with `u`
-  ([#38](https://github.com/garritfra/cell/pull/38))
+  ([#65](https://github.com/garritfra/cell/pull/65))
 - Normal mode `.` repeats the last cell-mutating change at the current cursor
   position, vim-style. Works after `x`, `dd`, `d` (visual), `p`/`P`, and any
   edit committed from Insert mode. `u` and `Ctrl-r` do not overwrite the repeat

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -316,6 +316,35 @@ pub static NORMAL_ENTRIES: &[HelpEntry] = &[
         summary: "Repeat last find reversed",
         detail: "Repeat the last f / F find in the opposite direction.",
     },
+    HelpEntry {
+        tags: &["~", "tilde"],
+        category: HelpCategory::Normal,
+        summary: "Toggle case of first character",
+        detail: "Toggle the case of the first character of the current cell's value\n\
+                 and advance the cursor one column to the right (vim `~` semantics\n\
+                 scoped to one cell). No-op on formula cells.",
+    },
+    HelpEntry {
+        tags: &["guu"],
+        category: HelpCategory::Normal,
+        summary: "Lowercase entire cell",
+        detail: "Convert every character in the current cell's value to lowercase.\n\
+                 No-op on formula cells. Undoable with u.",
+    },
+    HelpEntry {
+        tags: &["gUU"],
+        category: HelpCategory::Normal,
+        summary: "Uppercase entire cell",
+        detail: "Convert every character in the current cell's value to uppercase.\n\
+                 No-op on formula cells. Undoable with u.",
+    },
+    HelpEntry {
+        tags: &["g~~"],
+        category: HelpCategory::Normal,
+        summary: "Toggle case of entire cell",
+        detail: "Toggle the case of every character in the current cell's value\n\
+                 (uppercase ↔ lowercase). No-op on formula cells. Undoable with u.",
+    },
 ];
 
 pub static INSERT_ENTRIES: &[HelpEntry] = &[
@@ -402,6 +431,30 @@ pub static VISUAL_ENTRIES: &[HelpEntry] = &[
         category: HelpCategory::Visual,
         summary: "Cancel selection",
         detail: "Exit Visual mode and return to Normal mode without\nmodifying any cells.",
+    },
+    HelpEntry {
+        tags: &["u-visual"],
+        category: HelpCategory::Visual,
+        summary: "Lowercase selection",
+        detail: "Convert every character in every selected cell to lowercase.\n\
+                 Formula cells in the selection are skipped. Undoable with u\n\
+                 after returning to Normal mode.",
+    },
+    HelpEntry {
+        tags: &["U-visual"],
+        category: HelpCategory::Visual,
+        summary: "Uppercase selection",
+        detail: "Convert every character in every selected cell to uppercase.\n\
+                 Formula cells in the selection are skipped. Undoable with u\n\
+                 after returning to Normal mode.",
+    },
+    HelpEntry {
+        tags: &["~-visual"],
+        category: HelpCategory::Visual,
+        summary: "Toggle case of selection",
+        detail: "Toggle the case of every character in every selected cell\n\
+                 (uppercase ↔ lowercase). Formula cells in the selection are\n\
+                 skipped. Undoable with u after returning to Normal mode.",
     },
 ];
 

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -10,6 +10,17 @@ pub enum Direction {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CaseOp {
+    ToLower,
+    ToUpper,
+    /// Toggle every character's case.
+    ToggleAll,
+    /// Toggle only the first character's case; the handler also advances the
+    /// cursor right by one column (vim `~` semantics).
+    ToggleFirst,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SearchDirection {
     Forward,
     Backward,
@@ -159,6 +170,19 @@ pub enum Action {
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,
+    /// Apply a case transformation to a single cell. `ToggleFirst` also
+    /// advances the cursor right by one column after the edit.
+    CaseOpCell {
+        pos: CellPos,
+        op: CaseOp,
+    },
+    /// Apply a case transformation to every non-formula cell in the range
+    /// `[start, end]` (inclusive). Formula cells in the range are skipped.
+    CaseOpRange {
+        start: CellPos,
+        end: CellPos,
+        op: CaseOp,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -1,4 +1,4 @@
-use crate::action::{Action, CommandKind, Direction, Mode, SearchDirection};
+use crate::action::{Action, CaseOp, CommandKind, Direction, Mode, SearchDirection};
 use crate::clipboard::Register;
 use crate::mode::visual::VisualKind;
 use crate::undo::{UndoEntry, UndoStack};
@@ -864,6 +864,70 @@ impl App {
                     self.last_change = Some(saved);
                 }
             }
+            Action::CaseOpCell { pos, op } => {
+                let raw = self
+                    .sheet
+                    .get_cell(pos)
+                    .map(|c| c.raw.clone())
+                    .unwrap_or_default();
+                if raw.is_empty() {
+                    if op == CaseOp::ToggleFirst {
+                        self.process_action(Action::MoveCursor(Direction::Right, 1));
+                    }
+                    return;
+                }
+                if raw.starts_with('=') {
+                    self.status_message = Some("Cannot change case of a formula cell".into());
+                    return;
+                }
+                let new_raw = apply_case_op(&raw, op);
+                if new_raw != raw {
+                    self.undo_stack.push(UndoEntry::CellEdit {
+                        pos,
+                        old_raw: raw,
+                        new_raw: new_raw.clone(),
+                    });
+                    self.sheet.set_cell(pos, &new_raw);
+                    mark_dirty(&mut self.sheet, &self.deps, pos);
+                    recalculate(&mut self.sheet, &self.deps);
+                    self.dirty = true;
+                }
+                self.last_change = Some(Action::CaseOpCell { pos, op });
+                if op == CaseOp::ToggleFirst {
+                    self.process_action(Action::MoveCursor(Direction::Right, 1));
+                }
+            }
+            Action::CaseOpRange { start, end, op } => {
+                let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
+                let mut changes: Vec<(CellPos, String, String)> = Vec::new();
+                for row in start.0..=end.0 {
+                    for col in start.1..=max_col {
+                        let raw = self
+                            .sheet
+                            .get_cell((row, col))
+                            .map(|c| c.raw.clone())
+                            .unwrap_or_default();
+                        if raw.is_empty() || raw.starts_with('=') {
+                            continue;
+                        }
+                        let new_raw = apply_case_op(&raw, op);
+                        if new_raw != raw {
+                            changes.push(((row, col), raw, new_raw));
+                        }
+                    }
+                }
+                if !changes.is_empty() {
+                    for (pos, _, new_raw) in &changes {
+                        self.sheet.set_cell(*pos, new_raw);
+                        mark_dirty(&mut self.sheet, &self.deps, *pos);
+                    }
+                    recalculate(&mut self.sheet, &self.deps);
+                    self.undo_stack
+                        .push(UndoEntry::MultiCellEdit { changes });
+                    self.dirty = true;
+                }
+                self.last_change = Some(Action::CaseOpRange { start, end, op });
+            }
             Action::Open(_) | Action::Resize => {}
         }
     }
@@ -887,6 +951,7 @@ impl App {
             },
             Action::Paste(_) => Action::Paste(cursor),
             Action::PasteBefore(_) => Action::PasteBefore(cursor),
+            Action::CaseOpCell { op, .. } => Action::CaseOpCell { pos: cursor, op },
             _ => action,
         }
     }
@@ -1113,6 +1178,41 @@ impl App {
             self.deps.remove(pos);
         }
         mark_dirty(&mut self.sheet, &self.deps, pos);
+    }
+}
+
+fn apply_case_op(s: &str, op: CaseOp) -> String {
+    match op {
+        CaseOp::ToLower => s.to_lowercase(),
+        CaseOp::ToUpper => s.to_uppercase(),
+        CaseOp::ToggleAll => s
+            .chars()
+            .map(|c| {
+                if c.is_uppercase() {
+                    c.to_lowercase().next().unwrap_or(c)
+                } else if c.is_lowercase() {
+                    c.to_uppercase().next().unwrap_or(c)
+                } else {
+                    c
+                }
+            })
+            .collect(),
+        CaseOp::ToggleFirst => {
+            let mut chars = s.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => {
+                    let toggled = if c.is_uppercase() {
+                        c.to_lowercase().next().unwrap_or(c)
+                    } else if c.is_lowercase() {
+                        c.to_uppercase().next().unwrap_or(c)
+                    } else {
+                        c
+                    };
+                    std::iter::once(toggled).chain(chars).collect()
+                }
+            }
+        }
     }
 }
 
@@ -2708,6 +2808,197 @@ mod tests {
         assert_eq!(
             app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
             Some("hello")
+        );
+    }
+
+    // ── CaseOpCell / CaseOpRange ─────────────────────────────────────────────
+
+    #[test]
+    fn toggle_first_uppercases_first_char_of_lowercase() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToggleFirst,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("Hello")
+        );
+    }
+
+    #[test]
+    fn toggle_first_advances_cursor_right() {
+        let mut app = App::new();
+        app.cursor = (0, 0);
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToggleFirst,
+        });
+        assert_eq!(app.cursor, (0, 1));
+    }
+
+    #[test]
+    fn to_upper_uppercases_entire_cell() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "foo".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToUpper,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("FOO")
+        );
+    }
+
+    #[test]
+    fn to_lower_lowercases_entire_cell() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "HELLO".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToLower,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn toggle_all_toggles_every_char() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "HeLLo".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToggleAll,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("hEllO")
+        );
+    }
+
+    #[test]
+    fn case_op_cell_formula_is_noop_with_status() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "=SUM(A1:A5)".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToUpper,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("=SUM(A1:A5)")
+        );
+        assert!(app.status_message.is_some());
+    }
+
+    #[test]
+    fn case_op_cell_is_undoable() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToUpper,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("HELLO")
+        );
+        app.process_action(Action::Undo);
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn case_op_range_uppercases_all_cells() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "foo".into()));
+        app.process_action(Action::EditCell((0, 1), "BAR".into()));
+        app.process_action(Action::EditCell((0, 2), "baz".into()));
+        app.process_action(Action::CaseOpRange {
+            start: (0, 0),
+            end: (0, 2),
+            op: CaseOp::ToUpper,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("FOO")
+        );
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("BAR")
+        );
+        assert_eq!(
+            app.sheet.get_cell((0, 2)).map(|c| c.raw.as_str()),
+            Some("BAZ")
+        );
+    }
+
+    #[test]
+    fn case_op_range_skips_formula_cells() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::EditCell((0, 1), "=A1".into()));
+        app.process_action(Action::CaseOpRange {
+            start: (0, 0),
+            end: (0, 1),
+            op: CaseOp::ToUpper,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("HELLO")
+        );
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("=A1")
+        );
+    }
+
+    #[test]
+    fn case_op_range_is_undoable() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "foo".into()));
+        app.process_action(Action::EditCell((0, 1), "bar".into()));
+        app.process_action(Action::CaseOpRange {
+            start: (0, 0),
+            end: (0, 1),
+            op: CaseOp::ToUpper,
+        });
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("FOO")
+        );
+        app.process_action(Action::Undo);
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
+            Some("foo")
+        );
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("bar")
+        );
+    }
+
+    #[test]
+    fn dot_repeats_case_op_cell() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "hello".into()));
+        app.process_action(Action::EditCell((0, 1), "world".into()));
+        app.process_action(Action::CaseOpCell {
+            pos: (0, 0),
+            op: CaseOp::ToUpper,
+        });
+        app.cursor = (0, 1);
+        app.process_action(Action::RepeatLastChange);
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).map(|c| c.raw.as_str()),
+            Some("WORLD")
         );
     }
 

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -298,6 +298,7 @@ fn run_loop(
                                     | Action::ClearRange { .. }
                                     | Action::YankRange { .. }
                                     | Action::ChangeRange { .. }
+                                    | Action::CaseOpRange { .. }
                             );
                             if exits {
                                 let anchor = vs.anchor;

--- a/crates/cell-sheet-tui/src/mode/normal.rs
+++ b/crates/cell-sheet-tui/src/mode/normal.rs
@@ -1,4 +1,4 @@
-use crate::action::{Action, Direction, Mode, SearchDirection};
+use crate::action::{Action, CaseOp, Direction, Mode, SearchDirection};
 use crate::app::App;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -183,6 +183,42 @@ impl NormalState {
                 ('g', KeyCode::Char('v')) => {
                     self.discard_count();
                     Action::ReselectLastVisual
+                }
+                ('g', KeyCode::Char('u')) => {
+                    self.discard_count();
+                    self.pending = Some('u');
+                    Action::Noop
+                }
+                ('g', KeyCode::Char('U')) => {
+                    self.discard_count();
+                    self.pending = Some('U');
+                    Action::Noop
+                }
+                ('g', KeyCode::Char('~')) => {
+                    self.discard_count();
+                    self.pending = Some('~');
+                    Action::Noop
+                }
+                ('u', KeyCode::Char('u')) => {
+                    self.discard_count();
+                    Action::CaseOpCell {
+                        pos: app.cursor,
+                        op: CaseOp::ToLower,
+                    }
+                }
+                ('U', KeyCode::Char('U')) => {
+                    self.discard_count();
+                    Action::CaseOpCell {
+                        pos: app.cursor,
+                        op: CaseOp::ToUpper,
+                    }
+                }
+                ('~', KeyCode::Char('~')) => {
+                    self.discard_count();
+                    Action::CaseOpCell {
+                        pos: app.cursor,
+                        op: CaseOp::ToggleAll,
+                    }
                 }
                 ('d', KeyCode::Char('d')) => {
                     let count = self.pending_count.take().unwrap_or(1).max(1);
@@ -459,6 +495,13 @@ impl NormalState {
             KeyCode::Char('.') => {
                 self.discard_count();
                 Action::RepeatLastChange
+            }
+            KeyCode::Char('~') => {
+                self.discard_count();
+                Action::CaseOpCell {
+                    pos: app.cursor,
+                    op: CaseOp::ToggleFirst,
+                }
             }
             _ => {
                 // Unknown key: throw away any pending count so we don't
@@ -1082,8 +1125,9 @@ mod tests {
         let app = App::new();
         let mut state = NormalState::new();
         let _ = state.handle_key(key(KeyCode::Char('5')), &app);
-        // Some key that isn't bound: '~' is not handled in normal mode.
-        let _ = state.handle_key(key(KeyCode::Char('~')), &app);
+        // An unbound key (Tab is here used in the outer digit path where it is unrecognised as a digit).
+        // Use BackTab which is not bound in normal mode.
+        let _ = state.handle_key(key(KeyCode::BackTab), &app);
         assert!(state.pending_count.is_none());
         // Next motion should NOT carry the orphaned 5.
         assert_eq!(
@@ -1289,5 +1333,110 @@ mod tests {
                 end: (15, usize::MAX),
             }
         );
+    }
+
+    // --- case-op key-binding tests ----------------------------------------
+
+    #[test]
+    fn tilde_emits_toggle_first() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('~')), &app),
+            Action::CaseOpCell {
+                pos: (0, 0),
+                op: CaseOp::ToggleFirst,
+            }
+        );
+    }
+
+    #[test]
+    fn guu_emits_to_lower() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('g')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('u')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('u')), &app),
+            Action::CaseOpCell {
+                pos: (0, 0),
+                op: CaseOp::ToLower,
+            }
+        );
+    }
+
+    #[test]
+    fn guu_emits_to_lower_cursor_set() {
+        let mut app = App::new();
+        app.cursor = (2, 3);
+        let mut state = NormalState::new();
+        feed(&mut state, &app, "gu");
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('u')), &app),
+            Action::CaseOpCell {
+                pos: (2, 3),
+                op: CaseOp::ToLower,
+            }
+        );
+    }
+
+    #[test]
+    fn g_upper_u_u_emits_to_upper() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('g')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('U')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('U')), &app),
+            Action::CaseOpCell {
+                pos: (0, 0),
+                op: CaseOp::ToUpper,
+            }
+        );
+    }
+
+    #[test]
+    fn g_tilde_tilde_emits_toggle_all() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('g')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('~')), &app),
+            Action::Noop
+        );
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('~')), &app),
+            Action::CaseOpCell {
+                pos: (0, 0),
+                op: CaseOp::ToggleAll,
+            }
+        );
+    }
+
+    #[test]
+    fn gu_followed_by_non_u_is_noop() {
+        let app = App::new();
+        let mut state = NormalState::new();
+        feed(&mut state, &app, "gu");
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('x')), &app),
+            Action::Noop
+        );
+        assert!(state.pending.is_none());
     }
 }

--- a/crates/cell-sheet-tui/src/mode/visual.rs
+++ b/crates/cell-sheet-tui/src/mode/visual.rs
@@ -1,4 +1,4 @@
-use crate::action::{Action, Direction, Mode};
+use crate::action::{Action, CaseOp, Direction, Mode};
 use crate::app::App;
 use cell_sheet_core::model::CellPos;
 use crossterm::event::{KeyCode, KeyEvent};
@@ -91,6 +91,30 @@ impl VisualState {
             KeyCode::Char('y') => {
                 self.pending_count = None;
                 Action::YankRange { start, end }
+            }
+            KeyCode::Char('u') => {
+                self.pending_count = None;
+                Action::CaseOpRange {
+                    start,
+                    end,
+                    op: CaseOp::ToLower,
+                }
+            }
+            KeyCode::Char('U') => {
+                self.pending_count = None;
+                Action::CaseOpRange {
+                    start,
+                    end,
+                    op: CaseOp::ToUpper,
+                }
+            }
+            KeyCode::Char('~') => {
+                self.pending_count = None;
+                Action::CaseOpRange {
+                    start,
+                    end,
+                    op: CaseOp::ToggleAll,
+                }
             }
             KeyCode::Esc => Action::ChangeMode(Mode::Normal),
             _ => {
@@ -249,5 +273,52 @@ mod tests {
             }
         );
         assert!(state.pending_count.is_none());
+    }
+
+    // --- visual case-op key-binding tests ---------------------------------
+
+    #[test]
+    fn u_emits_to_lower_range() {
+        let mut app = App::new();
+        app.cursor = (1, 2);
+        let mut state = VisualState::new((0, 0), VisualKind::Character);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('u')), &app),
+            Action::CaseOpRange {
+                start: (0, 0),
+                end: (1, 2),
+                op: CaseOp::ToLower,
+            }
+        );
+    }
+
+    #[test]
+    fn shift_u_emits_to_upper_range() {
+        let mut app = App::new();
+        app.cursor = (0, 3);
+        let mut state = VisualState::new((0, 0), VisualKind::Character);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('U')), &app),
+            Action::CaseOpRange {
+                start: (0, 0),
+                end: (0, 3),
+                op: CaseOp::ToUpper,
+            }
+        );
+    }
+
+    #[test]
+    fn tilde_emits_toggle_all_range() {
+        let mut app = App::new();
+        app.cursor = (2, 1);
+        let mut state = VisualState::new((0, 0), VisualKind::Character);
+        assert_eq!(
+            state.handle_key(key(KeyCode::Char('~')), &app),
+            Action::CaseOpRange {
+                start: (0, 0),
+                end: (2, 1),
+                op: CaseOp::ToggleAll,
+            }
+        );
     }
 }


### PR DESCRIPTION
Closes #38.

## Summary

- **Normal mode `~`** — toggles the first character's case and advances the cursor one column right (vim `~` semantics, scoped to one cell)
- **Normal mode `guu`** — lowercases the entire current cell value
- **Normal mode `gUU`** — uppercases the entire current cell value
- **Normal mode `g~~`** — toggles case of every character in the current cell
- **Visual mode `u` / `U` / `~`** — applies lowercase / uppercase / toggle-all to every selected cell
- Formula cells are **always skipped** — the status line says "Cannot change case of a formula cell"
- All operations push a single undo entry, set `last_change` for `.` repeat, and mark the file dirty

## Implementation notes

`guu`, `gUU`, and `g~~` reuse the existing two-key pending machinery (`dd`/`yy` pattern): pressing `g` sets `pending = Some('g')`, the second key (`u`/`U`/`~`) clears that and sets a new single-char pending state, and the third key fires the action. This keeps the state machine uniform with existing doubled-operator commands.

`CaseOpRange` is added to the visual-mode exits list in `main.rs` so that the selection is torn down and Normal mode is restored after the operation.

## Test plan

- `cargo test` — 401 tests, 0 failures
- `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS=-Dwarnings` — clean
- `cargo fmt --all --check` — clean

All spec test cases from the issue are covered:
- `"hello"` after `~` → `"Hello"`, cursor advances one column
- `"foo"` after `gUU` → `"FOO"`
- Visual range `["foo", "BAR", "baz"]` after `U` → `["FOO", "BAR", "BAZ"]`
- Formula cell: no change, status message present


Made with [Cursor](https://cursor.com)