### PR TITLE
perf: batch multi-cell recalculation, fix ChangeRange and DeleteRow stale values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 - `ChangeRange` (`c` in Visual mode) now calls `mark_dirty` on dependents and
   triggers a single topological recalculation after clearing the range.
-  Previously, formulas that referenced cleared cells kept stale values (#8).
+  Previously, formulas that referenced cleared cells kept stale values
+  ([#66](https://github.com/garritfra/cell/pull/66)).
 - `DeleteRow` (`dd` / `Ndd`) now calls `mark_dirty` on dependents and triggers
   a single topological recalculation after clearing the row(s). Previously,
-  formulas that referenced deleted cells kept stale values (#8).
+  formulas that referenced deleted cells kept stale values
+  ([#66](https://github.com/garritfra/cell/pull/66)).
 
 ### Added
 
@@ -18,11 +20,12 @@
   topological-recalc cost once instead of once per cell. All built-in
   multi-cell paths (paste, clear-range, delete-row, undo/redo of ranges) now
   route through this API, making the deferred-recalc invariant explicit and
-  correctly nestable (#8).
+  correctly nestable ([#66](https://github.com/garritfra/cell/pull/66)).
 - Criterion benchmarks in `cell-sheet-core` (`cargo bench -p cell-sheet-core`):
   `edit_cells/unbatched` vs `edit_cells/batched` (demonstrating N× speedup),
   `recalculate/fanout` (single-pass cost at various formula counts), and
-  `mark_dirty/deep_chain` (BFS propagation depth) (#8).
+  `mark_dirty/deep_chain` (BFS propagation depth)
+  ([#66](https://github.com/garritfra/cell/pull/66)).
 
 - Vim-style numeric count prefix in normal mode: type digits before a motion or
   operator to repeat or scale it. `5j` moves five rows down, `10G` jumps to row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 ## Unreleased
 
+### Fixed
+
+- `ChangeRange` (`c` in Visual mode) now calls `mark_dirty` on dependents and
+  triggers a single topological recalculation after clearing the range.
+  Previously, formulas that referenced cleared cells kept stale values (#8).
+- `DeleteRow` (`dd` / `Ndd`) now calls `mark_dirty` on dependents and triggers
+  a single topological recalculation after clearing the row(s). Previously,
+  formulas that referenced deleted cells kept stale values (#8).
+
 ### Added
+
+- `App::begin_batch` / `App::commit_batch` API for deferred recalculation.
+  Wrap any sequence of `EditCell` actions in a batch to pay the O(graph)
+  topological-recalc cost once instead of once per cell. All built-in
+  multi-cell paths (paste, clear-range, delete-row, undo/redo of ranges) now
+  route through this API, making the deferred-recalc invariant explicit and
+  correctly nestable (#8).
+- Criterion benchmarks in `cell-sheet-core` (`cargo bench -p cell-sheet-core`):
+  `edit_cells/unbatched` vs `edit_cells/batched` (demonstrating N× speedup),
+  `recalculate/fanout` (single-pass cost at various formula counts), and
+  `mark_dirty/deep_chain` (BFS propagation depth) (#8).
 
 - Vim-style numeric count prefix in normal mode: type digits before a motion or
   operator to repeat or scale it. `5j` moves five rows down, `10G` jumps to row

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +167,7 @@ dependencies = [
 name = "cell-sheet-core"
 version = "0.3.1"
 dependencies = [
+ "criterion",
  "csv",
  "pretty_assertions",
 ]
@@ -181,6 +194,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -261,6 +301,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +387,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -548,6 +655,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +690,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -626,10 +750,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -856,6 +1000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1133,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1261,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -1135,13 +1313,33 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1215,6 +1413,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1518,6 +1725,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,7 +1764,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1595,6 +1812,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1701,6 +1928,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2024,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1902,6 +2148,26 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/cell-sheet-core/Cargo.toml
+++ b/crates/cell-sheet-core/Cargo.toml
@@ -14,3 +14,8 @@ csv = "1.3"
 
 [dev-dependencies]
 pretty_assertions = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "recalc"
+harness = false

--- a/crates/cell-sheet-core/benches/recalc.rs
+++ b/crates/cell-sheet-core/benches/recalc.rs
@@ -1,0 +1,108 @@
+use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use cell_sheet_core::model::Sheet;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+/// Build a sheet with `n` value cells in column A and `n` formula cells in
+/// column B where B_i = =A_i + 1.  Returns a pair ready for timing.
+fn setup_independent_formulas(n: usize) -> (Sheet, DepGraph) {
+    let mut sheet = Sheet::new();
+    let mut deps = DepGraph::new();
+    for i in 0..n {
+        sheet.set_cell((i, 0), &i.to_string());
+        let formula = format!("=A{}", i + 1);
+        set_formula(&mut sheet, &mut deps, (i, 1), &formula);
+    }
+    recalculate(&mut sheet, &deps);
+    (sheet, deps)
+}
+
+/// Simulate N sequential single-cell edits where each write is immediately
+/// followed by mark_dirty + recalculate — the unbatched O(n × graph) path
+/// that occurs when N independent EditCell actions fire without a batch.
+fn bench_unbatched_n_edits(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edit_cells/unbatched");
+    for n in [10usize, 50, 100] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter(|| {
+                let (mut sheet, deps) = setup_independent_formulas(n);
+                for i in 0..n {
+                    sheet.set_cell((i, 0), &(i + 100).to_string());
+                    mark_dirty(&mut sheet, &deps, (i, 0));
+                    recalculate(black_box(&mut sheet), black_box(&deps));
+                }
+                black_box(sheet)
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Same N edits batched: mark_dirty N times, then a single recalculate.
+/// Demonstrates O(graph) cost vs O(n × graph) for the unbatched path.
+fn bench_batched_n_edits(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edit_cells/batched");
+    for n in [10usize, 50, 100] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter(|| {
+                let (mut sheet, deps) = setup_independent_formulas(n);
+                for i in 0..n {
+                    sheet.set_cell((i, 0), &(i + 100).to_string());
+                    mark_dirty(&mut sheet, &deps, (i, 0));
+                }
+                recalculate(black_box(&mut sheet), black_box(&deps));
+                black_box(sheet)
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark a single recalculate call on a sheet with F independent
+/// formula cells — measures the base cost of one topological pass.
+fn bench_recalculate_fanout(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recalculate/fanout");
+    for n in [100usize, 500, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            let (mut sheet, deps) = setup_independent_formulas(n);
+            for i in 0..n {
+                mark_dirty(&mut sheet, &deps, (i, 0));
+            }
+            b.iter(|| {
+                recalculate(black_box(&mut sheet), black_box(&deps));
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark mark_dirty BFS on a deep chain: B1=A1+1, C1=B1+1, …
+/// Measures propagation cost for a max-depth dependency chain.
+fn bench_mark_dirty_deep_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mark_dirty/deep_chain");
+    for depth in [10usize, 50, 100] {
+        group.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, &depth| {
+            let mut sheet = Sheet::new();
+            let mut deps = DepGraph::new();
+            sheet.set_cell((0, 0), "1");
+            for col in 1..depth {
+                let prev_label = cell_sheet_core::model::col_index_to_label(col - 1);
+                let formula = format!("={prev_label}1+1");
+                set_formula(&mut sheet, &mut deps, (0, col), &formula);
+            }
+            recalculate(&mut sheet, &deps);
+            b.iter(|| {
+                mark_dirty(black_box(&mut sheet), black_box(&deps), (0, 0));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_unbatched_n_edits,
+    bench_batched_n_edits,
+    bench_recalculate_fanout,
+    bench_mark_dirty_deep_chain,
+);
+criterion_main!(benches);

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -48,6 +48,10 @@ pub struct App {
     pub jump_list: Vec<CellPos>,
     pub jump_idx: usize,
     pub last_visual: Option<LastVisual>,
+    /// Depth counter for deferred recalculation batches.
+    /// When > 0, `EditCell` skips `recalculate`; `commit_batch` triggers it
+    /// once when the outermost batch is closed.
+    batch_depth: u32,
 }
 
 const JUMP_LIST_CAP: usize = 100;
@@ -88,6 +92,7 @@ impl App {
             jump_list: Vec::new(),
             jump_idx: 0,
             last_visual: None,
+            batch_depth: 0,
         }
     }
 
@@ -155,7 +160,9 @@ impl App {
                     self.sheet.set_cell(pos, &raw);
                 }
                 mark_dirty(&mut self.sheet, &self.deps, pos);
-                recalculate(&mut self.sheet, &self.deps);
+                if self.batch_depth == 0 {
+                    recalculate(&mut self.sheet, &self.deps);
+                }
                 self.dirty = true;
             }
             Action::ChangeMode(mode) => {
@@ -216,6 +223,8 @@ impl App {
             }
             Action::ChangeRange { start, end } => {
                 let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
+                let mut changes = Vec::new();
+                self.begin_batch();
                 for row in start.0..=end.0 {
                     for col in start.1..=max_col {
                         let old_raw = self
@@ -224,16 +233,16 @@ impl App {
                             .map(|c| c.raw.clone())
                             .unwrap_or_default();
                         if !old_raw.is_empty() {
-                            self.undo_stack.push(UndoEntry::CellEdit {
-                                pos: (row, col),
-                                old_raw,
-                                new_raw: String::new(),
-                            });
-                            self.sheet.clear_cell((row, col));
+                            changes.push(((row, col), old_raw, String::new()));
+                            self.write_cell_raw((row, col), "");
                         }
                     }
                 }
-                self.dirty = true;
+                if !changes.is_empty() {
+                    self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
+                    self.dirty = true;
+                }
+                self.commit_batch();
                 self.insert_buffer = String::new();
                 self.mode = Mode::Insert;
             }
@@ -494,6 +503,7 @@ impl App {
                 let max_col = end.1.min(self.sheet.col_count.saturating_sub(1));
                 let mut block = Vec::new();
                 let mut changes = Vec::new();
+                self.begin_batch();
                 for row in start.0..=end.0 {
                     let mut row_data = Vec::new();
                     for col in start.1..=max_col {
@@ -513,14 +523,15 @@ impl App {
                 self.register = Some(Register::Block(block));
                 if !changes.is_empty() {
                     self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
-                    recalculate(&mut self.sheet, &self.deps);
                     self.dirty = true;
                 }
+                self.commit_batch();
             }
             Action::DeleteRow { start, count } => {
                 let count = count.max(1);
                 let cols = self.sheet.col_count;
                 let mut changes = Vec::new();
+                self.begin_batch();
                 if count == 1 {
                     let mut cells = Vec::with_capacity(cols);
                     for col in 0..cols {
@@ -531,7 +542,7 @@ impl App {
                             .unwrap_or_default();
                         if !raw.is_empty() {
                             changes.push(((start, col), raw.clone(), String::new()));
-                            self.sheet.clear_cell((start, col));
+                            self.write_cell_raw((start, col), "");
                         }
                         cells.push(raw);
                     }
@@ -548,7 +559,7 @@ impl App {
                                 .unwrap_or_default();
                             if !raw.is_empty() {
                                 changes.push(((r, col), raw.clone(), String::new()));
-                                self.sheet.clear_cell((r, col));
+                                self.write_cell_raw((r, col), "");
                             }
                             row_cells.push(raw);
                         }
@@ -560,11 +571,13 @@ impl App {
                     self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
                     self.dirty = true;
                 }
+                self.commit_batch();
             }
             Action::Paste(pos) | Action::PasteBefore(pos) => {
                 let is_after = matches!(action, Action::Paste(_));
                 if let Some(reg) = &self.register.clone() {
                     let mut changes: Vec<(CellPos, String, String)> = Vec::new();
+                    self.begin_batch();
                     match reg {
                         Register::Cell(raw) => {
                             let adjusted = crate::clipboard::adjust_formula(raw, 0, 0);
@@ -659,9 +672,9 @@ impl App {
                     }
                     if !changes.is_empty() {
                         self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
-                        recalculate(&mut self.sheet, &self.deps);
                         self.dirty = true;
                     }
+                    self.commit_batch();
                 }
             }
             Action::NextNonEmpty(count) => {
@@ -1027,15 +1040,39 @@ impl App {
             } => {
                 let raw = if redo { new_raw } else { old_raw };
                 self.write_cell_raw(*pos, raw);
-                recalculate(&mut self.sheet, &self.deps);
+                if self.batch_depth == 0 {
+                    recalculate(&mut self.sheet, &self.deps);
+                }
             }
             UndoEntry::MultiCellEdit { changes } => {
+                self.begin_batch();
                 for (pos, old_raw, new_raw) in changes {
                     let raw = if redo { new_raw } else { old_raw };
                     self.write_cell_raw(*pos, raw);
                 }
-                recalculate(&mut self.sheet, &self.deps);
+                self.commit_batch();
             }
+        }
+    }
+
+    /// Start a deferred-recalculation batch. While a batch is active,
+    /// `EditCell` writes cells and marks them dirty but defers the full
+    /// topological recalc. The recalc runs once when `commit_batch` returns
+    /// the depth to zero. Batches nest: every `begin_batch` must have a
+    /// matching `commit_batch`.
+    pub fn begin_batch(&mut self) {
+        self.batch_depth += 1;
+    }
+
+    /// End a deferred-recalculation batch. Triggers `recalculate` exactly
+    /// once when the outermost batch is committed (depth returns to zero).
+    pub fn commit_batch(&mut self) {
+        if self.batch_depth == 0 {
+            return;
+        }
+        self.batch_depth -= 1;
+        if self.batch_depth == 0 {
+            recalculate(&mut self.sheet, &self.deps);
         }
     }
 
@@ -2421,6 +2458,142 @@ mod tests {
         assert!(
             !msg.contains("Non-standard delimiter"),
             "ForceSave should bypass delimiter warning, got: {msg:?}"
+        );
+    }
+
+    // ── ChangeRange recalculation ───────────────────────────────────────────
+
+    #[test]
+    fn change_range_updates_dependents() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 1), "99".into()));
+        app.process_action(Action::EditCell((0, 0), "=B1".into()));
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(99.0)
+        );
+        app.process_action(Action::ChangeRange {
+            start: (0, 1),
+            end: (0, 1),
+        });
+        // B1 was cleared; =B1 must not keep the stale 99 value
+        let val = app.sheet.get_cell((0, 0)).map(|c| c.value.clone());
+        assert_ne!(
+            val,
+            Some(cell_sheet_core::model::CellValue::Number(99.0)),
+            "A1 must not keep stale value after B1 is cleared by ChangeRange"
+        );
+    }
+
+    // ── DeleteRow recalculation ─────────────────────────────────────────────
+
+    #[test]
+    fn delete_row_updates_dependents() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "10".into()));
+        app.process_action(Action::EditCell((0, 1), "20".into()));
+        app.process_action(Action::EditCell((1, 0), "=A1+B1".into()));
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(30.0)
+        );
+        app.process_action(Action::DeleteRow { start: 0, count: 1 });
+        let val = app.sheet.get_cell((1, 0)).map(|c| c.value.clone());
+        assert_ne!(
+            val,
+            Some(cell_sheet_core::model::CellValue::Number(30.0)),
+            "formula depending on deleted row must not keep stale value"
+        );
+    }
+
+    #[test]
+    fn delete_multiple_rows_updates_dependents() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "5".into()));
+        app.process_action(Action::EditCell((1, 0), "7".into()));
+        app.process_action(Action::EditCell((2, 0), "=A1+A2".into()));
+        assert_eq!(
+            app.sheet.get_cell((2, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(12.0)
+        );
+        app.process_action(Action::DeleteRow { start: 0, count: 2 });
+        let val = app.sheet.get_cell((2, 0)).map(|c| c.value.clone());
+        assert_ne!(
+            val,
+            Some(cell_sheet_core::model::CellValue::Number(12.0)),
+            "formula depending on deleted rows must not keep stale value"
+        );
+    }
+
+    // ── begin_batch / commit_batch ──────────────────────────────────────────
+
+    #[test]
+    fn begin_commit_batch_defers_recalc() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "1".into()));
+        app.process_action(Action::EditCell((1, 0), "=A1".into()));
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(1.0)
+        );
+
+        app.begin_batch();
+        app.process_action(Action::EditCell((0, 0), "42".into()));
+        // Inside the batch, A2 must be dirty but not yet recalculated.
+        assert!(
+            app.sheet.get_cell((1, 0)).map(|c| c.dirty).unwrap_or(false),
+            "A2 should be dirty inside a batch"
+        );
+        app.commit_batch();
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(42.0),
+            "A2 must be recalculated after commit_batch"
+        );
+    }
+
+    #[test]
+    fn batch_inter_dependent_cells() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "5".into()));
+        app.process_action(Action::EditCell((0, 1), "=A1".into()));
+        app.process_action(Action::EditCell((0, 2), "=B1".into()));
+
+        app.begin_batch();
+        app.process_action(Action::EditCell((0, 0), "99".into()));
+        app.commit_batch();
+
+        assert_eq!(
+            app.sheet.get_cell((0, 1)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(99.0)
+        );
+        assert_eq!(
+            app.sheet.get_cell((0, 2)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(99.0)
+        );
+    }
+
+    #[test]
+    fn nested_batches_recalc_on_outermost_commit() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "1".into()));
+        app.process_action(Action::EditCell((1, 0), "=A1".into()));
+
+        app.begin_batch();
+        app.begin_batch();
+        app.process_action(Action::EditCell((0, 0), "10".into()));
+        // First commit — still inside outer batch; no recalc yet.
+        app.commit_batch();
+        assert!(
+            app.sheet.get_cell((1, 0)).map(|c| c.dirty).unwrap_or(false),
+            "A2 must still be dirty after inner commit"
+        );
+        // Second commit — outermost; recalc fires.
+        app.commit_batch();
+        assert_eq!(
+            app.sheet.get_cell((1, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(10.0),
+            "A2 must be updated after outermost commit"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #8.

- **Bug fix:** `ChangeRange` (`c` in Visual mode) and `DeleteRow` (`dd`/`Ndd`) were calling `sheet.clear_cell()` directly, bypassing `write_cell_raw`. This meant `mark_dirty` was never called on dependent cells, so formulas referencing cleared/deleted cells kept stale values. Both actions now route through `write_cell_raw` and trigger a single `recalculate` via the new batch API.

- **New API:** `App::begin_batch` / `App::commit_batch` for deferred recalculation. While a batch is open, `EditCell` marks cells dirty but skips the full topological recalc; `commit_batch` runs it once when the outermost batch closes. All built-in multi-cell paths (paste, clear-range, change-range, delete-row, multi-cell undo/redo) now route through this API, making the deferred-recalc invariant explicit and correctly nestable.

- **Benchmarks:** Adds `cargo bench -p cell-sheet-core` with four benchmark groups: `edit_cells/unbatched` vs `edit_cells/batched` (demonstrating N× speedup), `recalculate/fanout` (single-pass cost at various formula counts), and `mark_dirty/deep_chain` (BFS propagation depth). These provide a regression baseline for future performance work.

## What changed

| Path | Change |
|------|--------|
| `crates/cell-sheet-tui/src/app.rs` | `begin_batch`/`commit_batch` on `App`; `ChangeRange`, `DeleteRow`, `ClearRange`, `Paste`, `apply_undo_entry` all use the batch API; 6 new tests |
| `crates/cell-sheet-core/Cargo.toml` | `criterion` dev-dependency + `[[bench]]` |
| `crates/cell-sheet-core/benches/recalc.rs` | New benchmark file |
| `CHANGELOG.md` | Entries under `## Unreleased` |

## Test plan

- [x] `cargo test` — 215 + 20 integration tests pass
- [x] `cargo clippy --workspace --all-targets --all-features` — no warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo bench -p cell-sheet-core --bench recalc -- --test` — all bench cases compile and succeed

New regression tests added:
- `change_range_updates_dependents` — `=B1` formula updates after `ChangeRange` clears B1
- `delete_row_updates_dependents` — formula updates after `DeleteRow`
- `delete_multiple_rows_updates_dependents` — same for `Ndd`
- `begin_commit_batch_defers_recalc` — inside a batch, dependents are dirty but not yet evaluated; evaluated on `commit_batch`
- `batch_inter_dependent_cells` — chain A1→B1→C1 resolves correctly through a batch
- `nested_batches_recalc_on_outermost_commit` — inner `commit_batch` does not trigger recalc; outer does


Made with [Cursor](https://cursor.com)