### PR TITLE
feat(tui): mouse support (#70)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,9 @@ When changing serialization, double-check round-trip behavior:
   `[Releasing](README.md#releasing)` flow — that's a maintainer action.
 - Force-pushing, rewriting published history, or skipping pre-commit hooks.
 - Generating very long binary blobs, hashes, or auto-generated payloads.
+- Enabling mouse capture unconditionally. Mouse support is opt-in via
+  the `mouse_enabled` runtime flag set by `:set mouse on`; do not
+  bypass it.
 
 ## Further reading
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,25 @@
 
 ### Added
 
-- Optional mouse support (off by default; enable with `:set mouse on`).
-  Left-click moves the cursor; click+drag selects a range; clicks on
-  column/row headers select whole columns/rows; scroll wheel scrolls
-  the viewport without moving the cursor; double-click enters Insert
-  mode. Hold Shift (or your terminal's bypass modifier) to use native
-  text selection for copy. (#70)
+- Optional mouse support, off by default. Toggle at runtime with
+  `:set mouse on | off | toggle`. When enabled: left-click moves the
+  cursor; click+drag inside the grid selects a Visual (Character)
+  range; click+drag on a column header selects whole columns and on
+  a row header selects whole rows (anchor stays at the click site so
+  the highlighted cell is where you pointed); scroll wheel scrolls
+  the viewport up/down by 3 rows without moving the cursor (matches
+  Vim's mouse behavior); horizontal wheel scrolls left/right when the
+  terminal emits `ScrollLeft` / `ScrollRight` (commonly Shift+wheel);
+  double-click on a cell enters Insert mode on it; dragging past the
+  visible edge auto-scrolls the viewport. A click on a grid cell
+  while in Insert mode commits the in-progress edit, in Command mode
+  cancels the prompt (preserving search-origin restore), and in Visual
+  mode exits the selection (preserving the `gv` snapshot) before the
+  cursor moves. Clicks on padding, the formula bar, or the status bar
+  are always no-ops. Hold Shift (or your terminal's bypass modifier
+  — Option/Alt on macOS Terminal/iTerm) to fall back to the
+  terminal's native text selection for copying values out
+  ([#84](https://github.com/garritfra/cell/pull/84))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Optional mouse support (off by default; enable with `:set mouse on`).
+  Left-click moves the cursor; click+drag selects a range; clicks on
+  column/row headers select whole columns/rows; scroll wheel scrolls
+  the viewport without moving the cursor; double-click enters Insert
+  mode. Hold Shift (or your terminal's bypass modifier) to use native
+  text selection for copy. (#70)
+
 ### Fixed
 
 - `:help` and the `:help <topic>` lookup now know about the 0.3.0 viewport

--- a/README.md
+++ b/README.md
@@ -178,6 +178,35 @@ Extend the selection with `hjkl` (or `[count]j` etc.), then:
 In the `:` prompt, `↑` / `↓` cycle through previously executed commands.
 
 
+## Mouse support
+
+Mouse support is **off by default** so the terminal's native text
+selection keeps working. Enable it at runtime with `:set mouse on`,
+disable it with `:set mouse off`, or flip the current state with
+`:set mouse toggle`.
+
+When enabled:
+
+- **Left-click** on a cell moves the cursor.
+- **Click + drag** inside the grid selects a Visual range.
+- **Click + drag** on a column header selects whole columns.
+- **Click + drag** on a row header selects whole rows.
+- **Scroll wheel** scrolls the viewport (cursor stays put). Horizontal
+  scroll works when the terminal emits `ScrollLeft` / `ScrollRight`
+  (commonly bound to Shift + wheel).
+- **Double-click** a cell to enter Insert mode on it.
+- **Drag past the visible edge** auto-scrolls the viewport.
+
+To copy a cell value out to your system clipboard while mouse mode is
+on, hold your terminal's bypass modifier when clicking and dragging:
+
+| Terminal | Bypass |
+| --- | --- |
+| Linux terminals (gnome-terminal, alacritty, kitty, …) | Shift |
+| Windows Terminal | Shift |
+| macOS Terminal.app, iTerm2 | Option/Alt |
+| tmux / screen | configure per their docs |
+
 ## Formulas
 
 Formulas start with `=` and support Excel-compatible syntax:

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -727,3 +727,81 @@ pub static FORMULA_ENTRIES: &[HelpEntry] = &[
         detail: "Returns one value if a condition is true, another if false.\n\nUsage: =IF(condition, value_if_true, value_if_false)\n\nExamples:\n  =IF(A1>10, \"big\", \"small\")\n  =IF(B2, C2, D2)",
     },
 ];
+
+pub static MOUSE_ENTRIES: &[HelpEntry] = &[
+    HelpEntry {
+        tags: &["mouse", ":set mouse"],
+        category: HelpCategory::Mouse,
+        summary: "Enable / disable mouse support",
+        detail: "Mouse support is OFF by default. Toggle at runtime:\n\
+                 \n\
+                 :set mouse on        Enable mouse capture.\n\
+                 :set mouse off       Disable mouse capture.\n\
+                 :set mouse toggle    Flip the current state.\n\
+                 \n\
+                 When mouse mode is on, the terminal stops doing native\n\
+                 text selection. Hold your terminal's bypass modifier to\n\
+                 fall back to native selection for copy:\n\
+                 \n\
+                 - Linux & Windows Terminal: Shift\n\
+                 - macOS Terminal.app and iTerm2: Option/Alt\n\
+                 - tmux/screen: see your terminal's docs",
+    },
+    HelpEntry {
+        tags: &["mouse-click", "click"],
+        category: HelpCategory::Mouse,
+        summary: "Left-click moves the cursor",
+        detail: "Left-click on a grid cell moves the cursor there. From\n\
+                 Insert mode the in-progress edit is committed first;\n\
+                 from Command mode the prompt is cancelled; from Visual\n\
+                 the selection is exited.\n\
+                 \n\
+                 Click on the formula bar, status bar, or padding around\n\
+                 the grid is a no-op and never commits an edit.",
+    },
+    HelpEntry {
+        tags: &["mouse-drag", "drag"],
+        category: HelpCategory::Mouse,
+        summary: "Click + drag selects a range",
+        detail: "Drag inside the grid: enters Visual mode and extends the\n\
+                 selection from the click cell to the current cell.\n\
+                 \n\
+                 Drag on a column header: selects whole columns.\n\
+                 Drag on a row header: selects whole rows.\n\
+                 \n\
+                 Dragging a cell selection past the visible edge auto-\n\
+                 scrolls the viewport one row/column per drag event.",
+    },
+    HelpEntry {
+        tags: &["mouse-scroll", "scroll-wheel", "wheel"],
+        category: HelpCategory::Mouse,
+        summary: "Scroll wheel scrolls the viewport",
+        detail: "The scroll wheel scrolls the viewport up or down by 3\n\
+                 rows. The cursor does not move, even if it scrolls out\n\
+                 of view (matches Vim's mouse behaviour).\n\
+                 \n\
+                 Horizontal scroll (Shift+wheel on most terminals)\n\
+                 scrolls the viewport left or right when the terminal\n\
+                 emits ScrollLeft / ScrollRight events.",
+    },
+    HelpEntry {
+        tags: &["mouse-double-click", "double-click", "edit-cell"],
+        category: HelpCategory::Mouse,
+        summary: "Double-click enters Insert mode",
+        detail: "Two left-clicks on the same cell within ~400ms enter\n\
+                 Insert mode on that cell. A second click on a different\n\
+                 cell, or after the threshold, is treated as a fresh\n\
+                 single click.",
+    },
+    HelpEntry {
+        tags: &["mouse-bypass", "shift-click"],
+        category: HelpCategory::Mouse,
+        summary: "Shift+click bypasses mouse capture",
+        detail: "Holding Shift while clicking is treated as a no-op by\n\
+                 cell, allowing the terminal's native text selection to\n\
+                 take over. Use this to copy a cell value or formula\n\
+                 string out to your system clipboard. (On macOS\n\
+                 Terminal.app and iTerm2 the bypass modifier is\n\
+                 typically Option/Alt — check your terminal settings.)",
+    },
+];

--- a/crates/cell-sheet-core/src/help/mod.rs
+++ b/crates/cell-sheet-core/src/help/mod.rs
@@ -7,6 +7,7 @@ pub enum HelpCategory {
     Visual,
     Command,
     Formula,
+    Mouse,
 }
 
 impl HelpCategory {
@@ -17,6 +18,7 @@ impl HelpCategory {
             HelpCategory::Visual => "VISUAL MODE",
             HelpCategory::Command => "COMMANDS",
             HelpCategory::Formula => "FORMULAS",
+            HelpCategory::Mouse => "MOUSE",
         }
     }
 }
@@ -49,6 +51,7 @@ impl HelpRegistry {
             VISUAL_ENTRIES,
             COMMAND_ENTRIES,
             FORMULA_ENTRIES,
+            MOUSE_ENTRIES,
         ])
     }
 
@@ -88,7 +91,7 @@ impl HelpRegistry {
     /// Return all categories that have at least one entry, in display order.
     pub fn categories(&self) -> Vec<HelpCategory> {
         use HelpCategory::*;
-        let order = [Normal, Insert, Visual, Command, Formula];
+        let order = [Normal, Insert, Visual, Command, Formula, Mouse];
         order
             .iter()
             .copied()
@@ -170,6 +173,24 @@ mod tests {
         assert!(
             registry.find(":set delimiter").is_some(),
             "missing :set delimiter"
+        );
+        assert!(registry.find("mouse").is_some(), "missing mouse");
+        assert!(
+            registry.find("mouse-click").is_some(),
+            "missing mouse-click"
+        );
+        assert!(
+            registry.find("mouse-scroll").is_some(),
+            "missing mouse-scroll"
+        );
+        assert!(registry.find("mouse-drag").is_some(), "missing mouse-drag");
+        assert!(
+            registry.find("mouse-double-click").is_some(),
+            "missing mouse-double-click"
+        );
+        assert!(
+            registry.find("mouse-bypass").is_some(),
+            "missing mouse-bypass"
         );
     }
 }

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -187,6 +187,14 @@ pub enum Action {
     /// Anchor (or extend) a whole-row selection. The corresponding
     /// VisualBlock setup happens in `run_loop`.
     MouseSelectRow(usize),
+    /// Scroll the viewport. `dy > 0` scrolls toward higher row indices
+    /// (content moves up, viewport reveals rows further down). `dx > 0`
+    /// scrolls right. The cursor is NOT moved (matches Vim's mouse
+    /// behaviour).
+    MouseScroll {
+        dx: i32,
+        dy: i32,
+    },
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -170,6 +170,10 @@ pub enum Action {
     /// Toggle the mouse-enabled flag. The actual `Enable/DisableMouseCapture`
     /// syscall is issued by `run_loop` after observing the flag change.
     SetMouse(bool),
+    /// Flip `App.mouse_enabled` to its opposite. Distinct from
+    /// `SetMouse(b)` so the parser doesn't need to know the current
+    /// state.
+    ToggleMouse,
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -167,6 +167,9 @@ pub enum Action {
     },
     ReselectLastVisual,
     SetDelimiter(u8),
+    /// Toggle the mouse-enabled flag. The actual `Enable/DisableMouseCapture`
+    /// syscall is issued by `run_loop` after observing the flag change.
+    SetMouse(bool),
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -184,6 +184,9 @@ pub enum Action {
     /// VisualBlock setup happens in `run_loop` parallel to the existing
     /// keyboard `v` flow.
     MouseSelectColumn(usize),
+    /// Anchor (or extend) a whole-row selection. The corresponding
+    /// VisualBlock setup happens in `run_loop`.
+    MouseSelectRow(usize),
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -175,6 +175,11 @@ pub enum Action {
     /// state.
     ToggleMouse,
     MouseClickCell(CellPos),
+    /// Drag in progress: extend the cursor to `pos`. The Visual selection
+    /// is set up by `run_loop` on the first drag event after the
+    /// originating `Down(Left)`; subsequent drags just move the cursor and
+    /// the existing `VisualState` re-derives the selection.
+    MouseDragTo(CellPos),
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -174,6 +174,7 @@ pub enum Action {
     /// `SetMouse(b)` so the parser doesn't need to know the current
     /// state.
     ToggleMouse,
+    MouseClickCell(CellPos),
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/action.rs
+++ b/crates/cell-sheet-tui/src/action.rs
@@ -180,6 +180,10 @@ pub enum Action {
     /// originating `Down(Left)`; subsequent drags just move the cursor and
     /// the existing `VisualState` re-derives the selection.
     MouseDragTo(CellPos),
+    /// Anchor (or extend) a whole-column selection. The corresponding
+    /// VisualBlock setup happens in `run_loop` parallel to the existing
+    /// keyboard `v` flow.
+    MouseSelectColumn(usize),
     SetStatus(String),
     /// Re-apply the last recorded cell-mutating operation at the current cursor.
     RepeatLastChange,

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -895,6 +895,11 @@ impl App {
                 self.cursor = (last_row, col);
                 self.viewport.ensure_visible(self.cursor);
             }
+            Action::MouseSelectRow(row) => {
+                let last_col = self.sheet.col_count.saturating_sub(1);
+                self.cursor = (row, last_col);
+                self.viewport.ensure_visible(self.cursor);
+            }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -882,6 +882,10 @@ impl App {
             Action::ToggleMouse => {
                 self.mouse_enabled = !self.mouse_enabled;
             }
+            Action::MouseClickCell(pos) => {
+                self.cursor = pos;
+                self.viewport.ensure_visible(self.cursor);
+            }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }
@@ -2550,6 +2554,15 @@ mod tests {
         assert!(app.mouse_enabled);
         app.process_action(Action::ToggleMouse);
         assert!(!app.mouse_enabled);
+    }
+
+    #[test]
+    fn mouse_click_cell_moves_cursor_and_ensures_visible() {
+        let mut app = App::new();
+        app.process_action(Action::MouseClickCell((50, 5)));
+        assert_eq!(app.cursor, (50, 5));
+        // Viewport must scroll to keep the cursor in view.
+        assert!(app.viewport.row_offset > 0);
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -886,6 +886,10 @@ impl App {
                 self.cursor = pos;
                 self.viewport.ensure_visible(self.cursor);
             }
+            Action::MouseDragTo(pos) => {
+                self.cursor = pos;
+                self.viewport.ensure_visible(self.cursor);
+            }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -891,13 +891,18 @@ impl App {
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::MouseSelectColumn(col) => {
-                let last_row = self.sheet.row_count.saturating_sub(1);
-                self.cursor = (last_row, col);
+                // Cursor stays at the top of the clicked column so the
+                // highlighted cell is where the user pointed; the visual
+                // anchor at (last_row, _) makes the selection rectangle
+                // cover the full column.
+                self.cursor = (0, col);
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::MouseSelectRow(row) => {
-                let last_col = self.sheet.col_count.saturating_sub(1);
-                self.cursor = (row, last_col);
+                // Cursor stays at the leftmost cell of the clicked row;
+                // the visual anchor at (_, last_col) makes the selection
+                // rectangle cover the full row.
+                self.cursor = (row, 0);
                 self.viewport.ensure_visible(self.cursor);
             }
             Action::MouseScroll { dx, dy } => {

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -1,5 +1,6 @@
 use crate::action::{Action, CaseOp, CommandKind, Direction, Mode, SearchDirection};
 use crate::clipboard::Register;
+use crate::mode::mouse::GridLayout;
 use crate::mode::visual::VisualKind;
 use crate::undo::{UndoEntry, UndoStack};
 use crate::viewport::Viewport;
@@ -45,6 +46,9 @@ pub struct App {
     /// the run_loop has issued `EnableMouseCapture` to the terminal and
     /// is routing `Event::Mouse` to `mode::mouse::handle_mouse_event`.
     pub mouse_enabled: bool,
+    /// Geometry from the most recent grid render, used by mouse hit-testing
+    /// on the next event. `None` until the first frame is drawn.
+    pub last_grid_layout: Option<GridLayout>,
     pub help_scroll: usize,
     pub help_topic: Option<String>,
     pub help_registry: HelpRegistry,
@@ -99,6 +103,7 @@ impl App {
             insert_buffer: String::new(),
             delimiter: b',',
             mouse_enabled: false,
+            last_grid_layout: None,
             help_scroll: 0,
             help_topic: None,
             help_registry: HelpRegistry::new(),

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -874,6 +874,9 @@ impl App {
             Action::SetMouse(b) => {
                 self.mouse_enabled = b;
             }
+            Action::ToggleMouse => {
+                self.mouse_enabled = !self.mouse_enabled;
+            }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }
@@ -2525,12 +2528,22 @@ mod tests {
     }
 
     #[test]
-    fn set_mouse_flag_starts_off_and_toggles() {
+    fn set_mouse_action_writes_flag() {
         let mut app = App::new();
         assert!(!app.mouse_enabled);
         app.process_action(Action::SetMouse(true));
         assert!(app.mouse_enabled);
         app.process_action(Action::SetMouse(false));
+        assert!(!app.mouse_enabled);
+    }
+
+    #[test]
+    fn toggle_mouse_flips_flag_from_either_state() {
+        let mut app = App::new();
+        assert!(!app.mouse_enabled);
+        app.process_action(Action::ToggleMouse);
+        assert!(app.mouse_enabled);
+        app.process_action(Action::ToggleMouse);
         assert!(!app.mouse_enabled);
     }
 

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -41,6 +41,10 @@ pub struct App {
     pub should_quit: bool,
     pub insert_buffer: String,
     pub delimiter: u8,
+    /// Off by default. Toggled by `:set mouse on|off|toggle`. When true,
+    /// the run_loop has issued `EnableMouseCapture` to the terminal and
+    /// is routing `Event::Mouse` to `mode::mouse::handle_mouse_event`.
+    pub mouse_enabled: bool,
     pub help_scroll: usize,
     pub help_topic: Option<String>,
     pub help_registry: HelpRegistry,
@@ -94,6 +98,7 @@ impl App {
             should_quit: false,
             insert_buffer: String::new(),
             delimiter: b',',
+            mouse_enabled: false,
             help_scroll: 0,
             help_topic: None,
             help_registry: HelpRegistry::new(),
@@ -865,6 +870,9 @@ impl App {
             Action::SetDelimiter(d) => {
                 self.delimiter = d;
                 self.status_message = Some(format!("Delimiter set to '{}'", d as char));
+            }
+            Action::SetMouse(b) => {
+                self.mouse_enabled = b;
             }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
@@ -2514,6 +2522,16 @@ mod tests {
         let mut app = App::new();
         app.process_action(Action::SetDelimiter(b'\t'));
         assert_eq!(app.delimiter, b'\t');
+    }
+
+    #[test]
+    fn set_mouse_flag_starts_off_and_toggles() {
+        let mut app = App::new();
+        assert!(!app.mouse_enabled);
+        app.process_action(Action::SetMouse(true));
+        assert!(app.mouse_enabled);
+        app.process_action(Action::SetMouse(false));
+        assert!(!app.mouse_enabled);
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -900,6 +900,20 @@ impl App {
                 self.cursor = (row, last_col);
                 self.viewport.ensure_visible(self.cursor);
             }
+            Action::MouseScroll { dx, dy } => {
+                if dy > 0 {
+                    self.viewport.row_offset = self.viewport.row_offset.saturating_add(dy as usize);
+                } else if dy < 0 {
+                    self.viewport.row_offset =
+                        self.viewport.row_offset.saturating_sub((-dy) as usize);
+                }
+                if dx > 0 {
+                    self.viewport.col_offset = self.viewport.col_offset.saturating_add(dx as usize);
+                } else if dx < 0 {
+                    self.viewport.col_offset =
+                        self.viewport.col_offset.saturating_sub((-dx) as usize);
+                }
+            }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -890,6 +890,11 @@ impl App {
                 self.cursor = pos;
                 self.viewport.ensure_visible(self.cursor);
             }
+            Action::MouseSelectColumn(col) => {
+                let last_row = self.sheet.row_count.saturating_sub(1);
+                self.cursor = (last_row, col);
+                self.viewport.ensure_visible(self.cursor);
+            }
             Action::SetStatus(msg) => {
                 self.status_message = Some(msg);
             }

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -419,14 +419,7 @@ fn run_loop(
                                 }
                                 app.command_history_idx = None;
                                 app.command_history_scratch.clear();
-                                let is_toggle = matches!(kind, CommandKind::Colon)
-                                    && cmd.trim() == "set mouse toggle";
                                 let parsed = submit(kind, &cmd);
-                                let parsed = if is_toggle {
-                                    Action::SetMouse(!app.mouse_enabled)
-                                } else {
-                                    parsed
-                                };
                                 app.command_line.clear();
                                 if is_wq {
                                     wq_pending = true;

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -623,6 +623,15 @@ fn run_loop(
                         }
                         _ => {}
                     }
+
+                    if let Action::ChangeMode(Mode::Insert) = &action {
+                        insert_cursor = app
+                            .sheet
+                            .get_cell(app.cursor)
+                            .map(|c| c.raw.len())
+                            .unwrap_or(0);
+                    }
+
                     app.process_action(action);
                 }
                 _ => {}

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -545,8 +545,8 @@ fn run_loop(
                     let layout = app.last_grid_layout.clone();
                     let action =
                         mode::mouse::handle_mouse_event(me, &mut mouse_state, app, layout.as_ref());
-                    if let Action::MouseDragTo(_) = &action {
-                        if app.mode == Mode::Normal {
+                    match &action {
+                        Action::MouseDragTo(_) if app.mode == Mode::Normal => {
                             if let mode::mouse::MouseDragState::DraggingCells { anchor } =
                                 mouse_state.drag
                             {
@@ -555,6 +555,18 @@ fn run_loop(
                                 app.mode = Mode::Visual;
                             }
                         }
+                        Action::MouseSelectColumn(_) => {
+                            if app.mode != Mode::VisualBlock {
+                                if let mode::mouse::MouseDragState::DraggingColumns { anchor_col } =
+                                    mouse_state.drag
+                                {
+                                    visual_state =
+                                        Some(VisualState::new((0, anchor_col), VisualKind::Block));
+                                    app.mode = Mode::VisualBlock;
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                     app.process_action(action);
                 }

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -545,6 +545,17 @@ fn run_loop(
                     let layout = app.last_grid_layout.clone();
                     let action =
                         mode::mouse::handle_mouse_event(me, &mut mouse_state, app, layout.as_ref());
+                    if let Action::MouseDragTo(_) = &action {
+                        if app.mode == Mode::Normal {
+                            if let mode::mouse::MouseDragState::DraggingCells { anchor } =
+                                mouse_state.drag
+                            {
+                                visual_state =
+                                    Some(VisualState::new(anchor, VisualKind::Character));
+                                app.mode = Mode::Visual;
+                            }
+                        }
+                    }
                     app.process_action(action);
                 }
                 _ => {}

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -566,6 +566,17 @@ fn run_loop(
                                 }
                             }
                         }
+                        Action::MouseSelectRow(_) => {
+                            if app.mode != Mode::VisualBlock {
+                                if let mode::mouse::MouseDragState::DraggingRows { anchor_row } =
+                                    mouse_state.drag
+                                {
+                                    visual_state =
+                                        Some(VisualState::new((anchor_row, 0), VisualKind::Block));
+                                    app.mode = Mode::VisualBlock;
+                                }
+                            }
+                        }
                         _ => {}
                     }
                     app.process_action(action);

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -11,7 +11,7 @@ use action::{Action, Mode};
 use app::{App, FileFormat};
 use clap::Parser;
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -148,6 +148,9 @@ fn run_tui(
 
     let result = run_loop(&mut terminal, &mut app);
 
+    if app.mouse_enabled {
+        let _ = execute!(terminal.backend_mut(), DisableMouseCapture);
+    }
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
 
@@ -266,8 +269,20 @@ fn run_loop(
     let mut insert_cursor: usize = 0;
     let mut wq_pending = false;
     let mut help_state = HelpState::new();
+    let mut mouse_state = mode::mouse::MouseState::new();
+    let mut mouse_capture_active = false;
 
     loop {
+        if app.mouse_enabled != mouse_capture_active {
+            if app.mouse_enabled {
+                execute!(terminal.backend_mut(), EnableMouseCapture)?;
+            } else {
+                execute!(terminal.backend_mut(), DisableMouseCapture)?;
+                mouse_state = mode::mouse::MouseState::new();
+            }
+            mouse_capture_active = app.mouse_enabled;
+        }
+
         let grid_height = terminal.size()?.height.saturating_sub(3) as usize;
         // The grid widget uses 1 row for column headers, so data rows = grid_height - 1.
         app.viewport.visible_rows = grid_height.saturating_sub(1);
@@ -298,225 +313,241 @@ fn run_loop(
         })?;
 
         if event::poll(std::time::Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind != KeyEventKind::Press {
-                    continue;
-                }
-
-                app.status_message = None;
-
-                let action = match app.mode {
-                    Mode::Normal => normal_state.handle_key(key, app),
-                    Mode::Insert => match key.code {
-                        KeyCode::Esc | KeyCode::Enter => {
-                            let edit_action = handle_insert_key(key, app);
-                            app.process_action(edit_action);
-                            Action::ChangeMode(Mode::Normal)
-                        }
-                        _ => {
-                            if let Some(insert_action) = handle_insert_char(key) {
-                                match insert_action {
-                                    InsertAction::InsertChar(c) => {
-                                        app.insert_buffer.insert(insert_cursor, c);
-                                        insert_cursor += 1;
-                                    }
-                                    InsertAction::Backspace => {
-                                        if insert_cursor > 0 {
-                                            insert_cursor -= 1;
-                                            app.insert_buffer.remove(insert_cursor);
-                                        }
-                                    }
-                                    InsertAction::Delete => {
-                                        if insert_cursor < app.insert_buffer.len() {
-                                            app.insert_buffer.remove(insert_cursor);
-                                        }
-                                    }
-                                    InsertAction::CursorLeft => {
-                                        insert_cursor = insert_cursor.saturating_sub(1);
-                                    }
-                                    InsertAction::CursorRight => {
-                                        insert_cursor =
-                                            (insert_cursor + 1).min(app.insert_buffer.len());
-                                    }
-                                    InsertAction::CursorHome => {
-                                        insert_cursor = 0;
-                                    }
-                                    InsertAction::CursorEnd => {
-                                        insert_cursor = app.insert_buffer.len();
-                                    }
-                                }
-                            }
-                            Action::Noop
-                        }
-                    },
-                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
-                        if let Some(ref mut vs) = visual_state {
-                            let action = vs.handle_key(key, app);
-                            let exits = matches!(
-                                action,
-                                Action::ChangeMode(Mode::Normal)
-                                    | Action::ClearRange { .. }
-                                    | Action::YankRange { .. }
-                                    | Action::ChangeRange { .. }
-                                    | Action::CaseOpRange { .. }
-                            );
-                            if exits {
-                                let anchor = vs.anchor;
-                                let kind = vs.kind;
-                                app.record_last_visual(anchor, kind);
-                                visual_state = None;
-                                app.mode = Mode::Normal;
-                            }
-                            action
-                        } else {
-                            Action::ChangeMode(Mode::Normal)
-                        }
+            match event::read()? {
+                Event::Key(key) => {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
                     }
-                    Mode::Help => help_state.handle_key(key, app, grid_height),
-                    Mode::Command => {
-                        use action::{CommandKind, SearchDirection};
-                        let cmd_action = handle_command_key(key, &app.command_line);
-                        let search_dir = match app.command_kind {
-                            CommandKind::Slash => Some(SearchDirection::Forward),
-                            CommandKind::Question => Some(SearchDirection::Backward),
-                            CommandKind::Colon => None,
-                        };
-                        match cmd_action {
-                            CommandAction::InsertChar(c) => {
-                                app.command_line.push(c);
-                                if let Some(dir) = search_dir {
-                                    Action::SearchIncremental {
-                                        pattern: app.command_line.clone(),
-                                        direction: dir,
+
+                    app.status_message = None;
+
+                    let action = match app.mode {
+                        Mode::Normal => normal_state.handle_key(key, app),
+                        Mode::Insert => match key.code {
+                            KeyCode::Esc | KeyCode::Enter => {
+                                let edit_action = handle_insert_key(key, app);
+                                app.process_action(edit_action);
+                                Action::ChangeMode(Mode::Normal)
+                            }
+                            _ => {
+                                if let Some(insert_action) = handle_insert_char(key) {
+                                    match insert_action {
+                                        InsertAction::InsertChar(c) => {
+                                            app.insert_buffer.insert(insert_cursor, c);
+                                            insert_cursor += 1;
+                                        }
+                                        InsertAction::Backspace => {
+                                            if insert_cursor > 0 {
+                                                insert_cursor -= 1;
+                                                app.insert_buffer.remove(insert_cursor);
+                                            }
+                                        }
+                                        InsertAction::Delete => {
+                                            if insert_cursor < app.insert_buffer.len() {
+                                                app.insert_buffer.remove(insert_cursor);
+                                            }
+                                        }
+                                        InsertAction::CursorLeft => {
+                                            insert_cursor = insert_cursor.saturating_sub(1);
+                                        }
+                                        InsertAction::CursorRight => {
+                                            insert_cursor =
+                                                (insert_cursor + 1).min(app.insert_buffer.len());
+                                        }
+                                        InsertAction::CursorHome => {
+                                            insert_cursor = 0;
+                                        }
+                                        InsertAction::CursorEnd => {
+                                            insert_cursor = app.insert_buffer.len();
+                                        }
                                     }
-                                } else {
-                                    Action::Noop
                                 }
+                                Action::Noop
                             }
-                            CommandAction::Backspace => {
-                                app.command_line.pop();
-                                if let Some(dir) = search_dir {
-                                    Action::SearchIncremental {
-                                        pattern: app.command_line.clone(),
-                                        direction: dir,
-                                    }
-                                } else {
-                                    Action::Noop
-                                }
-                            }
-                            CommandAction::Execute(cmd) => {
-                                let kind = app.command_kind;
-                                let is_wq =
-                                    matches!(kind, CommandKind::Colon) && cmd.trim() == "wq";
-                                // Push non-empty colon commands to history,
-                                // avoiding consecutive duplicates.
-                                if matches!(kind, CommandKind::Colon)
-                                    && !cmd.trim().is_empty()
-                                    && app.command_history.last().map(|s| s.as_str())
-                                        != Some(cmd.trim())
-                                {
-                                    app.command_history.push(cmd.trim().to_string());
-                                }
-                                app.command_history_idx = None;
-                                app.command_history_scratch.clear();
-                                let parsed = submit(kind, &cmd);
-                                app.command_line.clear();
-                                if is_wq {
-                                    wq_pending = true;
-                                }
-                                // Submitting any prompt returns to normal
-                                // mode regardless of whether the action
-                                // ends up moving the cursor.
-                                app.mode = Mode::Normal;
-                                parsed
-                            }
-                            CommandAction::Cancel => {
-                                app.command_history_idx = None;
-                                app.command_history_scratch.clear();
-                                if search_dir.is_some() {
-                                    Action::CancelSearch
-                                } else {
-                                    app.command_line.clear();
+                        },
+                        Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                            if let Some(ref mut vs) = visual_state {
+                                let action = vs.handle_key(key, app);
+                                let exits = matches!(
+                                    action,
                                     Action::ChangeMode(Mode::Normal)
+                                        | Action::ClearRange { .. }
+                                        | Action::YankRange { .. }
+                                        | Action::ChangeRange { .. }
+                                        | Action::CaseOpRange { .. }
+                                );
+                                if exits {
+                                    let anchor = vs.anchor;
+                                    let kind = vs.kind;
+                                    app.record_last_visual(anchor, kind);
+                                    visual_state = None;
+                                    app.mode = Mode::Normal;
                                 }
+                                action
+                            } else {
+                                Action::ChangeMode(Mode::Normal)
                             }
-                            CommandAction::HistoryPrev => {
-                                if app.command_history.is_empty() {
-                                    Action::Noop
-                                } else {
-                                    let new_idx = match app.command_history_idx {
-                                        None => {
-                                            // Save current in-progress text before browsing.
-                                            app.command_history_scratch = app.command_line.clone();
-                                            app.command_history.len() - 1
+                        }
+                        Mode::Help => help_state.handle_key(key, app, grid_height),
+                        Mode::Command => {
+                            use action::{CommandKind, SearchDirection};
+                            let cmd_action = handle_command_key(key, &app.command_line);
+                            let search_dir = match app.command_kind {
+                                CommandKind::Slash => Some(SearchDirection::Forward),
+                                CommandKind::Question => Some(SearchDirection::Backward),
+                                CommandKind::Colon => None,
+                            };
+                            match cmd_action {
+                                CommandAction::InsertChar(c) => {
+                                    app.command_line.push(c);
+                                    if let Some(dir) = search_dir {
+                                        Action::SearchIncremental {
+                                            pattern: app.command_line.clone(),
+                                            direction: dir,
                                         }
-                                        Some(i) => i.saturating_sub(1),
-                                    };
-                                    app.command_history_idx = Some(new_idx);
-                                    app.command_line = app.command_history[new_idx].clone();
-                                    Action::Noop
-                                }
-                            }
-                            CommandAction::HistoryNext => {
-                                match app.command_history_idx {
-                                    None => Action::Noop,
-                                    Some(i) => {
-                                        if i + 1 < app.command_history.len() {
-                                            let new_idx = i + 1;
-                                            app.command_history_idx = Some(new_idx);
-                                            app.command_line = app.command_history[new_idx].clone();
-                                        } else {
-                                            // Past the newest entry — restore scratch.
-                                            app.command_history_idx = None;
-                                            app.command_line = app.command_history_scratch.clone();
-                                        }
+                                    } else {
                                         Action::Noop
                                     }
                                 }
+                                CommandAction::Backspace => {
+                                    app.command_line.pop();
+                                    if let Some(dir) = search_dir {
+                                        Action::SearchIncremental {
+                                            pattern: app.command_line.clone(),
+                                            direction: dir,
+                                        }
+                                    } else {
+                                        Action::Noop
+                                    }
+                                }
+                                CommandAction::Execute(cmd) => {
+                                    let kind = app.command_kind;
+                                    let is_wq =
+                                        matches!(kind, CommandKind::Colon) && cmd.trim() == "wq";
+                                    // Push non-empty colon commands to history,
+                                    // avoiding consecutive duplicates.
+                                    if matches!(kind, CommandKind::Colon)
+                                        && !cmd.trim().is_empty()
+                                        && app.command_history.last().map(|s| s.as_str())
+                                            != Some(cmd.trim())
+                                    {
+                                        app.command_history.push(cmd.trim().to_string());
+                                    }
+                                    app.command_history_idx = None;
+                                    app.command_history_scratch.clear();
+                                    let parsed = submit(kind, &cmd);
+                                    app.command_line.clear();
+                                    if is_wq {
+                                        wq_pending = true;
+                                    }
+                                    // Submitting any prompt returns to normal
+                                    // mode regardless of whether the action
+                                    // ends up moving the cursor.
+                                    app.mode = Mode::Normal;
+                                    parsed
+                                }
+                                CommandAction::Cancel => {
+                                    app.command_history_idx = None;
+                                    app.command_history_scratch.clear();
+                                    if search_dir.is_some() {
+                                        Action::CancelSearch
+                                    } else {
+                                        app.command_line.clear();
+                                        Action::ChangeMode(Mode::Normal)
+                                    }
+                                }
+                                CommandAction::HistoryPrev => {
+                                    if app.command_history.is_empty() {
+                                        Action::Noop
+                                    } else {
+                                        let new_idx = match app.command_history_idx {
+                                            None => {
+                                                // Save current in-progress text before browsing.
+                                                app.command_history_scratch =
+                                                    app.command_line.clone();
+                                                app.command_history.len() - 1
+                                            }
+                                            Some(i) => i.saturating_sub(1),
+                                        };
+                                        app.command_history_idx = Some(new_idx);
+                                        app.command_line = app.command_history[new_idx].clone();
+                                        Action::Noop
+                                    }
+                                }
+                                CommandAction::HistoryNext => {
+                                    match app.command_history_idx {
+                                        None => Action::Noop,
+                                        Some(i) => {
+                                            if i + 1 < app.command_history.len() {
+                                                let new_idx = i + 1;
+                                                app.command_history_idx = Some(new_idx);
+                                                app.command_line =
+                                                    app.command_history[new_idx].clone();
+                                            } else {
+                                                // Past the newest entry — restore scratch.
+                                                app.command_history_idx = None;
+                                                app.command_line =
+                                                    app.command_history_scratch.clone();
+                                            }
+                                            Action::Noop
+                                        }
+                                    }
+                                }
+                                CommandAction::Noop => Action::Noop,
                             }
-                            CommandAction::Noop => Action::Noop,
+                        }
+                    };
+
+                    if let Action::ChangeMode(Mode::Visual) = &action {
+                        visual_state = Some(VisualState::new(app.cursor, VisualKind::Character));
+                    }
+                    if let Action::ChangeMode(Mode::VisualLine) = &action {
+                        visual_state = Some(VisualState::new(app.cursor, VisualKind::Line));
+                    }
+                    if let Action::ChangeMode(Mode::VisualBlock) = &action {
+                        visual_state = Some(VisualState::new(app.cursor, VisualKind::Block));
+                    }
+                    if let Action::ChangeMode(Mode::Insert) = &action {
+                        insert_cursor = app
+                            .sheet
+                            .get_cell(app.cursor)
+                            .map(|c| c.raw.len())
+                            .unwrap_or(0);
+                    }
+                    if matches!(&action, Action::ChangeCell(_) | Action::ChangeRange { .. }) {
+                        insert_cursor = 0;
+                    }
+                    if matches!(&action, Action::ReselectLastVisual) {
+                        if let Some(lv) = app.last_visual {
+                            visual_state = Some(VisualState::new(lv.anchor, lv.kind));
+                            app.cursor = lv.cursor;
+                            app.mode = match lv.kind {
+                                VisualKind::Character => Mode::Visual,
+                                VisualKind::Line => Mode::VisualLine,
+                                VisualKind::Block => Mode::VisualBlock,
+                            };
+                            app.viewport.ensure_visible(app.cursor);
                         }
                     }
-                };
 
-                if let Action::ChangeMode(Mode::Visual) = &action {
-                    visual_state = Some(VisualState::new(app.cursor, VisualKind::Character));
-                }
-                if let Action::ChangeMode(Mode::VisualLine) = &action {
-                    visual_state = Some(VisualState::new(app.cursor, VisualKind::Line));
-                }
-                if let Action::ChangeMode(Mode::VisualBlock) = &action {
-                    visual_state = Some(VisualState::new(app.cursor, VisualKind::Block));
-                }
-                if let Action::ChangeMode(Mode::Insert) = &action {
-                    insert_cursor = app
-                        .sheet
-                        .get_cell(app.cursor)
-                        .map(|c| c.raw.len())
-                        .unwrap_or(0);
-                }
-                if matches!(&action, Action::ChangeCell(_) | Action::ChangeRange { .. }) {
-                    insert_cursor = 0;
-                }
-                if matches!(&action, Action::ReselectLastVisual) {
-                    if let Some(lv) = app.last_visual {
-                        visual_state = Some(VisualState::new(lv.anchor, lv.kind));
-                        app.cursor = lv.cursor;
-                        app.mode = match lv.kind {
-                            VisualKind::Character => Mode::Visual,
-                            VisualKind::Line => Mode::VisualLine,
-                            VisualKind::Block => Mode::VisualBlock,
-                        };
-                        app.viewport.ensure_visible(app.cursor);
+                    app.process_action(action);
+
+                    if wq_pending && !app.dirty {
+                        app.should_quit = true;
+                        wq_pending = false;
                     }
                 }
-
-                app.process_action(action);
-
-                if wq_pending && !app.dirty {
-                    app.should_quit = true;
-                    wq_pending = false;
+                Event::Mouse(me) => {
+                    if !app.mouse_enabled {
+                        continue;
+                    }
+                    app.status_message = None;
+                    let layout = app.last_grid_layout.clone();
+                    let action =
+                        mode::mouse::handle_mouse_event(me, &mut mouse_state, app, layout.as_ref());
+                    app.process_action(action);
                 }
+                _ => {}
             }
         }
 

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -542,9 +542,42 @@ fn run_loop(
                         continue;
                     }
                     app.status_message = None;
+                    let drag_was_idle = mouse_state.drag == mode::mouse::MouseDragState::Idle;
                     let layout = app.last_grid_layout.clone();
                     let action =
                         mode::mouse::handle_mouse_event(me, &mut mouse_state, app, layout.as_ref());
+
+                    // First click on a grid target while in another mode:
+                    // commit/cancel/exit before dispatching.
+                    let is_first_grid_action = drag_was_idle
+                        && matches!(
+                            &action,
+                            Action::MouseClickCell(_)
+                                | Action::MouseSelectColumn(_)
+                                | Action::MouseSelectRow(_)
+                        );
+                    if is_first_grid_action {
+                        match app.mode {
+                            Mode::Insert => {
+                                let pos = app.cursor;
+                                let buf = std::mem::take(&mut app.insert_buffer);
+                                app.process_action(Action::EditCell(pos, buf));
+                                app.mode = Mode::Normal;
+                            }
+                            Mode::Command => {
+                                app.command_line.clear();
+                                app.command_history_idx = None;
+                                app.command_history_scratch.clear();
+                                app.mode = Mode::Normal;
+                            }
+                            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                                visual_state = None;
+                                app.mode = Mode::Normal;
+                            }
+                            _ => {}
+                        }
+                    }
+
                     match &action {
                         Action::MouseDragTo(_) if app.mode == Mode::Normal => {
                             if let mode::mouse::MouseDragState::DraggingCells { anchor } =

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -604,8 +604,16 @@ fn run_loop(
                                 if let mode::mouse::MouseDragState::DraggingColumns { anchor_col } =
                                     mouse_state.drag
                                 {
-                                    visual_state =
-                                        Some(VisualState::new((0, anchor_col), VisualKind::Block));
+                                    // Anchor at the bottom of the column so
+                                    // the selection rectangle covers the
+                                    // full column while the cursor (set by
+                                    // process_action to row 0) stays at the
+                                    // top — i.e. where the user clicked.
+                                    let last_row = app.sheet.row_count.saturating_sub(1);
+                                    visual_state = Some(VisualState::new(
+                                        (last_row, anchor_col),
+                                        VisualKind::Block,
+                                    ));
                                     app.mode = Mode::VisualBlock;
                                 }
                             }
@@ -615,8 +623,13 @@ fn run_loop(
                                 if let mode::mouse::MouseDragState::DraggingRows { anchor_row } =
                                     mouse_state.drag
                                 {
-                                    visual_state =
-                                        Some(VisualState::new((anchor_row, 0), VisualKind::Block));
+                                    // Mirror image: anchor at the rightmost
+                                    // column, cursor at column 0.
+                                    let last_col = app.sheet.col_count.saturating_sub(1);
+                                    visual_state = Some(VisualState::new(
+                                        (anchor_row, last_col),
+                                        VisualKind::Block,
+                                    ));
                                     app.mode = Mode::VisualBlock;
                                 }
                             }

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -599,39 +599,35 @@ fn run_loop(
                                 app.mode = Mode::Visual;
                             }
                         }
-                        Action::MouseSelectColumn(_) => {
-                            if app.mode != Mode::VisualBlock {
-                                if let mode::mouse::MouseDragState::DraggingColumns { anchor_col } =
-                                    mouse_state.drag
-                                {
-                                    // Anchor at the bottom of the column so
-                                    // the selection rectangle covers the
-                                    // full column while the cursor (set by
-                                    // process_action to row 0) stays at the
-                                    // top — i.e. where the user clicked.
-                                    let last_row = app.sheet.row_count.saturating_sub(1);
-                                    visual_state = Some(VisualState::new(
-                                        (last_row, anchor_col),
-                                        VisualKind::Block,
-                                    ));
-                                    app.mode = Mode::VisualBlock;
-                                }
+                        Action::MouseSelectColumn(_) if app.mode != Mode::VisualBlock => {
+                            if let mode::mouse::MouseDragState::DraggingColumns { anchor_col } =
+                                mouse_state.drag
+                            {
+                                // Anchor at the bottom of the column so
+                                // the selection rectangle covers the
+                                // full column while the cursor (set by
+                                // process_action to row 0) stays at the
+                                // top — i.e. where the user clicked.
+                                let last_row = app.sheet.row_count.saturating_sub(1);
+                                visual_state = Some(VisualState::new(
+                                    (last_row, anchor_col),
+                                    VisualKind::Block,
+                                ));
+                                app.mode = Mode::VisualBlock;
                             }
                         }
-                        Action::MouseSelectRow(_) => {
-                            if app.mode != Mode::VisualBlock {
-                                if let mode::mouse::MouseDragState::DraggingRows { anchor_row } =
-                                    mouse_state.drag
-                                {
-                                    // Mirror image: anchor at the rightmost
-                                    // column, cursor at column 0.
-                                    let last_col = app.sheet.col_count.saturating_sub(1);
-                                    visual_state = Some(VisualState::new(
-                                        (anchor_row, last_col),
-                                        VisualKind::Block,
-                                    ));
-                                    app.mode = Mode::VisualBlock;
-                                }
+                        Action::MouseSelectRow(_) if app.mode != Mode::VisualBlock => {
+                            if let mode::mouse::MouseDragState::DraggingRows { anchor_row } =
+                                mouse_state.drag
+                            {
+                                // Mirror image: anchor at the rightmost
+                                // column, cursor at column 0.
+                                let last_col = app.sheet.col_count.saturating_sub(1);
+                                visual_state = Some(VisualState::new(
+                                    (anchor_row, last_col),
+                                    VisualKind::Block,
+                                ));
+                                app.mode = Mode::VisualBlock;
                             }
                         }
                         _ => {}

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -419,7 +419,14 @@ fn run_loop(
                                 }
                                 app.command_history_idx = None;
                                 app.command_history_scratch.clear();
+                                let is_toggle = matches!(kind, CommandKind::Colon)
+                                    && cmd.trim() == "set mouse toggle";
                                 let parsed = submit(kind, &cmd);
+                                let parsed = if is_toggle {
+                                    Action::SetMouse(!app.mouse_enabled)
+                                } else {
+                                    parsed
+                                };
                                 app.command_line.clear();
                                 if is_wq {
                                     wq_pending = true;

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -565,12 +565,23 @@ fn run_loop(
                                 app.mode = Mode::Normal;
                             }
                             Mode::Command => {
-                                app.command_line.clear();
+                                use action::CommandKind;
                                 app.command_history_idx = None;
                                 app.command_history_scratch.clear();
-                                app.mode = Mode::Normal;
+                                if matches!(
+                                    app.command_kind,
+                                    CommandKind::Slash | CommandKind::Question
+                                ) {
+                                    app.process_action(Action::CancelSearch);
+                                } else {
+                                    app.command_line.clear();
+                                    app.mode = Mode::Normal;
+                                }
                             }
                             Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                                if let Some(vs) = &visual_state {
+                                    app.record_last_visual(vs.anchor, vs.kind);
+                                }
                                 visual_state = None;
                                 app.mode = Mode::Normal;
                             }

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -81,6 +81,17 @@ pub fn parse_command(input: &str) -> Action {
         } else {
             Action::ShowHelp(Some(topic.to_string()))
         }
+    } else if let Some(rest) = input.strip_prefix("set mouse") {
+        let arg = rest.trim();
+        match arg {
+            "on" => Action::SetMouse(true),
+            "off" => Action::SetMouse(false),
+            // The toggle case is rewritten in run_loop, where we have
+            // access to the live mouse_enabled flag. Returning
+            // SetMouse(true) here is a placeholder; run_loop replaces it.
+            "toggle" => Action::SetMouse(true),
+            _ => Action::SetStatus("usage: :set mouse on|off|toggle".into()),
+        }
     } else {
         Action::Noop
     }
@@ -291,6 +302,30 @@ mod tests {
             parse_command("set delimiter=\0"),
             Action::SetStatus(_)
         ));
+    }
+
+    #[test]
+    fn parse_set_mouse_on() {
+        assert_eq!(parse_command("set mouse on"), Action::SetMouse(true));
+    }
+
+    #[test]
+    fn parse_set_mouse_off() {
+        assert_eq!(parse_command("set mouse off"), Action::SetMouse(false));
+    }
+
+    #[test]
+    fn parse_set_mouse_bogus_returns_status_error() {
+        assert!(matches!(
+            parse_command("set mouse bogus"),
+            Action::SetStatus(_)
+        ));
+    }
+
+    #[test]
+    fn parse_set_mouse_toggle() {
+        // Parser produces SetMouse(true); run_loop rewrites toggle vs current state.
+        assert_eq!(parse_command("set mouse toggle"), Action::SetMouse(true));
     }
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/crates/cell-sheet-tui/src/mode/command.rs
+++ b/crates/cell-sheet-tui/src/mode/command.rs
@@ -81,16 +81,14 @@ pub fn parse_command(input: &str) -> Action {
         } else {
             Action::ShowHelp(Some(topic.to_string()))
         }
-    } else if let Some(rest) = input.strip_prefix("set mouse") {
-        let arg = rest.trim();
-        match arg {
+    } else if input == "set mouse" {
+        Action::SetStatus("Usage: :set mouse on|off|toggle".into())
+    } else if let Some(rest) = input.strip_prefix("set mouse ") {
+        match rest.trim() {
             "on" => Action::SetMouse(true),
             "off" => Action::SetMouse(false),
-            // The toggle case is rewritten in run_loop, where we have
-            // access to the live mouse_enabled flag. Returning
-            // SetMouse(true) here is a placeholder; run_loop replaces it.
-            "toggle" => Action::SetMouse(true),
-            _ => Action::SetStatus("usage: :set mouse on|off|toggle".into()),
+            "toggle" => Action::ToggleMouse,
+            _ => Action::SetStatus("Usage: :set mouse on|off|toggle".into()),
         }
     } else {
         Action::Noop
@@ -316,16 +314,27 @@ mod tests {
 
     #[test]
     fn parse_set_mouse_bogus_returns_status_error() {
-        assert!(matches!(
-            parse_command("set mouse bogus"),
-            Action::SetStatus(_)
-        ));
+        let Action::SetStatus(msg) = parse_command("set mouse bogus") else {
+            panic!("expected SetStatus");
+        };
+        assert!(msg.contains("set mouse"), "got: {msg}");
     }
 
     #[test]
     fn parse_set_mouse_toggle() {
-        // Parser produces SetMouse(true); run_loop rewrites toggle vs current state.
-        assert_eq!(parse_command("set mouse toggle"), Action::SetMouse(true));
+        assert_eq!(parse_command("set mouse toggle"), Action::ToggleMouse);
+    }
+
+    #[test]
+    fn parse_set_mousepad_is_not_set_mouse() {
+        // Ensure `set mouse` doesn't swallow longer commands.
+        assert!(matches!(parse_command("set mousepad"), Action::Noop));
+    }
+
+    #[test]
+    fn parse_set_mouse_extra_whitespace() {
+        assert_eq!(parse_command("set mouse   on"), Action::SetMouse(true));
+        assert_eq!(parse_command("set mouse  toggle"), Action::ToggleMouse);
     }
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/crates/cell-sheet-tui/src/mode/mod.rs
+++ b/crates/cell-sheet-tui/src/mode/mod.rs
@@ -1,5 +1,6 @@
 pub mod command;
 pub mod help;
 pub mod insert;
+pub mod mouse;
 pub mod normal;
 pub mod visual;

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -92,12 +92,11 @@ pub enum MouseDragState {
     DraggingCells {
         anchor: CellPos,
     },
-    // `DraggingColumns` / `DraggingRows` are armed by header-drag logic in
-    // Tasks 7+. Keep the variants here so the state machine is complete.
-    #[allow(dead_code)]
     DraggingColumns {
         anchor_col: usize,
     },
+    // `DraggingRows` is armed by header-drag logic in Task 8. Keep the
+    // variant here so the state machine is complete.
     #[allow(dead_code)]
     DraggingRows {
         anchor_row: usize,
@@ -148,11 +147,22 @@ pub fn handle_mouse_event(
                 });
                 Action::MouseClickCell(pos)
             }
+            MouseTarget::ColHeader(c) => {
+                state.drag = MouseDragState::DraggingColumns { anchor_col: c };
+                state.last_click = None;
+                Action::MouseSelectColumn(c)
+            }
             _ => Action::Noop,
         },
         MouseEventKind::Drag(MouseButton::Left) => match state.drag {
             MouseDragState::DraggingCells { .. } => match target {
                 MouseTarget::Cell(pos) => Action::MouseDragTo(pos),
+                _ => Action::Noop,
+            },
+            MouseDragState::DraggingColumns { .. } => match target {
+                MouseTarget::ColHeader(c) | MouseTarget::Cell((_, c)) => {
+                    Action::MouseSelectColumn(c)
+                }
                 _ => Action::Noop,
             },
             _ => Action::Noop,
@@ -368,5 +378,60 @@ mod tests {
         app.process_action(Action::MouseClickCell((1, 0)));
         app.process_action(Action::MouseDragTo((3, 2)));
         assert_eq!(app.cursor, (3, 2));
+    }
+
+    #[test]
+    fn down_on_column_header_emits_select_column() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        // x=18, y=1 → ColHeader(1).
+        let event = synth(MouseEventKind::Down(MouseButton::Left), 18, 1);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseSelectColumn(1)
+        );
+        assert_eq!(
+            state.drag,
+            MouseDragState::DraggingColumns { anchor_col: 1 }
+        );
+    }
+
+    #[test]
+    fn drag_in_column_mode_extends_to_other_column() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 18, 1),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // x=32, y=5 → Cell(_, 2). Drag from col 1 to col 2.
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 32, 5);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseSelectColumn(2)
+        );
+    }
+
+    #[test]
+    fn drag_in_column_mode_back_to_header_extends() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 18, 1),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // x=32, y=1 → ColHeader(2).
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 32, 1);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseSelectColumn(2)
+        );
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -1,12 +1,10 @@
-// Foundation for mouse support. Constructed and called by later tasks
-// (render layer publishes a `GridLayout`, the event loop calls `hit_test`).
-// Until those tasks land the items only have test-side users.
-#![allow(dead_code)]
-
 use cell_sheet_core::model::CellPos;
 
 /// Logical region a screen coordinate maps to. Built by [`hit_test`] from
 /// a [`GridLayout`] published by the render layer.
+// Tests reference every variant, so `#[expect(dead_code)]` would fire as
+// unfulfilled in the test build; fall back to `#[allow]` per review.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MouseTarget {
     Cell(CellPos),
@@ -18,6 +16,10 @@ pub enum MouseTarget {
 /// Geometry snapshot of the most recent grid render. Built by
 /// `render::grid::Grid::render` and stashed on `App` so the next mouse
 /// event can hit-test against accurate coordinates.
+#[expect(
+    dead_code,
+    reason = "wired up by render layer / event loop in Tasks 3-4"
+)]
 #[derive(Debug, Clone)]
 pub struct GridLayout {
     /// Top-left corner of the grid widget (in terminal cells).
@@ -38,6 +40,9 @@ pub struct GridLayout {
 }
 
 /// Map a terminal coordinate to a [`MouseTarget`]. Pure.
+// Tests call `hit_test`, so `#[expect(dead_code)]` would fire as unfulfilled
+// in the test build; fall back to `#[allow]` per review.
+#[allow(dead_code)]
 pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
     let in_x = x >= layout.x && x < layout.x + layout.width;
     let in_y = y >= layout.y && y < layout.y + layout.height;
@@ -152,5 +157,11 @@ mod tests {
         layout.row_offset = 100;
         // y=2 → row_offset_y = 2 - 2 = 0 → row 100
         assert_eq!(hit_test(&layout, 8, 2), MouseTarget::Cell((100, 0)));
+    }
+
+    #[test]
+    fn click_in_inter_column_gap_is_outside() {
+        // x=16 sits between col 0 (6..16) and col 1 (17..29).
+        assert_eq!(hit_test(&fixture(), 16, 3), MouseTarget::Outside);
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -79,6 +79,8 @@ use std::time::Instant;
 #[allow(dead_code)]
 pub const DOUBLE_CLICK_MS: u64 = 400;
 
+pub const MOUSE_SCROLL_LINES: i32 = 3;
+
 #[derive(Debug, Default)]
 pub struct MouseState {
     pub drag: MouseDragState,
@@ -177,6 +179,22 @@ pub fn handle_mouse_event(
             state.drag = MouseDragState::Idle;
             Action::Noop
         }
+        MouseEventKind::ScrollDown => Action::MouseScroll {
+            dx: 0,
+            dy: MOUSE_SCROLL_LINES,
+        },
+        MouseEventKind::ScrollUp => Action::MouseScroll {
+            dx: 0,
+            dy: -MOUSE_SCROLL_LINES,
+        },
+        MouseEventKind::ScrollLeft => Action::MouseScroll {
+            dx: -MOUSE_SCROLL_LINES,
+            dy: 0,
+        },
+        MouseEventKind::ScrollRight => Action::MouseScroll {
+            dx: MOUSE_SCROLL_LINES,
+            dy: 0,
+        },
         _ => Action::Noop,
     }
 }
@@ -491,5 +509,70 @@ mod tests {
             handle_mouse_event(drag, &mut state, &app, Some(&layout)),
             Action::MouseSelectRow(4)
         );
+    }
+
+    #[test]
+    fn scroll_down_emits_positive_dy() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = synth(MouseEventKind::ScrollDown, 8, 3);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 0, dy: 3 }
+        );
+    }
+
+    #[test]
+    fn scroll_up_emits_negative_dy() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = synth(MouseEventKind::ScrollUp, 8, 3);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 0, dy: -3 }
+        );
+    }
+
+    #[test]
+    fn scroll_left_emits_negative_dx() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = synth(MouseEventKind::ScrollLeft, 8, 3);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: -3, dy: 0 }
+        );
+    }
+
+    #[test]
+    fn scroll_right_emits_positive_dx() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = synth(MouseEventKind::ScrollRight, 8, 3);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 3, dy: 0 }
+        );
+    }
+
+    #[test]
+    fn scroll_does_not_move_cursor() {
+        let mut app = App::new();
+        app.cursor = (5, 2);
+        app.process_action(Action::MouseScroll { dx: 0, dy: 3 });
+        assert_eq!(app.cursor, (5, 2));
+        assert_eq!(app.viewport.row_offset, 3);
+    }
+
+    #[test]
+    fn scroll_up_at_top_saturates_to_zero() {
+        let mut app = App::new();
+        // viewport starts at row_offset=0; scrolling up should saturate.
+        app.process_action(Action::MouseScroll { dx: 0, dy: -10 });
+        assert_eq!(app.viewport.row_offset, 0);
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -2,8 +2,8 @@ use cell_sheet_core::model::CellPos;
 
 /// Logical region a screen coordinate maps to. Built by [`hit_test`] from
 /// a [`GridLayout`] published by the render layer.
-// Tests reference every variant, so `#[expect(dead_code)]` would fire as
-// unfulfilled in the test build; fall back to `#[allow]` per review.
+// Reachable from tests, but not yet from the bin entry point (the stub
+// `handle_mouse_event` doesn't call `hit_test`). Tasks 5+ wire it up.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MouseTarget {
@@ -34,8 +34,8 @@ pub struct GridLayout {
 }
 
 /// Map a terminal coordinate to a [`MouseTarget`]. Pure.
-// Tests call `hit_test`, so `#[expect(dead_code)]` would fire as unfulfilled
-// in the test build; fall back to `#[allow]` per review.
+// Reachable from tests, but the bin's `handle_mouse_event` is still a stub.
+// Tasks 5+ call this from the handler body.
 #[allow(dead_code)]
 pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
     let in_x = x >= layout.x && x < layout.x + layout.width;
@@ -73,6 +73,65 @@ pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
         }
     }
     MouseTarget::Outside
+}
+
+use crate::action::Action;
+use crate::app::App;
+use crossterm::event::MouseEvent;
+use std::time::Instant;
+
+// All of these are populated by the stub handler's successors (Tasks 5+).
+// Until then they're constructed only in tests.
+#[allow(dead_code)]
+pub const DOUBLE_CLICK_MS: u64 = 400;
+
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub struct MouseState {
+    pub drag: MouseDragState,
+    pub last_click: Option<LastClick>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MouseDragState {
+    #[default]
+    Idle,
+    DraggingCells {
+        anchor: CellPos,
+    },
+    DraggingColumns {
+        anchor_col: usize,
+    },
+    DraggingRows {
+        anchor_row: usize,
+    },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub struct LastClick {
+    pub at: Instant,
+    pub pos: CellPos,
+}
+
+impl MouseState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Translate a single `MouseEvent` into an `Action`. The handler is the
+/// only place that mutates `state` (drag tracking, double-click history).
+/// `app` and `layout` are read-only; the handler does not own selection
+/// or cursor mutations — those live in `App::process_action`.
+pub fn handle_mouse_event(
+    _event: MouseEvent,
+    _state: &mut MouseState,
+    _app: &App,
+    _layout: Option<&GridLayout>,
+) -> Action {
+    Action::Noop
 }
 
 #[cfg(test)]
@@ -156,5 +215,37 @@ mod tests {
     fn click_in_inter_column_gap_is_outside() {
         // x=16 sits between col 0 (6..16) and col 1 (17..29).
         assert_eq!(hit_test(&fixture(), 16, 3), MouseTarget::Outside);
+    }
+
+    use crate::action::Action;
+    use crate::app::App;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    fn synth(kind: MouseEventKind, x: u16, y: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: x,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn stub_handler_returns_noop() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::Noop
+        );
+    }
+
+    #[test]
+    fn fresh_mouse_state_is_idle() {
+        let s = MouseState::new();
+        assert_eq!(s.drag, MouseDragState::Idle);
+        assert!(s.last_click.is_none());
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -158,23 +158,56 @@ pub fn handle_mouse_event(
             }
             _ => Action::Noop,
         },
-        MouseEventKind::Drag(MouseButton::Left) => match state.drag {
-            MouseDragState::DraggingCells { .. } => match target {
-                MouseTarget::Cell(pos) => Action::MouseDragTo(pos),
-                _ => Action::Noop,
-            },
-            MouseDragState::DraggingColumns { .. } => match target {
-                MouseTarget::ColHeader(c) | MouseTarget::Cell((_, c)) => {
-                    Action::MouseSelectColumn(c)
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if state.drag == MouseDragState::Idle {
+                return Action::Noop;
+            }
+            // Edge auto-scroll: a cell drag landing outside the grid in
+            // the direction of motion advances the viewport one step.
+            // The user keeps holding the drag; the next event lands
+            // inside the freshly-revealed row/column and the
+            // per-drag-state matcher below extends the selection
+            // normally. Only fires for cell drags — for column/row
+            // drags the header/gutter is part of the natural
+            // interaction surface and must not trigger a scroll.
+            if matches!(state.drag, MouseDragState::DraggingCells { .. }) {
+                let grid_bottom = layout.y + layout.height;
+                let grid_right = layout.x + layout.width;
+                let header_y_end = layout.y + layout.header_height;
+                let row_num_x_end = layout.x + layout.row_num_width;
+                if event.row >= grid_bottom {
+                    return Action::MouseScroll { dx: 0, dy: 1 };
                 }
-                _ => Action::Noop,
-            },
-            MouseDragState::DraggingRows { .. } => match target {
-                MouseTarget::RowHeader(r) | MouseTarget::Cell((r, _)) => Action::MouseSelectRow(r),
-                _ => Action::Noop,
-            },
-            _ => Action::Noop,
-        },
+                if event.row < header_y_end {
+                    return Action::MouseScroll { dx: 0, dy: -1 };
+                }
+                if event.column >= grid_right {
+                    return Action::MouseScroll { dx: 1, dy: 0 };
+                }
+                if event.column < row_num_x_end {
+                    return Action::MouseScroll { dx: -1, dy: 0 };
+                }
+            }
+            match state.drag {
+                MouseDragState::DraggingCells { .. } => match target {
+                    MouseTarget::Cell(pos) => Action::MouseDragTo(pos),
+                    _ => Action::Noop,
+                },
+                MouseDragState::DraggingColumns { .. } => match target {
+                    MouseTarget::ColHeader(c) | MouseTarget::Cell((_, c)) => {
+                        Action::MouseSelectColumn(c)
+                    }
+                    _ => Action::Noop,
+                },
+                MouseDragState::DraggingRows { .. } => match target {
+                    MouseTarget::RowHeader(r) | MouseTarget::Cell((r, _)) => {
+                        Action::MouseSelectRow(r)
+                    }
+                    _ => Action::Noop,
+                },
+                MouseDragState::Idle => Action::Noop,
+            }
+        }
         MouseEventKind::Up(MouseButton::Left) => {
             state.drag = MouseDragState::Idle;
             Action::Noop
@@ -383,16 +416,18 @@ mod tests {
     }
 
     #[test]
-    fn drag_outside_grid_is_noop() {
+    fn drag_into_formula_bar_scrolls_up() {
         let app = App::new();
         let mut state = MouseState::new();
         let layout = fixture();
         let down = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
         handle_mouse_event(down, &mut state, &app, Some(&layout));
+        // y=0 is above the grid (in the formula bar region), which the
+        // edge auto-scroll logic treats as "past the top".
         let drag = synth(MouseEventKind::Drag(MouseButton::Left), 8, 0);
         assert_eq!(
             handle_mouse_event(drag, &mut state, &app, Some(&layout)),
-            Action::Noop
+            Action::MouseScroll { dx: 0, dy: -1 }
         );
     }
 
@@ -574,5 +609,83 @@ mod tests {
         // viewport starts at row_offset=0; scrolling up should saturate.
         app.process_action(Action::MouseScroll { dx: 0, dy: -10 });
         assert_eq!(app.viewport.row_offset, 0);
+    }
+
+    #[test]
+    fn drag_past_bottom_emits_scroll_down() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        // Arm DraggingCells first.
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // Layout: y=1, height=10 → grid_bottom = 11. y=11 is past the bottom.
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 8, 11);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 0, dy: 1 }
+        );
+    }
+
+    #[test]
+    fn drag_past_top_emits_scroll_up() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // Layout: y=1, header_height=1 → header_y_end = 2. y=1 is in header
+        // (above the data rows), which counts as "past the top" for drag purposes.
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 8, 1);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 0, dy: -1 }
+        );
+    }
+
+    #[test]
+    fn drag_past_right_emits_scroll_right() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // Layout: x=0, width=40 → grid_right = 40. x=40 is past.
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 40, 5);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 1, dy: 0 }
+        );
+    }
+
+    #[test]
+    fn drag_past_left_into_gutter_emits_scroll_left() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // Layout: x=0, row_num_width=5 → row_num_x_end = 5. x=4 is in gutter.
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 4, 5);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: -1, dy: 0 }
+        );
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -2,9 +2,6 @@ use cell_sheet_core::model::CellPos;
 
 /// Logical region a screen coordinate maps to. Built by [`hit_test`] from
 /// a [`GridLayout`] published by the render layer.
-// Reachable from tests, but not yet from the bin entry point (the stub
-// `handle_mouse_event` doesn't call `hit_test`). Tasks 5+ wire it up.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MouseTarget {
     Cell(CellPos),
@@ -34,9 +31,6 @@ pub struct GridLayout {
 }
 
 /// Map a terminal coordinate to a [`MouseTarget`]. Pure.
-// Reachable from tests, but the bin's `handle_mouse_event` is still a stub.
-// Tasks 5+ call this from the handler body.
-#[allow(dead_code)]
 pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
     let in_x = x >= layout.x && x < layout.x + layout.width;
     let in_y = y >= layout.y && y < layout.y + layout.height;
@@ -77,22 +71,20 @@ pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
 
 use crate::action::Action;
 use crate::app::App;
-use crossterm::event::MouseEvent;
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use std::time::Instant;
 
-// All of these are populated by the stub handler's successors (Tasks 5+).
-// Until then they're constructed only in tests.
+// `DOUBLE_CLICK_MS` is consumed by Task 12's double-click logic; until then
+// it's referenced only by tests.
 #[allow(dead_code)]
 pub const DOUBLE_CLICK_MS: u64 = 400;
 
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct MouseState {
     pub drag: MouseDragState,
     pub last_click: Option<LastClick>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum MouseDragState {
     #[default]
@@ -100,14 +92,20 @@ pub enum MouseDragState {
     DraggingCells {
         anchor: CellPos,
     },
+    // `DraggingColumns` / `DraggingRows` are armed by header-drag logic in
+    // Tasks 7+. Keep the variants here so the state machine is complete.
+    #[allow(dead_code)]
     DraggingColumns {
         anchor_col: usize,
     },
+    #[allow(dead_code)]
     DraggingRows {
         anchor_row: usize,
     },
 }
 
+// Fields are only read by Task 12's double-click logic; for now we just
+// construct the struct on left-down.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub struct LastClick {
@@ -126,12 +124,38 @@ impl MouseState {
 /// `app` and `layout` are read-only; the handler does not own selection
 /// or cursor mutations — those live in `App::process_action`.
 pub fn handle_mouse_event(
-    _event: MouseEvent,
-    _state: &mut MouseState,
+    event: MouseEvent,
+    state: &mut MouseState,
     _app: &App,
-    _layout: Option<&GridLayout>,
+    layout: Option<&GridLayout>,
 ) -> Action {
-    Action::Noop
+    if event.modifiers.contains(KeyModifiers::SHIFT) {
+        return Action::Noop;
+    }
+    let layout = match layout {
+        Some(l) => l,
+        None => return Action::Noop,
+    };
+    let target = hit_test(layout, event.column, event.row);
+
+    match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => match target {
+            MouseTarget::Cell(pos) => {
+                state.drag = MouseDragState::DraggingCells { anchor: pos };
+                state.last_click = Some(LastClick {
+                    at: Instant::now(),
+                    pos,
+                });
+                Action::MouseClickCell(pos)
+            }
+            _ => Action::Noop,
+        },
+        MouseEventKind::Up(MouseButton::Left) => {
+            state.drag = MouseDragState::Idle;
+            Action::Noop
+        }
+        _ => Action::Noop,
+    }
 }
 
 #[cfg(test)]
@@ -231,21 +255,63 @@ mod tests {
     }
 
     #[test]
-    fn stub_handler_returns_noop() {
+    fn fresh_mouse_state_is_idle() {
+        let s = MouseState::new();
+        assert_eq!(s.drag, MouseDragState::Idle);
+        assert!(s.last_click.is_none());
+    }
+
+    #[test]
+    fn down_left_on_cell_in_normal_emits_click() {
         let app = App::new();
         let mut state = MouseState::new();
         let layout = fixture();
         let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
         assert_eq!(
             handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseClickCell((1, 0))
+        );
+        assert_eq!(state.drag, MouseDragState::DraggingCells { anchor: (1, 0) });
+    }
+
+    #[test]
+    fn shift_click_is_noop_for_terminal_passthrough() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 8,
+            row: 3,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::Noop
+        );
+        // Shift-click must NOT arm a drag.
+        assert_eq!(state.drag, MouseDragState::Idle);
+    }
+
+    #[test]
+    fn down_left_with_no_layout_is_noop() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, None),
             Action::Noop
         );
     }
 
     #[test]
-    fn fresh_mouse_state_is_idle() {
-        let s = MouseState::new();
-        assert_eq!(s.drag, MouseDragState::Idle);
-        assert!(s.last_click.is_none());
+    fn up_left_clears_drag_state() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        state.drag = MouseDragState::DraggingCells { anchor: (1, 0) };
+        let layout = fixture();
+        let event = synth(MouseEventKind::Up(MouseButton::Left), 8, 3);
+        let _ = handle_mouse_event(event, &mut state, &app, Some(&layout));
+        assert_eq!(state.drag, MouseDragState::Idle);
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -688,4 +688,28 @@ mod tests {
             Action::MouseScroll { dx: -1, dy: 0 }
         );
     }
+
+    #[test]
+    fn click_in_insert_committed_cell_then_moves() {
+        // Simulate Task 11's run_loop logic by hand: commit Insert
+        // edit, then dispatch MouseClickCell.
+        let mut app = App::new();
+        app.mode = crate::action::Mode::Insert;
+        app.cursor = (0, 0);
+        app.insert_buffer = "hello".to_string();
+
+        let pos = app.cursor;
+        let buf = std::mem::take(&mut app.insert_buffer);
+        app.process_action(Action::EditCell(pos, buf));
+        app.mode = crate::action::Mode::Normal;
+        app.process_action(Action::MouseClickCell((3, 5)));
+
+        assert_eq!(app.cursor, (3, 5));
+        assert_eq!(app.mode, crate::action::Mode::Normal);
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.raw.clone()),
+            Some("hello".into()),
+            "buffer should have been committed"
+        );
+    }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -69,14 +69,11 @@ pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
     MouseTarget::Outside
 }
 
-use crate::action::Action;
+use crate::action::{Action, Mode};
 use crate::app::App;
 use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-// `DOUBLE_CLICK_MS` is consumed by Task 12's double-click logic; until then
-// it's referenced only by tests.
-#[allow(dead_code)]
 pub const DOUBLE_CLICK_MS: u64 = 400;
 
 pub const MOUSE_SCROLL_LINES: i32 = 3;
@@ -102,9 +99,6 @@ pub enum MouseDragState {
     },
 }
 
-// Fields are only read by Task 12's double-click logic; for now we just
-// construct the struct on left-down.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub struct LastClick {
     pub at: Instant,
@@ -139,12 +133,23 @@ pub fn handle_mouse_event(
     match event.kind {
         MouseEventKind::Down(MouseButton::Left) => match target {
             MouseTarget::Cell(pos) => {
-                state.drag = MouseDragState::DraggingCells { anchor: pos };
-                state.last_click = Some(LastClick {
-                    at: Instant::now(),
-                    pos,
-                });
-                Action::MouseClickCell(pos)
+                let now = Instant::now();
+                let is_double = state
+                    .last_click
+                    .map(|lc| {
+                        lc.pos == pos
+                            && now.duration_since(lc.at) <= Duration::from_millis(DOUBLE_CLICK_MS)
+                    })
+                    .unwrap_or(false);
+                if is_double {
+                    state.drag = MouseDragState::Idle;
+                    state.last_click = None;
+                    Action::ChangeMode(Mode::Insert)
+                } else {
+                    state.drag = MouseDragState::DraggingCells { anchor: pos };
+                    state.last_click = Some(LastClick { at: now, pos });
+                    Action::MouseClickCell(pos)
+                }
             }
             MouseTarget::ColHeader(c) => {
                 state.drag = MouseDragState::DraggingColumns { anchor_col: c };
@@ -739,6 +744,74 @@ mod tests {
         assert_eq!(lv.kind, VisualKind::Character);
         assert_eq!(app.cursor, (9, 9));
         assert_eq!(app.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn double_click_enters_insert_mode() {
+        use crate::action::Mode;
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        let _ = handle_mouse_event(event, &mut state, &app, Some(&layout));
+        let event2 = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        assert_eq!(
+            handle_mouse_event(event2, &mut state, &app, Some(&layout)),
+            Action::ChangeMode(Mode::Insert)
+        );
+    }
+
+    #[test]
+    fn click_then_different_cell_is_two_singles() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let _ = handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        let event2 = synth(MouseEventKind::Down(MouseButton::Left), 18, 5);
+        assert_eq!(
+            handle_mouse_event(event2, &mut state, &app, Some(&layout)),
+            Action::MouseClickCell((3, 1))
+        );
+    }
+
+    #[test]
+    fn double_click_clears_drag_and_last_click() {
+        // After firing the double-click action, no stale drag/last_click
+        // should linger so a subsequent third click is a fresh single
+        // click, not a triple-click.
+        use crate::action::Mode;
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let _ = handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        let _ = handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // After the double-click:
+        assert_eq!(state.drag, MouseDragState::Idle);
+        assert!(state.last_click.is_none());
+        // A third click on the same cell is a fresh single click,
+        // because last_click was cleared.
+        let third = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        assert_eq!(
+            handle_mouse_event(third, &mut state, &app, Some(&layout)),
+            Action::MouseClickCell((1, 0))
+        );
+        // And it now has Mode::Insert in scope so the test compiles.
+        let _ = Mode::Insert;
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -29,12 +29,6 @@ pub struct GridLayout {
     pub header_height: u16,
     /// `viewport.row_offset` at render time.
     pub row_offset: usize,
-    /// `viewport.col_offset` at render time. Captured for completeness;
-    /// `hit_test` resolves columns via `visible_cols` so this isn't read
-    /// yet. Will be consumed in Task 4 when the event loop interprets
-    /// scroll wheel events relative to the viewport origin.
-    #[allow(dead_code)]
-    pub col_offset: usize,
     /// Visible columns in left-to-right order: `(col_index, screen_x, width)`.
     pub visible_cols: Vec<(usize, u16, u16)>,
 }
@@ -98,7 +92,6 @@ mod tests {
             row_num_width: 5,
             header_height: 1,
             row_offset: 0,
-            col_offset: 0,
             visible_cols: vec![(0, 6, 10), (1, 17, 12), (2, 30, 8)],
         }
     }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -712,4 +712,58 @@ mod tests {
             "buffer should have been committed"
         );
     }
+
+    #[test]
+    fn click_in_visual_records_last_visual_for_gv() {
+        // Simulate Task 11's Visual-exit branch: snapshot last_visual
+        // BEFORE clearing visual_state, so a later `gv` can re-enter.
+        use crate::action::Mode;
+        use crate::mode::visual::{VisualKind, VisualState};
+
+        let mut app = App::new();
+        app.cursor = (4, 6);
+        app.mode = Mode::Visual;
+        let vs = VisualState::new((2, 3), VisualKind::Character);
+
+        // The exact two lines the run_loop performs on a click in Visual:
+        app.record_last_visual(vs.anchor, vs.kind);
+        app.mode = Mode::Normal;
+        // ...and then the click action is dispatched:
+        app.process_action(Action::MouseClickCell((9, 9)));
+
+        let lv = app.last_visual.expect("last_visual must be recorded");
+        assert_eq!(lv.anchor, (2, 3));
+        // cursor snapshot must capture the pre-click position, not the
+        // post-click position.
+        assert_eq!(lv.cursor, (4, 6));
+        assert_eq!(lv.kind, VisualKind::Character);
+        assert_eq!(app.cursor, (9, 9));
+        assert_eq!(app.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn click_in_command_clears_prompt_and_returns_to_normal() {
+        // Simulate Task 11's Command-cancel branch for the colon prompt.
+        use crate::action::{CommandKind, Mode};
+
+        let mut app = App::new();
+        app.mode = Mode::Command;
+        app.command_kind = CommandKind::Colon;
+        app.command_line = "se".into();
+        app.command_history_idx = Some(0);
+        app.command_history_scratch = "abc".into();
+
+        // The mouse-cancel branch (colon path):
+        app.command_history_idx = None;
+        app.command_history_scratch.clear();
+        app.command_line.clear();
+        app.mode = Mode::Normal;
+        app.process_action(Action::MouseClickCell((1, 1)));
+
+        assert_eq!(app.mode, Mode::Normal);
+        assert!(app.command_line.is_empty());
+        assert!(app.command_history_idx.is_none());
+        assert!(app.command_history_scratch.is_empty());
+        assert_eq!(app.cursor, (1, 1));
+    }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -167,31 +167,48 @@ pub fn handle_mouse_event(
             if state.drag == MouseDragState::Idle {
                 return Action::Noop;
             }
-            // Edge auto-scroll: a cell drag landing outside the grid in
+            // Edge auto-scroll: a drag landing outside the grid in
             // the direction of motion advances the viewport one step.
             // The user keeps holding the drag; the next event lands
             // inside the freshly-revealed row/column and the
             // per-drag-state matcher below extends the selection
-            // normally. Only fires for cell drags — for column/row
-            // drags the header/gutter is part of the natural
-            // interaction surface and must not trigger a scroll.
-            if matches!(state.drag, MouseDragState::DraggingCells { .. }) {
-                let grid_bottom = layout.y + layout.height;
-                let grid_right = layout.x + layout.width;
-                let header_y_end = layout.y + layout.header_height;
-                let row_num_x_end = layout.x + layout.row_num_width;
-                if event.row >= grid_bottom {
-                    return Action::MouseScroll { dx: 0, dy: 1 };
+            // normally. Edge sensitivity is per drag mode: cell drags
+            // scroll on all four edges, column drags only on the
+            // right edge, and row drags only on the bottom edge. The
+            // header band and gutter are the natural anchor surfaces
+            // for column/row drags, so scrolling there would make it
+            // impossible to drag back to a column/row the user
+            // already passed.
+            let grid_bottom = layout.y + layout.height;
+            let grid_right = layout.x + layout.width;
+            let header_y_end = layout.y + layout.header_height;
+            let row_num_x_end = layout.x + layout.row_num_width;
+            match state.drag {
+                MouseDragState::DraggingCells { .. } => {
+                    if event.row >= grid_bottom {
+                        return Action::MouseScroll { dx: 0, dy: 1 };
+                    }
+                    if event.row < header_y_end {
+                        return Action::MouseScroll { dx: 0, dy: -1 };
+                    }
+                    if event.column >= grid_right {
+                        return Action::MouseScroll { dx: 1, dy: 0 };
+                    }
+                    if event.column < row_num_x_end {
+                        return Action::MouseScroll { dx: -1, dy: 0 };
+                    }
                 }
-                if event.row < header_y_end {
-                    return Action::MouseScroll { dx: 0, dy: -1 };
+                MouseDragState::DraggingColumns { .. } => {
+                    if event.column >= grid_right {
+                        return Action::MouseScroll { dx: 1, dy: 0 };
+                    }
                 }
-                if event.column >= grid_right {
-                    return Action::MouseScroll { dx: 1, dy: 0 };
+                MouseDragState::DraggingRows { .. } => {
+                    if event.row >= grid_bottom {
+                        return Action::MouseScroll { dx: 0, dy: 1 };
+                    }
                 }
-                if event.column < row_num_x_end {
-                    return Action::MouseScroll { dx: -1, dy: 0 };
-                }
+                MouseDragState::Idle => {}
             }
             match state.drag {
                 MouseDragState::DraggingCells { .. } => match target {
@@ -838,5 +855,80 @@ mod tests {
         assert!(app.command_history_idx.is_none());
         assert!(app.command_history_scratch.is_empty());
         assert_eq!(app.cursor, (1, 1));
+    }
+
+    #[test]
+    fn double_click_after_long_insert_does_not_panic() {
+        // Regression: double-click → ChangeMode(Insert) must initialize
+        // insert_cursor against the new cell's content length, not carry
+        // a stale value from a prior Insert session. Without the fix in
+        // run_loop's Event::Mouse arm, typing after this sequence would
+        // panic with `byte index N is out of bounds`.
+        //
+        // We can't drive run_loop directly from a unit test, but we can
+        // reproduce the state machine and verify that App's insert_buffer
+        // is rewritten from the new cell's raw on ChangeMode(Insert),
+        // which is what the run_loop initializer reads from.
+        use crate::action::Mode;
+        let mut app = App::new();
+        // First Insert: long content at A1.
+        app.sheet.set_cell((0, 0), "hello world more");
+        // Simulate Esc-out: app.mode is whatever; we just need cell B5
+        // to have shorter content.
+        app.sheet.set_cell((4, 1), "hi");
+        // Cursor is now (4, 1) (as if a click + double-click landed it there).
+        app.cursor = (4, 1);
+        // ChangeMode(Insert) populates insert_buffer from app.cursor's cell.
+        app.process_action(Action::ChangeMode(Mode::Insert));
+        assert_eq!(app.insert_buffer, "hi");
+        // The run_loop initializer would set insert_cursor to
+        // sheet.get_cell(cursor).map(|c| c.raw.len()).unwrap_or(0).
+        // For cell (4, 1) with raw "hi", that's 2.
+        let new_insert_cursor = app
+            .sheet
+            .get_cell(app.cursor)
+            .map(|c| c.raw.len())
+            .unwrap_or(0);
+        assert_eq!(new_insert_cursor, 2);
+    }
+
+    #[test]
+    fn column_drag_past_right_edge_scrolls_right() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        // Down on a column header to arm DraggingColumns.
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 18, 1),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // Drag past the right edge (grid right = x=40).
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 40, 1);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 1, dy: 0 }
+        );
+    }
+
+    #[test]
+    fn row_drag_past_bottom_edge_scrolls_down() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        // Down on a row header to arm DraggingRows.
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 2, 4),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // Drag past the bottom edge (grid bottom = y=11).
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 2, 11);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseScroll { dx: 0, dy: 1 }
+        );
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -16,10 +16,6 @@ pub enum MouseTarget {
 /// Geometry snapshot of the most recent grid render. Built by
 /// `render::grid::Grid::render` and stashed on `App` so the next mouse
 /// event can hit-test against accurate coordinates.
-#[expect(
-    dead_code,
-    reason = "wired up by render layer / event loop in Tasks 3-4"
-)]
 #[derive(Debug, Clone)]
 pub struct GridLayout {
     /// Top-left corner of the grid widget (in terminal cells).
@@ -33,7 +29,11 @@ pub struct GridLayout {
     pub header_height: u16,
     /// `viewport.row_offset` at render time.
     pub row_offset: usize,
-    /// `viewport.col_offset` at render time.
+    /// `viewport.col_offset` at render time. Captured for completeness;
+    /// `hit_test` resolves columns via `visible_cols` so this isn't read
+    /// yet. Will be consumed in Task 4 when the event loop interprets
+    /// scroll wheel events relative to the viewport origin.
+    #[allow(dead_code)]
     pub col_offset: usize,
     /// Visible columns in left-to-right order: `(col_index, screen_x, width)`.
     pub visible_cols: Vec<(usize, u16, u16)>,

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -95,9 +95,6 @@ pub enum MouseDragState {
     DraggingColumns {
         anchor_col: usize,
     },
-    // `DraggingRows` is armed by header-drag logic in Task 8. Keep the
-    // variant here so the state machine is complete.
-    #[allow(dead_code)]
     DraggingRows {
         anchor_row: usize,
     },
@@ -152,6 +149,11 @@ pub fn handle_mouse_event(
                 state.last_click = None;
                 Action::MouseSelectColumn(c)
             }
+            MouseTarget::RowHeader(r) => {
+                state.drag = MouseDragState::DraggingRows { anchor_row: r };
+                state.last_click = None;
+                Action::MouseSelectRow(r)
+            }
             _ => Action::Noop,
         },
         MouseEventKind::Drag(MouseButton::Left) => match state.drag {
@@ -163,6 +165,10 @@ pub fn handle_mouse_event(
                 MouseTarget::ColHeader(c) | MouseTarget::Cell((_, c)) => {
                     Action::MouseSelectColumn(c)
                 }
+                _ => Action::Noop,
+            },
+            MouseDragState::DraggingRows { .. } => match target {
+                MouseTarget::RowHeader(r) | MouseTarget::Cell((r, _)) => Action::MouseSelectRow(r),
                 _ => Action::Noop,
             },
             _ => Action::Noop,
@@ -432,6 +438,58 @@ mod tests {
         assert_eq!(
             handle_mouse_event(drag, &mut state, &app, Some(&layout)),
             Action::MouseSelectColumn(2)
+        );
+    }
+
+    #[test]
+    fn down_on_row_header_emits_select_row() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        // x=2 is the gutter, y=4 → row_offset_y = 2 → row 2.
+        let event = synth(MouseEventKind::Down(MouseButton::Left), 2, 4);
+        assert_eq!(
+            handle_mouse_event(event, &mut state, &app, Some(&layout)),
+            Action::MouseSelectRow(2)
+        );
+        assert_eq!(state.drag, MouseDragState::DraggingRows { anchor_row: 2 });
+    }
+
+    #[test]
+    fn drag_in_row_mode_extends_to_other_row() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 2, 4),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // x=8, y=6 → Cell((4, 0)). Drag from row 2 to row 4.
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 8, 6);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseSelectRow(4)
+        );
+    }
+
+    #[test]
+    fn drag_in_row_mode_back_to_gutter_extends() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        handle_mouse_event(
+            synth(MouseEventKind::Down(MouseButton::Left), 2, 4),
+            &mut state,
+            &app,
+            Some(&layout),
+        );
+        // x=2 is gutter, y=6 → row 4 → RowHeader(4).
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 2, 6);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseSelectRow(4)
         );
     }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -1,0 +1,156 @@
+// Foundation for mouse support. Constructed and called by later tasks
+// (render layer publishes a `GridLayout`, the event loop calls `hit_test`).
+// Until those tasks land the items only have test-side users.
+#![allow(dead_code)]
+
+use cell_sheet_core::model::CellPos;
+
+/// Logical region a screen coordinate maps to. Built by [`hit_test`] from
+/// a [`GridLayout`] published by the render layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseTarget {
+    Cell(CellPos),
+    ColHeader(usize),
+    RowHeader(usize),
+    Outside,
+}
+
+/// Geometry snapshot of the most recent grid render. Built by
+/// `render::grid::Grid::render` and stashed on `App` so the next mouse
+/// event can hit-test against accurate coordinates.
+#[derive(Debug, Clone)]
+pub struct GridLayout {
+    /// Top-left corner of the grid widget (in terminal cells).
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+    /// Width of the row-number gutter on the left edge of the grid.
+    pub row_num_width: u16,
+    /// Height of the column-header row at the top of the grid.
+    pub header_height: u16,
+    /// `viewport.row_offset` at render time.
+    pub row_offset: usize,
+    /// `viewport.col_offset` at render time.
+    pub col_offset: usize,
+    /// Visible columns in left-to-right order: `(col_index, screen_x, width)`.
+    pub visible_cols: Vec<(usize, u16, u16)>,
+}
+
+/// Map a terminal coordinate to a [`MouseTarget`]. Pure.
+pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
+    let in_x = x >= layout.x && x < layout.x + layout.width;
+    let in_y = y >= layout.y && y < layout.y + layout.height;
+    if !in_x || !in_y {
+        return MouseTarget::Outside;
+    }
+
+    let row_num_x_end = layout.x + layout.row_num_width;
+    let header_y_end = layout.y + layout.header_height;
+    let in_gutter = x < row_num_x_end;
+    let in_header = y < header_y_end;
+
+    if in_gutter && in_header {
+        return MouseTarget::Outside;
+    }
+    if in_header {
+        for &(col, cx, cw) in &layout.visible_cols {
+            if x >= cx && x < cx + cw {
+                return MouseTarget::ColHeader(col);
+            }
+        }
+        return MouseTarget::Outside;
+    }
+    if in_gutter {
+        let row_offset_y = y - header_y_end;
+        return MouseTarget::RowHeader(layout.row_offset + row_offset_y as usize);
+    }
+
+    let row_offset_y = y - header_y_end;
+    let row = layout.row_offset + row_offset_y as usize;
+    for &(col, cx, cw) in &layout.visible_cols {
+        if x >= cx && x < cx + cw {
+            return MouseTarget::Cell((row, col));
+        }
+    }
+    MouseTarget::Outside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> GridLayout {
+        // Grid at (0, 1) with 1-row header, row-number gutter of width 5.
+        // Three visible columns of widths 10, 12, 8 starting at x = 6 (after
+        // the gutter), with a 1-byte separator between each column (so col 1
+        // starts at x = 17, col 2 at x = 30).
+        GridLayout {
+            x: 0,
+            y: 1,
+            width: 40,
+            height: 10,
+            row_num_width: 5,
+            header_height: 1,
+            row_offset: 0,
+            col_offset: 0,
+            visible_cols: vec![(0, 6, 10), (1, 17, 12), (2, 30, 8)],
+        }
+    }
+
+    #[test]
+    fn click_in_cell() {
+        // x=8 is in column 0 (6..16), y=3 is in row 1 (after header at y=1).
+        assert_eq!(hit_test(&fixture(), 8, 3), MouseTarget::Cell((1, 0)));
+    }
+
+    #[test]
+    fn click_in_column_header() {
+        // y=1 is the header row.
+        assert_eq!(hit_test(&fixture(), 18, 1), MouseTarget::ColHeader(1));
+    }
+
+    #[test]
+    fn click_in_row_header() {
+        // x=2 is in the gutter, y=4 is row 2 (header_y_end=2 → row_offset_y=2).
+        assert_eq!(hit_test(&fixture(), 2, 4), MouseTarget::RowHeader(2));
+    }
+
+    #[test]
+    fn click_top_left_corner_is_outside() {
+        assert_eq!(hit_test(&fixture(), 2, 1), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_outside_grid_widget() {
+        // y=0 is above the grid widget.
+        assert_eq!(hit_test(&fixture(), 8, 0), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_in_padding_right_of_last_visible_col() {
+        // Last visible col ends at x=37 (30+8-1); x=39 is in padding.
+        assert_eq!(hit_test(&fixture(), 39, 3), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_below_last_rendered_row() {
+        // Layout height is 10, so y=11 is outside.
+        assert_eq!(hit_test(&fixture(), 8, 11), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_uses_per_column_widths() {
+        // Column 1 has width 12 (17..29). x=27 must hit col 1, not col 2.
+        // y=5 → row_offset_y = 5 - 2 = 3.
+        assert_eq!(hit_test(&fixture(), 27, 5), MouseTarget::Cell((3, 1)));
+    }
+
+    #[test]
+    fn click_with_nonzero_row_offset() {
+        let mut layout = fixture();
+        layout.row_offset = 100;
+        // y=2 → row_offset_y = 2 - 2 = 0 → row 100
+        assert_eq!(hit_test(&layout, 8, 2), MouseTarget::Cell((100, 0)));
+    }
+}

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -931,4 +931,30 @@ mod tests {
             Action::MouseScroll { dx: 0, dy: 1 }
         );
     }
+
+    #[test]
+    fn select_column_keeps_cursor_at_top_not_bottom() {
+        let mut app = App::new();
+        // Populate enough rows that "last_row" is non-trivially != 0.
+        for r in 0..5 {
+            app.sheet.set_cell((r, 2), "x");
+        }
+        app.process_action(Action::MouseSelectColumn(2));
+        // Cursor must be at the TOP of the column (row 0), not the
+        // bottom — otherwise the highlighted cell sits at the far end
+        // of the selection instead of where the user clicked.
+        assert_eq!(app.cursor, (0, 2));
+    }
+
+    #[test]
+    fn select_row_keeps_cursor_at_left_not_right() {
+        let mut app = App::new();
+        for c in 0..5 {
+            app.sheet.set_cell((3, c), "x");
+        }
+        app.process_action(Action::MouseSelectRow(3));
+        // Cursor must be at the LEFTMOST cell of the row (col 0), not
+        // the right edge.
+        assert_eq!(app.cursor, (3, 0));
+    }
 }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -150,6 +150,13 @@ pub fn handle_mouse_event(
             }
             _ => Action::Noop,
         },
+        MouseEventKind::Drag(MouseButton::Left) => match state.drag {
+            MouseDragState::DraggingCells { .. } => match target {
+                MouseTarget::Cell(pos) => Action::MouseDragTo(pos),
+                _ => Action::Noop,
+            },
+            _ => Action::Noop,
+        },
         MouseEventKind::Up(MouseButton::Left) => {
             state.drag = MouseDragState::Idle;
             Action::Noop
@@ -313,5 +320,53 @@ mod tests {
         let event = synth(MouseEventKind::Up(MouseButton::Left), 8, 3);
         let _ = handle_mouse_event(event, &mut state, &app, Some(&layout));
         assert_eq!(state.drag, MouseDragState::Idle);
+    }
+
+    #[test]
+    fn drag_after_down_emits_drag_to() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let down = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        handle_mouse_event(down, &mut state, &app, Some(&layout));
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 18, 5);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::MouseDragTo((3, 1))
+        );
+    }
+
+    #[test]
+    fn drag_without_down_is_noop() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 18, 5);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::Noop
+        );
+    }
+
+    #[test]
+    fn drag_outside_grid_is_noop() {
+        let app = App::new();
+        let mut state = MouseState::new();
+        let layout = fixture();
+        let down = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+        handle_mouse_event(down, &mut state, &app, Some(&layout));
+        let drag = synth(MouseEventKind::Drag(MouseButton::Left), 8, 0);
+        assert_eq!(
+            handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+            Action::Noop
+        );
+    }
+
+    #[test]
+    fn click_then_drag_moves_cursor_to_target() {
+        let mut app = App::new();
+        app.process_action(Action::MouseClickCell((1, 0)));
+        app.process_action(Action::MouseDragTo((3, 2)));
+        assert_eq!(app.cursor, (3, 2));
     }
 }

--- a/crates/cell-sheet-tui/src/render/grid.rs
+++ b/crates/cell-sheet-tui/src/render/grid.rs
@@ -1,3 +1,4 @@
+use crate::mode::mouse::GridLayout;
 use crate::viewport::Viewport;
 use cell_sheet_core::model::{col_index_to_label, CellPos, CellValue, Sheet};
 use ratatui::{
@@ -12,6 +13,7 @@ pub struct Grid<'a> {
     pub viewport: &'a Viewport,
     pub cursor: CellPos,
     pub selection: Option<(CellPos, CellPos)>,
+    pub layout_out: &'a mut Option<GridLayout>,
 }
 
 const ROW_NUM_WIDTH: u16 = 5;
@@ -53,6 +55,18 @@ impl<'a> Widget for Grid<'a> {
             visible_cols.push((col, x, w));
             x += w + 1;
         }
+
+        *self.layout_out = Some(GridLayout {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: area.height,
+            row_num_width: ROW_NUM_WIDTH,
+            header_height: 1,
+            row_offset: self.viewport.row_offset,
+            col_offset: self.viewport.col_offset,
+            visible_cols: visible_cols.clone(),
+        });
 
         // Rows
         for row_offset in 0..area.height.saturating_sub(1) {
@@ -108,5 +122,41 @@ impl<'a> Widget for Grid<'a> {
                 buf.set_string(col_x, y, truncated, style);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    #[test]
+    fn render_publishes_grid_layout() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "a");
+        sheet.set_cell((0, 1), "b");
+        let viewport = Viewport::new();
+        let area = Rect::new(0, 1, 30, 5);
+        let mut buf = Buffer::empty(area);
+        let mut layout = None;
+
+        Grid {
+            sheet: &sheet,
+            viewport: &viewport,
+            cursor: (0, 0),
+            selection: None,
+            layout_out: &mut layout,
+        }
+        .render(area, &mut buf);
+
+        let l = layout.expect("layout should be published");
+        assert_eq!(l.x, 0);
+        assert_eq!(l.y, 1);
+        assert_eq!(l.width, 30);
+        assert_eq!(l.row_num_width, ROW_NUM_WIDTH);
+        assert_eq!(l.header_height, 1);
+        assert!(!l.visible_cols.is_empty());
+        assert_eq!(l.visible_cols[0].0, 0);
     }
 }

--- a/crates/cell-sheet-tui/src/render/grid.rs
+++ b/crates/cell-sheet-tui/src/render/grid.rs
@@ -64,7 +64,6 @@ impl<'a> Widget for Grid<'a> {
             row_num_width: ROW_NUM_WIDTH,
             header_height: 1,
             row_offset: self.viewport.row_offset,
-            col_offset: self.viewport.col_offset,
             visible_cols: visible_cols.clone(),
         });
 

--- a/crates/cell-sheet-tui/src/render/mod.rs
+++ b/crates/cell-sheet-tui/src/render/mod.rs
@@ -117,3 +117,46 @@ pub fn render(
         chunks[3],
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn render_writes_layout_to_app_and_overwrites_on_second_call() {
+        let backend = TestBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.sheet.set_cell((0, 0), "a");
+        app.sheet.set_cell((0, 1), "b");
+
+        terminal
+            .draw(|frame| {
+                render(frame, &mut app, None, 0, None);
+            })
+            .unwrap();
+        let first = app
+            .last_grid_layout
+            .clone()
+            .expect("layout populated after first render");
+        assert!(!first.visible_cols.is_empty());
+        assert_eq!(first.header_height, 1);
+
+        // A second render must OVERWRITE, not stack/append. Mutating the
+        // viewport between renders is the simplest way to prove it.
+        app.viewport.row_offset = 5;
+        terminal
+            .draw(|frame| {
+                render(frame, &mut app, None, 0, None);
+            })
+            .unwrap();
+        let second = app
+            .last_grid_layout
+            .as_ref()
+            .expect("layout still populated after second render");
+        assert_eq!(second.row_offset, 5);
+    }
+}

--- a/crates/cell-sheet-tui/src/render/mod.rs
+++ b/crates/cell-sheet-tui/src/render/mod.rs
@@ -6,6 +6,7 @@ pub mod status_bar;
 
 use crate::action::Mode;
 use crate::app::App;
+use crate::mode::mouse::GridLayout;
 use cell_sheet_core::model::CellPos;
 use command_line::CommandLine;
 use formula_bar::FormulaBar;
@@ -19,7 +20,7 @@ use status_bar::StatusBar;
 
 pub fn render(
     frame: &mut Frame,
-    app: &App,
+    app: &mut App,
     selection: Option<(CellPos, CellPos)>,
     insert_cursor: usize,
     partial_command: Option<&str>,
@@ -74,15 +75,18 @@ pub fn render(
         }
     }
 
+    let mut grid_layout: Option<GridLayout> = None;
     frame.render_widget(
         Grid {
             sheet: &app.sheet,
             viewport: &app.viewport,
             cursor: app.cursor,
             selection,
+            layout_out: &mut grid_layout,
         },
         chunks[1],
     );
+    app.last_grid_layout = grid_layout;
 
     let file_name = app
         .file_path

--- a/docs/superpowers/plans/2026-04-30-mouse-support.md
+++ b/docs/superpowers/plans/2026-04-30-mouse-support.md
@@ -177,8 +177,8 @@ mod tests {
 
     #[test]
     fn click_in_row_header() {
-        // x=2 is in the gutter, y=4 is row 3 (with row_offset=0).
-        assert_eq!(hit_test(&fixture(), 2, 4), MouseTarget::RowHeader(3));
+        // x=2 is in the gutter, y=4 → row_offset_y = 4 - 2 = 2.
+        assert_eq!(hit_test(&fixture(), 2, 4), MouseTarget::RowHeader(2));
     }
 
     #[test]
@@ -207,15 +207,22 @@ mod tests {
     #[test]
     fn click_uses_per_column_widths() {
         // Column 1 has width 12 (17..29). x=27 must hit col 1, not col 2.
-        assert_eq!(hit_test(&fixture(), 27, 5), MouseTarget::Cell((4, 1)));
+        // y=5 → row_offset_y = 5 - 2 = 3.
+        assert_eq!(hit_test(&fixture(), 27, 5), MouseTarget::Cell((3, 1)));
     }
 
     #[test]
     fn click_with_nonzero_row_offset() {
         let mut layout = fixture();
         layout.row_offset = 100;
-        // y=2 → row_offset_y=1 → row 101
-        assert_eq!(hit_test(&layout, 8, 2), MouseTarget::Cell((101, 0)));
+        // y=2 → row_offset_y = 2 - 2 = 0 → row 100
+        assert_eq!(hit_test(&layout, 8, 2), MouseTarget::Cell((100, 0)));
+    }
+
+    #[test]
+    fn click_in_inter_column_gap_is_outside() {
+        // x=16 sits between col 0 (6..16) and col 1 (17..29).
+        assert_eq!(hit_test(&fixture(), 16, 3), MouseTarget::Outside);
     }
 }
 ```
@@ -1260,12 +1267,13 @@ fn down_on_row_header_emits_select_row() {
     let app = App::new();
     let mut state = MouseState::new();
     let layout = fixture();
+    // x=2 is the gutter, y=4 → row_offset_y = 2 → row 2.
     let event = synth(MouseEventKind::Down(MouseButton::Left), 2, 4);
     assert_eq!(
         handle_mouse_event(event, &mut state, &app, Some(&layout)),
-        Action::MouseSelectRow(3)
+        Action::MouseSelectRow(2)
     );
-    assert_eq!(state.drag, MouseDragState::DraggingRows { anchor_row: 3 });
+    assert_eq!(state.drag, MouseDragState::DraggingRows { anchor_row: 2 });
 }
 ```
 

--- a/docs/superpowers/plans/2026-04-30-mouse-support.md
+++ b/docs/superpowers/plans/2026-04-30-mouse-support.md
@@ -1,0 +1,2053 @@
+# Mouse Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in mouse support to cell — left-click moves the cursor, click+drag selects a range, scroll wheel scrolls the viewport, double-click enters Insert mode — gated behind `:set mouse on`.
+
+**Architecture:** A new `mode/mouse.rs` module mirrors the keyboard-mode handlers. A pure `hit_test(GridLayout, x, y) → MouseTarget` translates screen coordinates to logical cell positions. The render layer publishes `GridLayout` once per frame and stashes it on `App` for the next event. `run_loop` gains an `Event::Mouse` arm that delegates to `mouse::handle_mouse_event`, mirroring the existing keyboard dispatch.
+
+**Tech Stack:** Rust 2021, crossterm 0.29 (`MouseEvent`, `EnableMouseCapture` / `DisableMouseCapture`), ratatui (already in tree), no new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-04-30-mouse-support-design.md`](../specs/2026-04-30-mouse-support-design.md) — Issue [#70](https://github.com/garritfra/cell/issues/70).
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `crates/cell-sheet-tui/src/mode/mouse.rs` | **Create** | `MouseTarget`, `GridLayout`, `MouseState`, `MouseDragState`, `LastClick`, `hit_test`, `handle_mouse_event`. Owns nearly all mouse logic. |
+| `crates/cell-sheet-tui/src/mode/mod.rs` | Modify | Add `pub mod mouse;`. |
+| `crates/cell-sheet-tui/src/action.rs` | Modify | Add 6 new `Action` variants. |
+| `crates/cell-sheet-tui/src/app.rs` | Modify | Add `mouse_enabled: bool` and `last_grid_layout: Option<GridLayout>`; new arms in `process_action`. |
+| `crates/cell-sheet-tui/src/render/grid.rs` | Modify | Build a `GridLayout` while rendering and return it. |
+| `crates/cell-sheet-tui/src/render/mod.rs` | Modify | Thread the `GridLayout` from grid render into `App`. |
+| `crates/cell-sheet-tui/src/mode/command.rs` | Modify | Parse `set mouse on \| off \| toggle`. |
+| `crates/cell-sheet-tui/src/main.rs` | Modify | Capture `Event::Mouse`, dispatch to handler; toggle `EnableMouseCapture` / `DisableMouseCapture` when the flag changes; clean up on shutdown. |
+| `crates/cell-sheet-core/src/help/mod.rs` | Modify | Add `HelpCategory::Mouse` and wire `MOUSE_ENTRIES`. |
+| `crates/cell-sheet-core/src/help/entries.rs` | Modify | Add `MOUSE_ENTRIES`. |
+| `crates/cell-sheet-tui/src/render/help.rs` | Read-check | Verify the help renderer iterates `categories()` (no change needed if so). |
+| `README.md` | Modify | Add a "Mouse support" section. |
+| `AGENTS.md` | Modify | Add a one-liner under "Things to avoid". |
+| `CHANGELOG.md` | Modify | Add an `Added` entry under `## Unreleased`. |
+
+---
+
+## Task 1: Foundation — `MouseTarget`, `GridLayout`, `hit_test`
+
+Pure functions and types only. No event handling, no integration.
+
+**Files:**
+- Create: `crates/cell-sheet-tui/src/mode/mouse.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mod.rs`
+
+- [ ] **Step 1: Add the module to `mode/mod.rs`**
+
+`crates/cell-sheet-tui/src/mode/mod.rs` currently:
+
+```rust
+pub mod command;
+pub mod help;
+pub mod insert;
+pub mod normal;
+pub mod visual;
+```
+
+Add one line:
+
+```rust
+pub mod command;
+pub mod help;
+pub mod insert;
+pub mod mouse;
+pub mod normal;
+pub mod visual;
+```
+
+- [ ] **Step 2: Create `mode/mouse.rs` with the types and a stub `hit_test`**
+
+```rust
+use cell_sheet_core::model::CellPos;
+
+/// Logical region a screen coordinate maps to. Built by [`hit_test`] from
+/// a [`GridLayout`] published by the render layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseTarget {
+    Cell(CellPos),
+    ColHeader(usize),
+    RowHeader(usize),
+    Outside,
+}
+
+/// Geometry snapshot of the most recent grid render. Built by
+/// `render::grid::Grid::render` and stashed on `App` so the next mouse
+/// event can hit-test against accurate coordinates.
+#[derive(Debug, Clone)]
+pub struct GridLayout {
+    /// Top-left corner of the grid widget (in terminal cells).
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+    /// Width of the row-number gutter on the left edge of the grid.
+    pub row_num_width: u16,
+    /// Height of the column-header row at the top of the grid.
+    pub header_height: u16,
+    /// `viewport.row_offset` at render time.
+    pub row_offset: usize,
+    /// `viewport.col_offset` at render time.
+    pub col_offset: usize,
+    /// Visible columns in left-to-right order: `(col_index, screen_x, width)`.
+    pub visible_cols: Vec<(usize, u16, u16)>,
+}
+
+/// Map a terminal coordinate to a [`MouseTarget`]. Pure.
+pub fn hit_test(layout: &GridLayout, x: u16, y: u16) -> MouseTarget {
+    let in_x = x >= layout.x && x < layout.x + layout.width;
+    let in_y = y >= layout.y && y < layout.y + layout.height;
+    if !in_x || !in_y {
+        return MouseTarget::Outside;
+    }
+
+    let row_num_x_end = layout.x + layout.row_num_width;
+    let header_y_end = layout.y + layout.header_height;
+    let in_gutter = x < row_num_x_end;
+    let in_header = y < header_y_end;
+
+    if in_gutter && in_header {
+        return MouseTarget::Outside;
+    }
+    if in_header {
+        for &(col, cx, cw) in &layout.visible_cols {
+            if x >= cx && x < cx + cw {
+                return MouseTarget::ColHeader(col);
+            }
+        }
+        return MouseTarget::Outside;
+    }
+    if in_gutter {
+        let row_offset_y = y - header_y_end;
+        return MouseTarget::RowHeader(layout.row_offset + row_offset_y as usize);
+    }
+
+    let row_offset_y = y - header_y_end;
+    let row = layout.row_offset + row_offset_y as usize;
+    for &(col, cx, cw) in &layout.visible_cols {
+        if x >= cx && x < cx + cw {
+            return MouseTarget::Cell((row, col));
+        }
+    }
+    MouseTarget::Outside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> GridLayout {
+        // Grid at (0, 1) with 2-row header (formula bar above it isn't ours),
+        // row-number gutter of width 5, column-header height of 1.
+        // Three visible columns of widths 10, 12, 8 starting at x = 6 (after
+        // the gutter), with the column-separator that grid.rs draws between
+        // each column accounted for as part of the column on its left.
+        GridLayout {
+            x: 0,
+            y: 1,
+            width: 40,
+            height: 10,
+            row_num_width: 5,
+            header_height: 1,
+            row_offset: 0,
+            col_offset: 0,
+            visible_cols: vec![(0, 6, 10), (1, 17, 12), (2, 30, 8)],
+        }
+    }
+
+    #[test]
+    fn click_in_cell() {
+        // x=8 is in column 0 (6..16), y=3 is in row 1 (after header at y=1).
+        assert_eq!(hit_test(&fixture(), 8, 3), MouseTarget::Cell((1, 0)));
+    }
+
+    #[test]
+    fn click_in_column_header() {
+        // y=1 is the header row.
+        assert_eq!(hit_test(&fixture(), 18, 1), MouseTarget::ColHeader(1));
+    }
+
+    #[test]
+    fn click_in_row_header() {
+        // x=2 is in the gutter, y=4 is row 3 (with row_offset=0).
+        assert_eq!(hit_test(&fixture(), 2, 4), MouseTarget::RowHeader(3));
+    }
+
+    #[test]
+    fn click_top_left_corner_is_outside() {
+        assert_eq!(hit_test(&fixture(), 2, 1), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_outside_grid_widget() {
+        // y=0 is above the grid widget.
+        assert_eq!(hit_test(&fixture(), 8, 0), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_in_padding_right_of_last_visible_col() {
+        // Last visible col ends at x=37 (30+8-1); x=39 is in padding.
+        assert_eq!(hit_test(&fixture(), 39, 3), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_below_last_rendered_row() {
+        // Layout height is 10, so y=11 is outside.
+        assert_eq!(hit_test(&fixture(), 8, 11), MouseTarget::Outside);
+    }
+
+    #[test]
+    fn click_uses_per_column_widths() {
+        // Column 1 has width 12 (17..29). x=27 must hit col 1, not col 2.
+        assert_eq!(hit_test(&fixture(), 27, 5), MouseTarget::Cell((4, 1)));
+    }
+
+    #[test]
+    fn click_with_nonzero_row_offset() {
+        let mut layout = fixture();
+        layout.row_offset = 100;
+        // y=2 → row_offset_y=1 → row 101
+        assert_eq!(hit_test(&layout, 8, 2), MouseTarget::Cell((101, 0)));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify the foundation**
+
+```sh
+cargo test -p cell-sheet-tui mode::mouse::tests
+```
+
+Expected: 9 passing.
+
+- [ ] **Step 4: Run clippy and fmt**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add crates/cell-sheet-tui/src/mode/mod.rs crates/cell-sheet-tui/src/mode/mouse.rs
+git commit -m "feat(tui): add MouseTarget, GridLayout, and hit_test (#70)
+
+Pure foundation for mouse support. Translates terminal coordinates to
+a logical cell / header / outside region. No integration yet."
+```
+
+---
+
+## Task 2: `:set mouse on|off|toggle` + `Action::SetMouse` + `App.mouse_enabled`
+
+Add the runtime toggle. No event handling yet — the flag just flips, with `Enable/DisableMouseCapture` syscalls deferred to Task 4.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/command.rs`
+
+- [ ] **Step 1: Add `Action::SetMouse(bool)` to `action.rs`**
+
+In `crates/cell-sheet-tui/src/action.rs`, in the `Action` enum, immediately after the existing `SetDelimiter(u8)` variant:
+
+```rust
+    SetDelimiter(u8),
+    /// Toggle the mouse-enabled flag. The actual `Enable/DisableMouseCapture`
+    /// syscall is issued by `run_loop` after observing the flag change.
+    SetMouse(bool),
+    SetStatus(String),
+```
+
+- [ ] **Step 2: Add the `mouse_enabled` field to `App`**
+
+In `crates/cell-sheet-tui/src/app.rs`, add to the `App` struct (after `pub delimiter: u8`):
+
+```rust
+    pub delimiter: u8,
+    /// Off by default. Toggled by `:set mouse on|off|toggle`. When true,
+    /// the run_loop has issued `EnableMouseCapture` to the terminal and
+    /// is routing `Event::Mouse` to `mode::mouse::handle_mouse_event`.
+    pub mouse_enabled: bool,
+    pub help_scroll: usize,
+```
+
+…and in `App::new`:
+
+```rust
+            delimiter: b',',
+            mouse_enabled: false,
+            help_scroll: 0,
+```
+
+- [ ] **Step 3: Handle `Action::SetMouse` in `process_action`**
+
+Find the existing `Action::SetDelimiter(d) => { ... }` arm in `process_action` and add immediately after it:
+
+```rust
+            Action::SetMouse(b) => {
+                self.mouse_enabled = b;
+            }
+```
+
+- [ ] **Step 4: Write failing tests for the `:set mouse` parser**
+
+In `crates/cell-sheet-tui/src/mode/command.rs`, find the existing `#[cfg(test)] mod tests { ... }` (or add one if absent) and add:
+
+```rust
+#[test]
+fn parse_set_mouse_on() {
+    assert_eq!(parse_command("set mouse on"), Action::SetMouse(true));
+}
+
+#[test]
+fn parse_set_mouse_off() {
+    assert_eq!(parse_command("set mouse off"), Action::SetMouse(false));
+}
+
+#[test]
+fn parse_set_mouse_toggle_returns_status_error_for_now() {
+    // `toggle` is parsed in the next step; verify the no-op path here.
+    assert!(matches!(parse_command("set mouse bogus"), Action::SetStatus(_)));
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they fail**
+
+```sh
+cargo test -p cell-sheet-tui mode::command::tests::parse_set_mouse
+```
+
+Expected: FAIL — `parse_command` does not yet recognize `set mouse`.
+
+- [ ] **Step 6: Implement `set mouse` parsing**
+
+In `crates/cell-sheet-tui/src/mode/command.rs::parse_command`, add a new branch *after* the existing `set delimiter=` block but *before* the final `else { Action::Noop }`:
+
+```rust
+    if let Some(rest) = input.strip_prefix("set mouse") {
+        let arg = rest.trim();
+        return match arg {
+            "on" => Action::SetMouse(true),
+            "off" => Action::SetMouse(false),
+            "toggle" => Action::SetMouse(true), // overridden by run_loop using app.mouse_enabled
+            "" => Action::SetStatus("usage: :set mouse on|off|toggle".into()),
+            _ => Action::SetStatus("usage: :set mouse on|off|toggle".into()),
+        };
+    }
+```
+
+The `toggle` arm intentionally returns `SetMouse(true)` — `run_loop` rewrites it just below the parse, where it has access to the current `app.mouse_enabled`. Add a unit test for `toggle`:
+
+```rust
+#[test]
+fn parse_set_mouse_toggle() {
+    // Parser produces SetMouse(true); run_loop rewrites toggle vs current state.
+    assert_eq!(parse_command("set mouse toggle"), Action::SetMouse(true));
+}
+```
+
+- [ ] **Step 7: Toggle rewrite in `run_loop`**
+
+In `crates/cell-sheet-tui/src/main.rs::run_loop`, in the `CommandAction::Execute(cmd)` branch, just before the existing `let parsed = submit(kind, &cmd);`, capture whether this is a toggle:
+
+```rust
+let is_toggle =
+    matches!(kind, CommandKind::Colon) && cmd.trim() == "set mouse toggle";
+let parsed = submit(kind, &cmd);
+let parsed = if is_toggle {
+    Action::SetMouse(!app.mouse_enabled)
+} else {
+    parsed
+};
+```
+
+- [ ] **Step 8: Add tests for `process_action(SetMouse)`**
+
+In `crates/cell-sheet-tui/src/app.rs::tests`:
+
+```rust
+#[test]
+fn set_mouse_flag_starts_off_and_toggles() {
+    let mut app = App::new();
+    assert!(!app.mouse_enabled);
+    app.process_action(Action::SetMouse(true));
+    assert!(app.mouse_enabled);
+    app.process_action(Action::SetMouse(false));
+    assert!(!app.mouse_enabled);
+}
+```
+
+- [ ] **Step 9: Run all tests, fmt, clippy**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+Expected: all green.
+
+- [ ] **Step 10: Commit**
+
+```sh
+git add crates/cell-sheet-tui/src/{action.rs,app.rs,main.rs,mode/command.rs}
+git commit -m "feat(tui): add :set mouse on|off|toggle (#70)
+
+Adds Action::SetMouse and App.mouse_enabled (off by default). Capture
+syscall is wired in a later step. Toggle is resolved in run_loop with
+access to the live flag."
+```
+
+---
+
+## Task 3: Publish `GridLayout` from the render layer
+
+The render layer constructs a `GridLayout` while drawing the grid and stashes it on `App` for the next mouse event.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/render/grid.rs`
+- Modify: `crates/cell-sheet-tui/src/render/mod.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs` (re-export `GridLayout` for `app.rs`)
+
+- [ ] **Step 1: Add `last_grid_layout` to `App`**
+
+In `crates/cell-sheet-tui/src/app.rs`:
+
+```rust
+use crate::mode::mouse::GridLayout;
+```
+
+Add a field to `App`:
+
+```rust
+    pub mouse_enabled: bool,
+    /// Geometry from the most recent grid render, used by mouse hit-testing
+    /// on the next event. `None` until the first frame is drawn.
+    pub last_grid_layout: Option<GridLayout>,
+    pub help_scroll: usize,
+```
+
+…and in `App::new`:
+
+```rust
+            mouse_enabled: false,
+            last_grid_layout: None,
+```
+
+- [ ] **Step 2: Modify `Grid` to populate a layout**
+
+In `crates/cell-sheet-tui/src/render/grid.rs`, change the `Grid` struct so the renderer can write back a layout. The simplest pattern that works with `Widget` (which takes `self` by value): give `Grid` an `&mut Option<GridLayout>` field.
+
+```rust
+use crate::mode::mouse::GridLayout;
+use crate::viewport::Viewport;
+use cell_sheet_core::model::{col_index_to_label, CellPos, CellValue, Sheet};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::Widget,
+};
+
+pub struct Grid<'a> {
+    pub sheet: &'a Sheet,
+    pub viewport: &'a Viewport,
+    pub cursor: CellPos,
+    pub selection: Option<(CellPos, CellPos)>,
+    pub layout_out: &'a mut Option<GridLayout>,
+}
+```
+
+Inside `impl<'a> Widget for Grid<'a>::render`, after the existing `for col in self.viewport.col_offset.. { ... }` loop that already builds `let mut visible_cols = Vec::new();`, populate the output:
+
+```rust
+        *self.layout_out = Some(GridLayout {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: area.height,
+            row_num_width: ROW_NUM_WIDTH,
+            header_height: 1,
+            row_offset: self.viewport.row_offset,
+            col_offset: self.viewport.col_offset,
+            visible_cols: visible_cols
+                .iter()
+                .map(|&(col, cx, cw)| (col, cx, cw))
+                .collect(),
+        });
+```
+
+(Place this right after the column-header loop completes — before the row-rendering loop is fine.)
+
+- [ ] **Step 3: Thread the layout through `render::render`**
+
+In `crates/cell-sheet-tui/src/render/mod.rs`, change the signature so the caller can read back the layout:
+
+```rust
+pub fn render(
+    frame: &mut Frame,
+    app: &mut App,
+    selection: Option<(CellPos, CellPos)>,
+    insert_cursor: usize,
+    partial_command: Option<&str>,
+) {
+```
+
+Note `app` is now `&mut App`. Update the `Grid` construction:
+
+```rust
+    let mut grid_layout: Option<GridLayout> = None;
+    frame.render_widget(
+        Grid {
+            sheet: &app.sheet,
+            viewport: &app.viewport,
+            cursor: app.cursor,
+            selection,
+            layout_out: &mut grid_layout,
+        },
+        chunks[1],
+    );
+    app.last_grid_layout = grid_layout;
+```
+
+Add the import at the top:
+
+```rust
+use crate::mode::mouse::GridLayout;
+```
+
+- [ ] **Step 4: Update the `terminal.draw` call in `run_loop`**
+
+In `crates/cell-sheet-tui/src/main.rs::run_loop`, the existing `terminal.draw(|frame| { render::render(frame, app, ...) })?;` already passes `app: &mut App` since `app` is `&mut App` in `run_loop`. Verify the call still type-checks; no edit needed unless `render::render` was being called with `&app`. If so, change to `app`.
+
+- [ ] **Step 5: Add a render unit test**
+
+In `crates/cell-sheet-tui/src/render/grid.rs`, add a `#[cfg(test)] mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    #[test]
+    fn render_publishes_grid_layout() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), CellValue::Text("a".into()));
+        sheet.set_cell((0, 1), CellValue::Text("b".into()));
+        let viewport = Viewport::new();
+        let area = Rect::new(0, 1, 30, 5);
+        let mut buf = Buffer::empty(area);
+        let mut layout = None;
+
+        Grid {
+            sheet: &sheet,
+            viewport: &viewport,
+            cursor: (0, 0),
+            selection: None,
+            layout_out: &mut layout,
+        }
+        .render(area, &mut buf);
+
+        let l = layout.expect("layout should be published");
+        assert_eq!(l.x, 0);
+        assert_eq!(l.y, 1);
+        assert_eq!(l.width, 30);
+        assert_eq!(l.row_num_width, ROW_NUM_WIDTH);
+        assert_eq!(l.header_height, 1);
+        assert!(!l.visible_cols.is_empty());
+        assert_eq!(l.visible_cols[0].0, 0);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, fmt, clippy**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): publish GridLayout from grid render (#70)
+
+The renderer now writes a GridLayout snapshot back to App on every
+frame. Mouse hit-testing reads this on the next event."
+```
+
+---
+
+## Task 4: Wire mouse capture and route `Event::Mouse` to a stub handler
+
+Enable/disable `MouseCapture` based on `app.mouse_enabled`, and route `Event::Mouse` to a stub `handle_mouse_event` that returns `Action::Noop`. End-to-end plumbing only.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/main.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+
+- [ ] **Step 1: Add `MouseState` and a stub `handle_mouse_event`**
+
+Append to `crates/cell-sheet-tui/src/mode/mouse.rs`:
+
+```rust
+use crate::action::Action;
+use crate::app::App;
+use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+use std::time::{Duration, Instant};
+
+pub const DOUBLE_CLICK_MS: u64 = 400;
+
+#[derive(Debug, Default)]
+pub struct MouseState {
+    pub drag: MouseDragState,
+    pub last_click: Option<LastClick>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MouseDragState {
+    #[default]
+    Idle,
+    DraggingCells { anchor: CellPos },
+    DraggingColumns { anchor_col: usize },
+    DraggingRows { anchor_row: usize },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LastClick {
+    pub at: Instant,
+    pub pos: CellPos,
+}
+
+impl MouseState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Translate a single `MouseEvent` into an `Action`. The handler is the
+/// only place that mutates `state` (drag tracking, double-click history).
+/// `app` is read-only for now; future steps may need `&mut App` for
+/// mode-aware bookkeeping.
+pub fn handle_mouse_event(
+    _event: MouseEvent,
+    _state: &mut MouseState,
+    _app: &App,
+    _layout: Option<&GridLayout>,
+) -> Action {
+    Action::Noop
+}
+```
+
+- [ ] **Step 2: Wire enable/disable in `run_tui` and `run_loop`**
+
+In `crates/cell-sheet-tui/src/main.rs`, change the import:
+
+```rust
+use crossterm::{
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, MouseEvent,
+    },
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+```
+
+Update `run_tui`'s cleanup so mouse capture never leaks past process exit:
+
+```rust
+    let result = run_loop(&mut terminal, &mut app);
+
+    if app.mouse_enabled {
+        let _ = execute!(terminal.backend_mut(), DisableMouseCapture);
+    }
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+```
+
+In `run_loop`, near the top of the function, track whether mouse capture is currently engaged in the terminal so we can sync to `app.mouse_enabled`:
+
+```rust
+    let mut mouse_state = mode::mouse::MouseState::new();
+    let mut mouse_capture_active = false;
+```
+
+At the top of the loop, *before* `terminal.draw(...)`, sync the terminal state:
+
+```rust
+    loop {
+        if app.mouse_enabled != mouse_capture_active {
+            if app.mouse_enabled {
+                execute!(terminal.backend_mut(), EnableMouseCapture)?;
+            } else {
+                execute!(terminal.backend_mut(), DisableMouseCapture)?;
+                mouse_state = mode::mouse::MouseState::new(); // drop stale drag
+            }
+            mouse_capture_active = app.mouse_enabled;
+        }
+
+        let grid_height = terminal.size()?.height.saturating_sub(3) as usize;
+        // ... existing code
+```
+
+Add the `mod mouse;` reference is already there (Task 1). Now extend the `event::read()` arm to also accept mouse events. Below the existing `if let Event::Key(key) = event::read()? {` block, replace the structure with:
+
+```rust
+        if event::poll(std::time::Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(key) => {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    app.status_message = None;
+                    // ... entire existing key-handling block, unchanged ...
+                }
+                Event::Mouse(me) => {
+                    if !app.mouse_enabled {
+                        continue;
+                    }
+                    app.status_message = None;
+                    // Clone the layout so we don't hold an immutable
+                    // borrow of `app` across the call (which also takes
+                    // `app` for future read-only access).
+                    let layout = app.last_grid_layout.clone();
+                    let action = mode::mouse::handle_mouse_event(
+                        me,
+                        &mut mouse_state,
+                        app,
+                        layout.as_ref(),
+                    );
+                    app.process_action(action);
+                }
+                _ => {}
+            }
+        }
+```
+
+(The existing key-handling code — about 220 lines — moves verbatim into the `Event::Key(key) => { ... }` arm. This is the largest mechanical change in the plan; preserve every line.)
+
+- [ ] **Step 3: Add a smoke test driving a synthetic mouse event**
+
+In `crates/cell-sheet-tui/src/mode/mouse.rs::tests`, append:
+
+```rust
+use crate::app::App;
+use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+
+fn synth(kind: MouseEventKind, x: u16, y: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column: x,
+        row: y,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+#[test]
+fn stub_handler_returns_noop() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+    assert_eq!(
+        handle_mouse_event(event, &mut state, &app, Some(&layout)),
+        Action::Noop
+    );
+}
+```
+
+- [ ] **Step 4: Run tests, fmt, clippy**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+Expected: all green. The TUI binary now toggles real mouse capture in response to `:set mouse on/off`, but does nothing with the events.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): route Event::Mouse to a stub handler (#70)
+
+Mouse capture engages and disengages with :set mouse. Events flow into
+mode::mouse::handle_mouse_event, which currently returns Noop. The next
+tasks teach it to translate clicks, drags, and scrolls into Actions."
+```
+
+---
+
+## Task 5: Left-click → `MouseClickCell` (Normal mode)
+
+The simplest happy path: in Normal mode, a `Down(Left)` on a `Cell(pos)` moves the cursor.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+
+- [ ] **Step 1: Add `Action::MouseClickCell`**
+
+In `crates/cell-sheet-tui/src/action.rs`, after `SetMouse(bool)`:
+
+```rust
+    SetMouse(bool),
+    MouseClickCell(CellPos),
+    SetStatus(String),
+```
+
+- [ ] **Step 2: Handle it in `process_action`**
+
+In `crates/cell-sheet-tui/src/app.rs`, after the `Action::SetMouse(b) => { ... }` arm:
+
+```rust
+            Action::MouseClickCell(pos) => {
+                self.cursor = pos;
+                self.viewport.ensure_visible(self.cursor);
+            }
+```
+
+- [ ] **Step 3: Write the failing handler test**
+
+In `crates/cell-sheet-tui/src/mode/mouse.rs::tests`:
+
+```rust
+#[test]
+fn down_left_on_cell_in_normal_emits_click() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+    assert_eq!(
+        handle_mouse_event(event, &mut state, &app, Some(&layout)),
+        Action::MouseClickCell((1, 0))
+    );
+    assert_eq!(state.drag, MouseDragState::DraggingCells { anchor: (1, 0) });
+}
+```
+
+- [ ] **Step 4: Run test to verify failure**
+
+```sh
+cargo test -p cell-sheet-tui mode::mouse::tests::down_left_on_cell
+```
+
+Expected: FAIL — handler returns `Noop`.
+
+- [ ] **Step 5: Implement `Down(Left)` for Cell targets**
+
+Replace the body of `handle_mouse_event` in `crates/cell-sheet-tui/src/mode/mouse.rs`:
+
+```rust
+pub fn handle_mouse_event(
+    event: MouseEvent,
+    state: &mut MouseState,
+    _app: &App,
+    layout: Option<&GridLayout>,
+) -> Action {
+    if event.modifiers.contains(KeyModifiers::SHIFT) {
+        return Action::Noop;
+    }
+    let layout = match layout {
+        Some(l) => l,
+        None => return Action::Noop,
+    };
+    let target = hit_test(layout, event.column, event.row);
+
+    match event.kind {
+        MouseEventKind::Down(crossterm::event::MouseButton::Left) => match target {
+            MouseTarget::Cell(pos) => {
+                state.drag = MouseDragState::DraggingCells { anchor: pos };
+                state.last_click = Some(LastClick {
+                    at: Instant::now(),
+                    pos,
+                });
+                Action::MouseClickCell(pos)
+            }
+            _ => Action::Noop,
+        },
+        MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
+            state.drag = MouseDragState::Idle;
+            Action::Noop
+        }
+        _ => Action::Noop,
+    }
+}
+```
+
+- [ ] **Step 6: Run handler test to verify pass**
+
+```sh
+cargo test -p cell-sheet-tui mode::mouse::tests::down_left_on_cell
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Add a process_action test**
+
+In `crates/cell-sheet-tui/src/app.rs::tests`:
+
+```rust
+#[test]
+fn mouse_click_cell_moves_cursor() {
+    let mut app = App::new();
+    app.process_action(Action::MouseClickCell((3, 5)));
+    assert_eq!(app.cursor, (3, 5));
+}
+```
+
+- [ ] **Step 8: Run all tests, fmt, clippy**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+- [ ] **Step 9: Commit**
+
+```sh
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): left-click moves the cursor (#70)"
+```
+
+---
+
+## Task 6: Click+drag inside grid → Visual selection via `MouseDragTo`
+
+First `Drag(Left)` after a `Down(Left)` enters Visual mode with anchor at the click cell. Subsequent drags extend the cursor.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+- Modify: `crates/cell-sheet-tui/src/main.rs`
+
+- [ ] **Step 1: Add `Action::MouseDragTo`**
+
+In `action.rs`:
+
+```rust
+    MouseClickCell(CellPos),
+    MouseDragTo(CellPos),
+    SetStatus(String),
+```
+
+- [ ] **Step 2: Handle in `process_action`**
+
+In `app.rs`:
+
+```rust
+            Action::MouseDragTo(pos) => {
+                self.cursor = pos;
+                self.viewport.ensure_visible(self.cursor);
+            }
+```
+
+The visual transition itself happens in `run_loop` (Step 4 below), mirroring how `Action::ChangeMode(Mode::Visual)` is handled today.
+
+- [ ] **Step 3: Failing handler test**
+
+In `crates/cell-sheet-tui/src/mode/mouse.rs::tests`:
+
+```rust
+#[test]
+fn drag_after_down_emits_drag_to() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let down = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+    handle_mouse_event(down, &mut state, &app, Some(&layout));
+    let drag = synth(MouseEventKind::Drag(MouseButton::Left), 18, 5);
+    assert_eq!(
+        handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+        Action::MouseDragTo((3, 1))
+    );
+}
+
+#[test]
+fn drag_without_down_is_noop() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let drag = synth(MouseEventKind::Drag(MouseButton::Left), 18, 5);
+    assert_eq!(
+        handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+        Action::Noop
+    );
+}
+```
+
+- [ ] **Step 4: Implement the `Drag` arm**
+
+Add a `MouseEventKind::Drag(...)` arm to the `match event.kind` in `handle_mouse_event`:
+
+```rust
+        MouseEventKind::Drag(crossterm::event::MouseButton::Left) => match state.drag {
+            MouseDragState::DraggingCells { .. } => match target {
+                MouseTarget::Cell(pos) => Action::MouseDragTo(pos),
+                _ => Action::Noop,
+            },
+            _ => Action::Noop,
+        },
+```
+
+- [ ] **Step 5: Run handler tests**
+
+```sh
+cargo test -p cell-sheet-tui mode::mouse::tests::drag
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Wire visual-mode transition in `run_loop`**
+
+In `crates/cell-sheet-tui/src/main.rs`, after `Event::Mouse(me)` dispatches the action and *before* `app.process_action(action);`, mirror the existing keyboard pattern that turns `Action::ChangeMode(Mode::Visual)` into a real `visual_state`:
+
+```rust
+                Event::Mouse(me) => {
+                    if !app.mouse_enabled {
+                        continue;
+                    }
+                    app.status_message = None;
+                    let layout = app.last_grid_layout.clone();
+                    let action = mode::mouse::handle_mouse_event(
+                        me,
+                        &mut mouse_state,
+                        app,
+                        layout.as_ref(),
+                    );
+                    if let Action::MouseDragTo(_) = &action {
+                        if app.mode == Mode::Normal {
+                            if let mode::mouse::MouseDragState::DraggingCells { anchor } =
+                                mouse_state.drag
+                            {
+                                visual_state =
+                                    Some(VisualState::new(anchor, VisualKind::Character));
+                                app.mode = Mode::Visual;
+                            }
+                        }
+                    }
+                    app.process_action(action);
+                }
+```
+
+- [ ] **Step 7: Add an integration smoke test**
+
+In `crates/cell-sheet-tui/src/mode/mouse.rs::tests`, drive the full pipeline through `App` (no terminal):
+
+```rust
+#[test]
+fn click_then_drag_moves_cursor_to_target() {
+    let mut app = App::new();
+    app.process_action(Action::MouseClickCell((1, 0)));
+    app.process_action(Action::MouseDragTo((3, 2)));
+    assert_eq!(app.cursor, (3, 2));
+}
+```
+
+(The Visual-mode transition itself is exercised end-to-end only via the run_loop; we verify the action-processing side here.)
+
+- [ ] **Step 8: Run all tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): click+drag selects a Visual range (#70)"
+```
+
+---
+
+## Task 7: Click+drag on a column header → `MouseSelectColumn`
+
+Click on a column header selects the whole column (all rows of that column). Drag extends column-by-column.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+- Modify: `crates/cell-sheet-tui/src/main.rs`
+
+- [ ] **Step 1: Add `MouseSelectColumn`**
+
+In `action.rs`:
+
+```rust
+    MouseDragTo(CellPos),
+    /// Anchor (or extend) a whole-column selection to column `col`.
+    MouseSelectColumn(usize),
+    SetStatus(String),
+```
+
+- [ ] **Step 2: Handle in `process_action`**
+
+In `app.rs`:
+
+```rust
+            Action::MouseSelectColumn(col) => {
+                let last_row = self.sheet.row_count.saturating_sub(1);
+                self.cursor = (last_row, col);
+                self.viewport.ensure_visible(self.cursor);
+            }
+```
+
+The Visual-mode transition itself happens in `run_loop` (Step 5).
+
+- [ ] **Step 3: Failing handler tests**
+
+In `mode/mouse.rs::tests`:
+
+```rust
+#[test]
+fn down_on_column_header_emits_select_column() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::Down(MouseButton::Left), 18, 1);
+    assert_eq!(
+        handle_mouse_event(event, &mut state, &app, Some(&layout)),
+        Action::MouseSelectColumn(1)
+    );
+    assert_eq!(state.drag, MouseDragState::DraggingColumns { anchor_col: 1 });
+}
+
+#[test]
+fn drag_in_column_mode_extends_to_other_column() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    handle_mouse_event(
+        synth(MouseEventKind::Down(MouseButton::Left), 18, 1),
+        &mut state,
+        &app,
+        Some(&layout),
+    );
+    let drag = synth(MouseEventKind::Drag(MouseButton::Left), 32, 5);
+    assert_eq!(
+        handle_mouse_event(drag, &mut state, &app, Some(&layout)),
+        Action::MouseSelectColumn(2)
+    );
+}
+```
+
+- [ ] **Step 4: Implement the `ColHeader` and `DraggingColumns` paths**
+
+Update `handle_mouse_event`:
+
+In the `Down(Left)` match: add a `ColHeader(c)` arm:
+
+```rust
+            MouseTarget::ColHeader(c) => {
+                state.drag = MouseDragState::DraggingColumns { anchor_col: c };
+                state.last_click = None;
+                Action::MouseSelectColumn(c)
+            }
+```
+
+In the `Drag(Left)` match: add a `DraggingColumns { .. }` arm:
+
+```rust
+            MouseDragState::DraggingColumns { .. } => match target {
+                MouseTarget::ColHeader(c) | MouseTarget::Cell((_, c)) => {
+                    Action::MouseSelectColumn(c)
+                }
+                _ => Action::Noop,
+            },
+```
+
+- [ ] **Step 5: Wire visual-mode transition in `run_loop`**
+
+In `main.rs::run_loop`, in the `Event::Mouse` arm, extend the visual transition logic:
+
+```rust
+                    match &action {
+                        Action::MouseDragTo(_) if app.mode == Mode::Normal => {
+                            if let mode::mouse::MouseDragState::DraggingCells { anchor } =
+                                mouse_state.drag
+                            {
+                                visual_state =
+                                    Some(VisualState::new(anchor, VisualKind::Character));
+                                app.mode = Mode::Visual;
+                            }
+                        }
+                        Action::MouseSelectColumn(_) => {
+                            if let mode::mouse::MouseDragState::DraggingColumns { anchor_col } =
+                                mouse_state.drag
+                            {
+                                let last_row = app.sheet.row_count.saturating_sub(1);
+                                visual_state = Some(VisualState::new(
+                                    (0, anchor_col),
+                                    VisualKind::Block,
+                                ));
+                                app.cursor = (last_row, anchor_col);
+                                app.mode = Mode::VisualBlock;
+                            }
+                        }
+                        _ => {}
+                    }
+```
+
+(Replace the `if let Action::MouseDragTo` block from Task 6 with this `match`.)
+
+- [ ] **Step 6: Run tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): click+drag on column header selects columns (#70)"
+```
+
+---
+
+## Task 8: Click+drag on a row header → `MouseSelectRow`
+
+Mirror image of Task 7.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+- Modify: `crates/cell-sheet-tui/src/main.rs`
+
+- [ ] **Step 1: Add `MouseSelectRow`**
+
+```rust
+    MouseSelectColumn(usize),
+    MouseSelectRow(usize),
+    SetStatus(String),
+```
+
+- [ ] **Step 2: Handle in `process_action`**
+
+```rust
+            Action::MouseSelectRow(row) => {
+                let last_col = self.sheet.col_count.saturating_sub(1);
+                self.cursor = (row, last_col);
+                self.viewport.ensure_visible(self.cursor);
+            }
+```
+
+- [ ] **Step 3: Failing handler tests**
+
+```rust
+#[test]
+fn down_on_row_header_emits_select_row() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::Down(MouseButton::Left), 2, 4);
+    assert_eq!(
+        handle_mouse_event(event, &mut state, &app, Some(&layout)),
+        Action::MouseSelectRow(3)
+    );
+    assert_eq!(state.drag, MouseDragState::DraggingRows { anchor_row: 3 });
+}
+```
+
+- [ ] **Step 4: Implement the `RowHeader` and `DraggingRows` paths**
+
+In `Down(Left)`:
+
+```rust
+            MouseTarget::RowHeader(r) => {
+                state.drag = MouseDragState::DraggingRows { anchor_row: r };
+                state.last_click = None;
+                Action::MouseSelectRow(r)
+            }
+```
+
+In `Drag(Left)`:
+
+```rust
+            MouseDragState::DraggingRows { .. } => match target {
+                MouseTarget::RowHeader(r) | MouseTarget::Cell((r, _)) => {
+                    Action::MouseSelectRow(r)
+                }
+                _ => Action::Noop,
+            },
+```
+
+- [ ] **Step 5: Extend the `run_loop` visual transition**
+
+In the `match &action` from Task 7, add:
+
+```rust
+                        Action::MouseSelectRow(_) => {
+                            if let mode::mouse::MouseDragState::DraggingRows { anchor_row } =
+                                mouse_state.drag
+                            {
+                                let last_col = app.sheet.col_count.saturating_sub(1);
+                                visual_state = Some(VisualState::new(
+                                    (anchor_row, 0),
+                                    VisualKind::Block,
+                                ));
+                                app.cursor = (anchor_row, last_col);
+                                app.mode = Mode::VisualBlock;
+                            }
+                        }
+```
+
+- [ ] **Step 6: Run tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): click+drag on row header selects rows (#70)"
+```
+
+---
+
+## Task 9: Scroll wheel → `MouseScroll`
+
+Vertical scroll moves the viewport, cursor stays put. Horizontal via `ScrollLeft` / `ScrollRight` if the terminal emits them.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/action.rs`
+- Modify: `crates/cell-sheet-tui/src/app.rs`
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+
+- [ ] **Step 1: Add `MouseScroll`**
+
+In `action.rs`:
+
+```rust
+    MouseSelectRow(usize),
+    /// Scroll the viewport. `dy > 0` scrolls toward higher row indices
+    /// (i.e. content moves up, viewport reveals rows further down).
+    /// `dx > 0` scrolls right. Cursor is not moved.
+    MouseScroll { dx: i32, dy: i32 },
+    SetStatus(String),
+```
+
+- [ ] **Step 2: Handle in `process_action`**
+
+In `app.rs`:
+
+```rust
+            Action::MouseScroll { dx, dy } => {
+                if dy > 0 {
+                    self.viewport.row_offset =
+                        self.viewport.row_offset.saturating_add(dy as usize);
+                } else if dy < 0 {
+                    self.viewport.row_offset =
+                        self.viewport.row_offset.saturating_sub((-dy) as usize);
+                }
+                if dx > 0 {
+                    self.viewport.col_offset =
+                        self.viewport.col_offset.saturating_add(dx as usize);
+                } else if dx < 0 {
+                    self.viewport.col_offset =
+                        self.viewport.col_offset.saturating_sub((-dx) as usize);
+                }
+            }
+```
+
+- [ ] **Step 3: Failing handler tests**
+
+In `mode/mouse.rs::tests`:
+
+```rust
+#[test]
+fn scroll_down_emits_positive_dy() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::ScrollDown, 8, 3);
+    assert_eq!(
+        handle_mouse_event(event, &mut state, &app, Some(&layout)),
+        Action::MouseScroll { dx: 0, dy: 3 }
+    );
+}
+
+#[test]
+fn scroll_up_emits_negative_dy() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::ScrollUp, 8, 3);
+    assert_eq!(
+        handle_mouse_event(event, &mut state, &app, Some(&layout)),
+        Action::MouseScroll { dx: 0, dy: -3 }
+    );
+}
+
+#[test]
+fn scroll_does_not_move_cursor() {
+    let mut app = App::new();
+    app.cursor = (5, 2);
+    app.process_action(Action::MouseScroll { dx: 0, dy: 3 });
+    assert_eq!(app.cursor, (5, 2));
+    assert_eq!(app.viewport.row_offset, 3);
+}
+```
+
+- [ ] **Step 4: Implement the scroll arms**
+
+Add a constant near the top of `mouse.rs`:
+
+```rust
+pub const MOUSE_SCROLL_LINES: i32 = 3;
+```
+
+Extend `handle_mouse_event`:
+
+```rust
+        MouseEventKind::ScrollDown => Action::MouseScroll { dx: 0, dy: MOUSE_SCROLL_LINES },
+        MouseEventKind::ScrollUp => Action::MouseScroll { dx: 0, dy: -MOUSE_SCROLL_LINES },
+        MouseEventKind::ScrollLeft => Action::MouseScroll { dx: -MOUSE_SCROLL_LINES, dy: 0 },
+        MouseEventKind::ScrollRight => Action::MouseScroll { dx: MOUSE_SCROLL_LINES, dy: 0 },
+```
+
+- [ ] **Step 5: Add a test that disabling mouse mid-drag clears state**
+
+The `mouse_capture_active` sync block in `run_loop` (Task 4) already calls `mouse_state = MouseState::new()` when the flag flips off. Verify it via a smaller direct test in `mode/mouse.rs::tests`:
+
+```rust
+#[test]
+fn fresh_mouse_state_is_idle() {
+    let s = MouseState::new();
+    assert_eq!(s.drag, MouseDragState::Idle);
+    assert!(s.last_click.is_none());
+}
+```
+
+(The end-to-end "disable mid-drag" path is covered by the manual smoke test in Final Verification.)
+
+- [ ] **Step 6: Run tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): scroll wheel scrolls the viewport (#70)"
+```
+
+---
+
+## Task 10: Edge auto-scroll on drag past the visible edge
+
+When a `Drag(Left)` lands outside the grid in the direction of the drag, advance the viewport by one row/column so the next event has somewhere to land.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn drag_past_bottom_advances_row_offset() {
+    let mut app = App::new();
+    // Build a sheet large enough that scrolling has somewhere to go.
+    app.sheet.row_count = 100;
+    app.sheet.col_count = 10;
+
+    let mut state = MouseState::new();
+    let layout = fixture();
+    handle_mouse_event(
+        synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+        &mut state,
+        &app,
+        Some(&layout),
+    );
+    // y past the bottom of the grid (height=10, y_start=1 → bottom row at y=10)
+    let drag_below = synth(MouseEventKind::Drag(MouseButton::Left), 8, 11);
+    let action = handle_mouse_event(drag_below, &mut state, &app, Some(&layout));
+    // The handler emits a MouseScroll(dy=+1) chained with MouseDragTo.
+    // We model this as the handler returning a single MouseScroll and
+    // using state to flag a deferred drag — but for simplicity in this
+    // first implementation we ONLY emit the scroll when at the edge,
+    // and rely on the next Drag event to land inside the freshly-revealed row.
+    assert_eq!(action, Action::MouseScroll { dx: 0, dy: 1 });
+}
+```
+
+- [ ] **Step 2: Implement edge detection**
+
+Replace the `Drag(Left)` arm. When the drag lands outside the grid bounds, emit a one-row/one-column scroll instead of a drag. (Simpler than the spec's "advance offset then dispatch with new cell" — the next drag event lands correctly because the viewport has moved.)
+
+```rust
+        MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+            if state.drag == MouseDragState::Idle {
+                return Action::Noop;
+            }
+            // Edge auto-scroll: a drag landing outside the grid in the
+            // direction of motion advances the viewport one step.
+            let grid_bottom = layout.y + layout.height;
+            let grid_right = layout.x + layout.width;
+            let header_y_end = layout.y + layout.header_height;
+            let row_num_x_end = layout.x + layout.row_num_width;
+            if event.row >= grid_bottom {
+                return Action::MouseScroll { dx: 0, dy: 1 };
+            }
+            if event.row < header_y_end {
+                return Action::MouseScroll { dx: 0, dy: -1 };
+            }
+            if event.column >= grid_right {
+                return Action::MouseScroll { dx: 1, dy: 0 };
+            }
+            if event.column < row_num_x_end {
+                return Action::MouseScroll { dx: -1, dy: 0 };
+            }
+            match state.drag {
+                MouseDragState::DraggingCells { .. } => match target {
+                    MouseTarget::Cell(pos) => Action::MouseDragTo(pos),
+                    _ => Action::Noop,
+                },
+                MouseDragState::DraggingColumns { .. } => match target {
+                    MouseTarget::ColHeader(c) | MouseTarget::Cell((_, c)) => {
+                        Action::MouseSelectColumn(c)
+                    }
+                    _ => Action::Noop,
+                },
+                MouseDragState::DraggingRows { .. } => match target {
+                    MouseTarget::RowHeader(r) | MouseTarget::Cell((r, _)) => {
+                        Action::MouseSelectRow(r)
+                    }
+                    _ => Action::Noop,
+                },
+                MouseDragState::Idle => Action::Noop,
+            }
+        }
+```
+
+- [ ] **Step 3: Run tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): drag past edge auto-scrolls the viewport (#70)"
+```
+
+---
+
+## Task 11: Mode-aware click — commit/cancel/exit before move; `Outside` is always Noop
+
+A click on `Outside` is always a no-op (does NOT commit). A click on a real grid target while in `Insert` / `Command` / `Visual` first transitions back to Normal (committing or cancelling as appropriate), then dispatches the click action.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/main.rs`
+
+This is a `run_loop` change, not a handler change: the handler is mode-agnostic; the `run_loop` already manages mode entry/exit state. We synthesize an Esc-equivalent before processing the mouse action.
+
+- [ ] **Step 1: Update the `Event::Mouse` arm**
+
+```rust
+                Event::Mouse(me) => {
+                    if !app.mouse_enabled {
+                        continue;
+                    }
+                    app.status_message = None;
+                    let layout = app.last_grid_layout.clone();
+                    let action = mode::mouse::handle_mouse_event(
+                        me,
+                        &mut mouse_state,
+                        app,
+                        layout.as_ref(),
+                    );
+
+                    // Outside / Noop never causes a mode transition.
+                    let is_grid_action = matches!(
+                        &action,
+                        Action::MouseClickCell(_)
+                            | Action::MouseSelectColumn(_)
+                            | Action::MouseSelectRow(_)
+                    );
+                    if is_grid_action {
+                        match app.mode {
+                            Mode::Insert => {
+                                // Commit the in-progress edit, exactly the
+                                // same path Enter takes today.
+                                let pos = app.cursor;
+                                let buf = std::mem::take(&mut app.insert_buffer);
+                                app.process_action(Action::EditCell(pos, buf));
+                                app.mode = Mode::Normal;
+                            }
+                            Mode::Command => {
+                                app.command_line.clear();
+                                app.command_history_idx = None;
+                                app.command_history_scratch.clear();
+                                app.mode = Mode::Normal;
+                            }
+                            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                                visual_state = None;
+                                app.mode = Mode::Normal;
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    // Visual-mode-on-drag transition (from Tasks 6–8) goes here,
+                    // unchanged.
+                    match &action {
+                        Action::MouseDragTo(_) if app.mode == Mode::Normal => {
+                            if let mode::mouse::MouseDragState::DraggingCells { anchor } =
+                                mouse_state.drag
+                            {
+                                visual_state =
+                                    Some(VisualState::new(anchor, VisualKind::Character));
+                                app.mode = Mode::Visual;
+                            }
+                        }
+                        Action::MouseSelectColumn(_) => {
+                            if let mode::mouse::MouseDragState::DraggingColumns { anchor_col } =
+                                mouse_state.drag
+                            {
+                                visual_state = Some(VisualState::new(
+                                    (0, anchor_col),
+                                    VisualKind::Block,
+                                ));
+                                app.mode = Mode::VisualBlock;
+                            }
+                        }
+                        Action::MouseSelectRow(_) => {
+                            if let mode::mouse::MouseDragState::DraggingRows { anchor_row } =
+                                mouse_state.drag
+                            {
+                                visual_state = Some(VisualState::new(
+                                    (anchor_row, 0),
+                                    VisualKind::Block,
+                                ));
+                                app.mode = Mode::VisualBlock;
+                            }
+                        }
+                        _ => {}
+                    }
+
+                    app.process_action(action);
+                }
+```
+
+- [ ] **Step 2: Run all tests, fmt, clippy**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add crates/cell-sheet-tui/src/main.rs
+git commit -m "feat(tui): click in Insert/Command/Visual exits the mode first (#70)"
+```
+
+---
+
+## Task 12: Double-click on a cell → enter Insert mode
+
+Implement double-click detection in `MouseState`. Two `Down(Left)` events on the same cell within `DOUBLE_CLICK_MS` fire `Action::ChangeMode(Mode::Insert)` instead of `MouseClickCell`.
+
+**Files:**
+- Modify: `crates/cell-sheet-tui/src/mode/mouse.rs`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn double_click_enters_insert_mode() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let event = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+    let _ = handle_mouse_event(event, &mut state, &app, Some(&layout));
+    let event2 = synth(MouseEventKind::Down(MouseButton::Left), 8, 3);
+    assert_eq!(
+        handle_mouse_event(event2, &mut state, &app, Some(&layout)),
+        Action::ChangeMode(crate::action::Mode::Insert)
+    );
+}
+
+#[test]
+fn click_then_different_cell_is_two_singles() {
+    let app = App::new();
+    let mut state = MouseState::new();
+    let layout = fixture();
+    let _ = handle_mouse_event(
+        synth(MouseEventKind::Down(MouseButton::Left), 8, 3),
+        &mut state,
+        &app,
+        Some(&layout),
+    );
+    let event2 = synth(MouseEventKind::Down(MouseButton::Left), 18, 5);
+    assert_eq!(
+        handle_mouse_event(event2, &mut state, &app, Some(&layout)),
+        Action::MouseClickCell((3, 1))
+    );
+}
+```
+
+- [ ] **Step 2: Implement double-click detection**
+
+In the `Down(Left)` arm of `handle_mouse_event`, before the existing `MouseTarget::Cell` arm:
+
+```rust
+            MouseTarget::Cell(pos) => {
+                let now = Instant::now();
+                let is_double = state
+                    .last_click
+                    .map(|lc| {
+                        lc.pos == pos
+                            && now.duration_since(lc.at) <= Duration::from_millis(DOUBLE_CLICK_MS)
+                    })
+                    .unwrap_or(false);
+                if is_double {
+                    state.drag = MouseDragState::Idle;
+                    state.last_click = None;
+                    Action::ChangeMode(Mode::Insert)
+                } else {
+                    state.drag = MouseDragState::DraggingCells { anchor: pos };
+                    state.last_click = Some(LastClick { at: now, pos });
+                    Action::MouseClickCell(pos)
+                }
+            }
+```
+
+Also clear `last_click` whenever `Down(Left)` lands on `ColHeader` / `RowHeader` (drag, scroll, or non-cell click) so a stale click can't combine with a much later one (already done in Task 7/8 for header clicks; verify and keep).
+
+Add the `Mode` import:
+
+```rust
+use crate::action::{Action, Mode};
+```
+
+- [ ] **Step 3: Run tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-tui/src
+git commit -m "feat(tui): double-click on a cell enters Insert mode (#70)"
+```
+
+---
+
+## Task 13: Help-system entries — `MOUSE_ENTRIES` + `HelpCategory::Mouse`
+
+Per AGENTS.md, every user-visible binding must have a `HelpEntry`.
+
+**Files:**
+- Modify: `crates/cell-sheet-core/src/help/mod.rs`
+- Modify: `crates/cell-sheet-core/src/help/entries.rs`
+- Read-check: `crates/cell-sheet-tui/src/render/help.rs`
+
+- [ ] **Step 1: Add `Mouse` to `HelpCategory`**
+
+In `crates/cell-sheet-core/src/help/mod.rs`:
+
+```rust
+pub enum HelpCategory {
+    Normal,
+    Insert,
+    Visual,
+    Command,
+    Formula,
+    Mouse,
+}
+```
+
+```rust
+    pub fn label(&self) -> &'static str {
+        match self {
+            HelpCategory::Normal => "NORMAL MODE",
+            HelpCategory::Insert => "INSERT MODE",
+            HelpCategory::Visual => "VISUAL MODE",
+            HelpCategory::Command => "COMMANDS",
+            HelpCategory::Formula => "FORMULAS",
+            HelpCategory::Mouse => "MOUSE",
+        }
+    }
+```
+
+In `categories()`:
+
+```rust
+        let order = [Normal, Insert, Visual, Command, Formula, Mouse];
+```
+
+In `HelpRegistry::new()`:
+
+```rust
+        Self::from_entries(&[
+            NORMAL_ENTRIES,
+            INSERT_ENTRIES,
+            VISUAL_ENTRIES,
+            COMMAND_ENTRIES,
+            FORMULA_ENTRIES,
+            MOUSE_ENTRIES,
+        ])
+```
+
+- [ ] **Step 2: Add `MOUSE_ENTRIES`**
+
+In `crates/cell-sheet-core/src/help/entries.rs`, append:
+
+```rust
+pub static MOUSE_ENTRIES: &[HelpEntry] = &[
+    HelpEntry {
+        tags: &["mouse", ":set mouse"],
+        category: HelpCategory::Mouse,
+        summary: "Enable / disable mouse support",
+        detail: "Mouse support is OFF by default. Toggle at runtime:\n\
+                 \n\
+                 :set mouse on        Enable mouse capture.\n\
+                 :set mouse off       Disable mouse capture.\n\
+                 :set mouse toggle    Flip the current state.\n\
+                 \n\
+                 When mouse mode is on, the terminal stops doing native\n\
+                 text selection. Hold your terminal's bypass modifier to\n\
+                 fall back to native selection for copy:\n\
+                 \n\
+                 - Linux & Windows Terminal: Shift\n\
+                 - macOS Terminal.app and iTerm2: Option/Alt\n\
+                 - tmux/screen: see your terminal's docs",
+    },
+    HelpEntry {
+        tags: &["mouse-click", "click"],
+        category: HelpCategory::Mouse,
+        summary: "Left-click moves the cursor",
+        detail: "Left-click on a grid cell moves the cursor there. From\n\
+                 Insert mode the in-progress edit is committed first;\n\
+                 from Command mode the prompt is cancelled; from Visual\n\
+                 the selection is exited.\n\
+                 \n\
+                 Click on the formula bar, status bar, or padding around\n\
+                 the grid is a no-op and never commits an edit.",
+    },
+    HelpEntry {
+        tags: &["mouse-drag", "drag"],
+        category: HelpCategory::Mouse,
+        summary: "Click + drag selects a range",
+        detail: "Drag inside the grid: enters Visual mode and extends the\n\
+                 selection from the click cell to the current cell.\n\
+                 \n\
+                 Drag on a column header: selects whole columns.\n\
+                 Drag on a row header: selects whole rows.\n\
+                 \n\
+                 Dragging past the visible edge auto-scrolls the\n\
+                 viewport one row/column per drag event.",
+    },
+    HelpEntry {
+        tags: &["mouse-scroll", "scroll-wheel", "wheel"],
+        category: HelpCategory::Mouse,
+        summary: "Scroll wheel scrolls the viewport",
+        detail: "The scroll wheel scrolls the viewport up or down by 3\n\
+                 rows. The cursor does not move, even if it scrolls out\n\
+                 of view (matches Vim's mouse behaviour).\n\
+                 \n\
+                 Horizontal scroll (Shift+wheel on most terminals)\n\
+                 scrolls the viewport left or right when the terminal\n\
+                 emits ScrollLeft / ScrollRight events.",
+    },
+    HelpEntry {
+        tags: &["mouse-double-click", "double-click", "edit-cell"],
+        category: HelpCategory::Mouse,
+        summary: "Double-click enters Insert mode",
+        detail: "Two left-clicks on the same cell within ~400ms enter\n\
+                 Insert mode on that cell. A second click on a different\n\
+                 cell, or after the threshold, is treated as a fresh\n\
+                 single click.",
+    },
+    HelpEntry {
+        tags: &["mouse-bypass", "shift-click"],
+        category: HelpCategory::Mouse,
+        summary: "Shift+click bypasses mouse capture",
+        detail: "Holding Shift while clicking is treated as a no-op by\n\
+                 cell, allowing the terminal's native text selection to\n\
+                 take over. Use this to copy a cell value or formula\n\
+                 string out to your system clipboard. (On macOS\n\
+                 Terminal.app and iTerm2 the bypass modifier is\n\
+                 typically Option/Alt — check your terminal settings.)",
+    },
+];
+```
+
+- [ ] **Step 3: Verify the help renderer doesn't need a change**
+
+```sh
+rg "categories\(\)|HelpCategory::" crates/cell-sheet-tui/src/render/help.rs
+```
+
+If the renderer iterates `registry.categories()` (it should, per the existing pattern), no change is required. If it hard-codes the category list, add `HelpCategory::Mouse` there.
+
+- [ ] **Step 4: Update the `full_registry_has_expected_tags` test**
+
+In `crates/cell-sheet-core/src/help/mod.rs::tests::full_registry_has_expected_tags`:
+
+```rust
+        assert!(registry.find("mouse").is_some(), "missing mouse");
+        assert!(registry.find("mouse-click").is_some(), "missing mouse-click");
+        assert!(registry.find("mouse-scroll").is_some(), "missing mouse-scroll");
+```
+
+- [ ] **Step 5: Run tests, fmt, clippy, commit**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+git add crates/cell-sheet-core/src/help crates/cell-sheet-tui/src/render/help.rs
+git commit -m "docs(help): add MOUSE_ENTRIES and Mouse category (#70)"
+```
+
+---
+
+## Task 14: README, AGENTS.md, CHANGELOG
+
+Wrap up with the documentation surface.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: README — add a "Mouse support" subsection**
+
+Find the existing "Usage" or "Keybindings" section in `README.md` and add a subsection. Place it after the keybindings list and before the file-formats section:
+
+```markdown
+## Mouse support
+
+Mouse support is **off by default** so the terminal's native text
+selection keeps working. Enable it at runtime:
+
+```
+:set mouse on        # enable
+:set mouse off       # disable
+:set mouse toggle    # flip
+```
+
+When enabled:
+
+- **Left-click** on a cell moves the cursor.
+- **Click + drag** inside the grid selects a Visual range.
+- **Click + drag** on a column header selects whole columns.
+- **Click + drag** on a row header selects whole rows.
+- **Scroll wheel** scrolls the viewport (cursor stays put). Horizontal
+  scroll works when the terminal emits `ScrollLeft` / `ScrollRight`
+  (commonly bound to Shift + wheel).
+- **Double-click** a cell to enter Insert mode on it.
+- **Drag past the visible edge** auto-scrolls the viewport.
+
+To copy a cell value out to your system clipboard while mouse mode is
+on, hold your terminal's bypass modifier when clicking and dragging:
+
+| Terminal | Bypass |
+| --- | --- |
+| Linux terminals (gnome-terminal, alacritty, kitty, …) | Shift |
+| Windows Terminal | Shift |
+| macOS Terminal.app, iTerm2 | Option/Alt |
+| tmux / screen | configure per their docs |
+```
+
+- [ ] **Step 2: AGENTS.md — add a one-liner under "Things to avoid"**
+
+In the existing `### Things to avoid` list, add:
+
+```markdown
+- Enabling mouse capture unconditionally. Mouse support is opt-in via
+  the `mouse_enabled` runtime flag set by `:set mouse on`; do not
+  bypass it.
+```
+
+- [ ] **Step 3: CHANGELOG — add an entry under `## Unreleased`**
+
+```markdown
+## Unreleased
+
+### Added
+
+- Optional mouse support (off by default; enable with `:set mouse on`).
+  Left-click moves the cursor; click+drag selects a range; clicks on
+  column/row headers select whole columns/rows; scroll wheel scrolls
+  the viewport without moving the cursor; double-click enters Insert
+  mode. Hold Shift (or your terminal's bypass modifier) to use native
+  text selection for copy. (#70)
+```
+
+- [ ] **Step 4: Run final verification**
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+Expected: clean across the board.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add README.md AGENTS.md CHANGELOG.md
+git commit -m "docs: document mouse support (#70)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full pre-commit pipeline one more time**
+
+Per AGENTS.md, before claiming work is done, run all three:
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test
+```
+
+Each must pass clean (CI uses `RUSTFLAGS=-Dwarnings`).
+
+- [ ] **Smoke test the binary by hand**
+
+```sh
+cargo run -- examples/sample.csv  # or any test sheet
+```
+
+Then in the TUI:
+
+1. `:set mouse on` — status line should not error.
+2. Click a cell several rows/columns away — cursor should jump there.
+3. Click and drag across a few cells — should enter Visual and select the range.
+4. Click on a column header — should select the whole column (VisualBlock).
+5. Click on a row header — should select the whole row.
+6. Scroll the wheel — viewport should scroll, cursor should not move.
+7. Double-click a cell — should enter Insert mode.
+8. Press Esc, then Shift+click — should be a no-op (terminal selection works).
+9. `:set mouse off` — clicks should stop having any effect.
+10. `:q` — terminal should exit cleanly with no lingering mouse capture.
+
+- [ ] **All acceptance criteria from the spec are now true:**
+
+Cross-reference [`docs/superpowers/specs/2026-04-30-mouse-support-design.md`](../specs/2026-04-30-mouse-support-design.md) "Acceptance criteria" section. Each box should be checkable.

--- a/docs/superpowers/specs/2026-04-30-mouse-support-design.md
+++ b/docs/superpowers/specs/2026-04-30-mouse-support-design.md
@@ -247,15 +247,25 @@ via `Action::SetStatus("failed to enable mouse: <err>")` and leave
   observing the flag change (because `process_action` does not own
   stdout).
 - `Action::MouseClickCell(pos)` → set `app.cursor = pos`,
-  `viewport.ensure_visible(pos)`. (No selection.)
-- `Action::MouseDragTo(pos)` → set `app.cursor = pos`,
-  `viewport.ensure_visible(pos)`. The active `VisualState` (created on
-  the prior `Down`) extends naturally because Visual selection is
-  derived from `anchor` and `cursor`.
-- `Action::MouseSelectColumn(c)` / `MouseSelectRow(r)` → enter
-  `VisualBlock` with anchor and cursor spanning the full column or row,
-  reusing the existing whole-column/whole-row selection paths if any
-  exist; otherwise build the equivalent `VisualState` directly.
+  `viewport.ensure_visible(pos)`. The mode stays `Normal`. (A bare
+  click never produces a selection — only a drag does.)
+- `Action::MouseDragTo(pos)` → if the app is currently in `Normal`
+  mode, the handler emits this only on the *first* `Drag(Left)` event
+  after a `Down(Left)`, and `run_loop` enters `Visual` mode with
+  `anchor = MouseDragState::DraggingCells.anchor` before processing
+  the action — exactly the way `Action::ChangeMode(Mode::Visual)` is
+  handled today. On subsequent `Drag` events while already in
+  `Visual`, this just sets `app.cursor = pos` and
+  `viewport.ensure_visible(pos)`; the existing `VisualState` extends
+  naturally because Visual selection is derived from `anchor` and
+  `cursor`.
+- `Action::MouseSelectColumn(c)` → set cursor to row 0 of column `c`
+  and enter `VisualBlock` with anchor at `(0, c)` and cursor at
+  `(last_row, c)` so the whole column is selected. On a subsequent
+  drag, anchor stays at `(0, original_anchor_col)`, cursor moves to
+  `(last_row, target_col)`.
+- `Action::MouseSelectRow(r)` → mirror image: anchor `(r, 0)`, cursor
+  `(r, last_col)`.
 - `Action::MouseScroll { dx, dy }` → mutate `viewport.row_offset` and
   `viewport.col_offset` only. Cursor is **not** moved, even if it
   scrolls out of view (matches Vim).

--- a/docs/superpowers/specs/2026-04-30-mouse-support-design.md
+++ b/docs/superpowers/specs/2026-04-30-mouse-support-design.md
@@ -1,0 +1,443 @@
+# Mouse Support — Design Spec
+
+**Issue:** [#70](https://github.com/garritfra/cell/issues/70)
+**Date:** 2026-04-30
+**Status:** Approved, ready for implementation plan
+
+---
+
+## Background
+
+cell is a keyboard-first, Vim-modal terminal spreadsheet. Today, every
+interaction goes through `event::read` → `Event::Key` → a per-mode handler
+in `crates/cell-sheet-tui/src/mode/`. There is no mouse capture, no
+config-file infrastructure, and no notion of "where on the screen does
+this cell live" outside of the render layer.
+
+The geometry is owned by two places:
+
+- `crates/cell-sheet-tui/src/render/grid.rs` — the column-header row,
+  per-column widths via `sheet.col_widths`, the row-number gutter
+  (`ROW_NUM_WIDTH = 5`), and where the grid is drawn within the frame.
+- `crates/cell-sheet-tui/src/viewport.rs` — `row_offset` / `col_offset`
+  for scrolling.
+
+Adding mouse support is fundamentally an exercise in (a) capturing mouse
+events and (b) translating screen coordinates back into logical
+`(row, col)` cell positions using that geometry.
+
+---
+
+## Goals
+
+1. **Opt-in mouse mode** — off by default, enabled via `:set mouse on`.
+2. **Left-click** moves the cursor to the clicked cell.
+3. **Click + drag** selects a range:
+   - Inside the grid → Visual (Character) selection from anchor cell to
+     current cell.
+   - On a column header → whole-column range from anchor column to
+     current column.
+   - On a row header → whole-row range from anchor row to current row.
+4. **Drag past visible edge** auto-scrolls the viewport one row/column
+   per drag event.
+5. **Scroll wheel** scrolls the viewport without moving the cursor.
+   Horizontal scroll works on terminals that emit `ScrollLeft` /
+   `ScrollRight` (e.g. Shift+wheel on most terminals).
+6. **Double-click** on a cell enters Insert mode on it.
+7. **Click while in another mode** transitions back to Normal first,
+   then moves the cursor: Insert commits the in-progress edit, Command
+   cancels the prompt, Visual exits the selection. (A click on
+   `Outside` is always a no-op and never commits anything.)
+8. **Shift+click** is a no-op so the terminal's native text selection
+   keeps working for copy.
+9. `:help mouse`, README, AGENTS.md, and CHANGELOG are updated.
+
+## Non-goals
+
+Explicitly deferred to follow-up issues:
+
+- Drag column borders to resize columns.
+- Right-click context menu.
+- Click on status-line / mode indicator elements.
+- Drag-to-select inside the cell editor while in Insert mode (mouse only
+  acts at grid level for now).
+- Persistent config file (e.g. `~/.config/cell/config.toml`). The only
+  configuration mechanism is the runtime `:set` command, matching the
+  existing `:set delimiter=` precedent.
+- Legacy mouse protocols (X10, normal). Crossterm's `EnableMouseCapture`
+  enables SGR 1006 by default, which works in every terminal we
+  reasonably target.
+
+---
+
+## Approach
+
+A new `mode/mouse.rs` module mirroring the keyboard-mode handlers, plus
+a small `GridLayout` struct published from the render layer for
+hit-testing. Three reasons for this shape:
+
+1. **Pure hit-test seam.** `hit_test(layout, x, y) → MouseTarget` is a
+   pure function — no terminal, no IO, fully unit-testable.
+2. **Mode-handler symmetry.** `mode/mouse.rs` translates a `MouseEvent`
+   into an `Action` exactly the way `mode/normal.rs` translates a
+   `KeyEvent`. `run_loop` gains one new arm and stays a router.
+3. **Single source of geometry.** The render layer already owns column
+   widths and offsets; publishing a `GridLayout` per frame is cheaper and
+   safer than duplicating that math in the event handler.
+
+### Module layout
+
+```
+crates/cell-sheet-tui/src/
+├─ main.rs                # EnableMouseCapture / DisableMouseCapture;
+│                         # route Event::Mouse to mode::mouse::handle_mouse_event
+├─ app.rs                 # add `mouse_enabled: bool`, last-frame `GridLayout`
+├─ render/grid.rs         # publish GridLayout (area, header_height,
+│                         # row_num_width, row_offset, col_offset,
+│                         # visible_cols: Vec<(col_index, x, width)>)
+├─ mode/mouse.rs          # NEW: MouseDragState, hit_test, handle_mouse_event
+├─ mode/command.rs        # extend parse_command() with `set mouse on|off|toggle`
+└─ action.rs              # add Action variants (see below)
+```
+
+### `MouseTarget`
+
+```rust
+pub enum MouseTarget {
+    Cell(CellPos),
+    ColHeader(usize),     // column index
+    RowHeader(usize),     // 0-indexed row
+    Outside,              // formula bar, status bar, command line, padding
+}
+```
+
+### `MouseState`
+
+Lives in `mode/mouse.rs` and is owned by `run_loop` exactly the way
+`NormalState` and `Option<VisualState>` are today. Bundles drag state
+and double-click detection (crossterm does not expose a click-count;
+we track it ourselves):
+
+```rust
+pub struct MouseState {
+    drag: MouseDragState,
+    last_click: Option<LastClick>,
+}
+
+enum MouseDragState {
+    Idle,
+    DraggingCells   { anchor: CellPos },
+    DraggingColumns { anchor_col: usize },
+    DraggingRows    { anchor_row: usize },
+}
+
+struct LastClick {
+    at: std::time::Instant,
+    pos: CellPos,
+}
+```
+
+A `Down(Left)` event qualifies as a double-click if `last_click` is
+`Some` and:
+
+- `now - at <= DOUBLE_CLICK_MS` (400ms; matches typical OS defaults), and
+- the click landed on the same `CellPos`.
+
+After dispatch, `last_click` is updated to the current click. A drag,
+scroll, or non-cell click clears `last_click` to `None` so a stale
+single-click can never combine with a much later one to spuriously
+trigger Insert mode.
+
+### New `Action` variants
+
+```rust
+Action::SetMouse(bool),                  // process via App::process_action
+Action::MouseClickCell(CellPos),         // also commits/cancels prior mode
+Action::MouseDragTo(CellPos),            // extends current Visual selection
+Action::MouseSelectColumn(usize),
+Action::MouseSelectRow(usize),
+Action::MouseScroll { dx: i32, dy: i32 }, // viewport-only; cursor untouched
+```
+
+`MouseClickCell`, `MouseSelectColumn`, and `MouseSelectRow` reuse
+existing range/visual primitives in `App::process_action` rather than
+introducing parallel selection logic.
+
+---
+
+## Data flow
+
+### Enable / disable
+
+`:set mouse on|off|toggle` parses to `Action::SetMouse(bool)`.
+`App::process_action` flips `app.mouse_enabled`. Whenever the flag
+changes, `run_loop` issues `execute!(stdout, EnableMouseCapture)` or
+`DisableMouseCapture`. Mouse is **off on startup** so existing users see
+no behavior change until they opt in.
+
+`run_tui` issues `DisableMouseCapture` symmetrically with
+`LeaveAlternateScreen` on shutdown so mouse capture never leaks past
+process exit. If `EnableMouseCapture` returns an `io::Error`, surface
+via `Action::SetStatus("failed to enable mouse: <err>")` and leave
+`mouse_enabled = false`.
+
+### Per-event flow (when `mouse_enabled == true`)
+
+1. `event::read()` returns `Event::Mouse(me)`.
+2. `run_loop` reads the most recent `GridLayout` saved during the prior
+   `terminal.draw`.
+3. Calls `mode::mouse::handle_mouse_event(me, &mut mouse_state, &mut app, &layout)`.
+4. The handler:
+   1. **Bypass passthrough.** If `me.modifiers.contains(SHIFT)`, return
+      `Action::Noop` immediately so the terminal's native selection
+      wins.
+   2. Runs `hit_test(layout, me.column, me.row) → MouseTarget`.
+   3. Switches on `me.kind`:
+      - `Down(Left)` →
+        - If `target == Outside` → `Noop`. (Click on padding, status
+          bar, or formula bar never commits an in-progress edit; only
+          Esc or a real grid click does.)
+        - If `target` is a `Cell(pos)` and the click qualifies as a
+          double-click (see `MouseState` above), dispatch
+          `Action::ChangeMode(Mode::Insert)` on `pos`. (No anchor armed
+          for drag — the user is editing, not selecting.)
+        - Otherwise, prepare a single `Action`:
+          - In `Insert` mode: emit a synthetic commit (same code path
+            as Enter today) before the click action — implemented as a
+            small two-step action sequence in `run_loop` rather than a
+            new compound `Action`.
+          - In `Command` mode: cancel the prompt (clear `command_line`,
+            return to Normal) before the click action.
+          - In `Visual` / `VisualLine` / `VisualBlock` mode: exit Visual
+            (clear `visual_state`, return to Normal) before the click
+            action. Mirrors Vim's `mouse=a`.
+          - Then dispatch by target: `Cell(pos)` ⇒ `MouseClickCell(pos)`
+            and arm `DraggingCells { anchor: pos }`; `ColHeader(c)` ⇒
+            `MouseSelectColumn(c)` and arm `DraggingColumns`;
+            `RowHeader(r)` ⇒ `MouseSelectRow(r)` and arm `DraggingRows`.
+      - `Drag(Left)` →
+        - If drag is `Idle`, treat as `Noop` (a stray drag event with no
+          armed anchor — should not happen in practice).
+        - Otherwise dispatch `MouseDragTo(target_pos)` (or
+          column/row-extend variants); the app converts this to a
+          Visual selection from `anchor` to `target_pos`.
+        - **Edge auto-scroll**: if `me.row` is past the last visible
+          data row (or `me.column` past the last visible column),
+          advance `viewport.row_offset` / `col_offset` by 1 *before*
+          computing the target, then dispatch with the now-visible
+          cell. Bounded to one row/column per event.
+      - `Up(Left)` → reset `MouseDragState` to `Idle`. The visual
+        selection persists exactly the way it does after releasing a
+        keyboard `v`+motion sequence.
+      - `ScrollDown` / `ScrollUp` → `Action::MouseScroll { dy: ±3, dx: 0 }`.
+        `MOUSE_SCROLL_LINES = 3` (matches common terminal/Vim defaults).
+        Cursor stays put even if it leaves the visible area.
+      - `ScrollLeft` / `ScrollRight` → same with `dx: ±3, dy: 0`. On
+        terminals that don't emit these, horizontal scrolling silently
+        doesn't work.
+5. The returned `Action` flows through the existing
+   `App::process_action` pipeline; mode transitions, undo coalescing,
+   and viewport recentering reuse current paths unchanged.
+
+`App::process_action` gains arms for the new variants:
+
+- `Action::SetMouse(b)` → set `app.mouse_enabled = b`. Also resets
+  `MouseState` to `Idle` if `b == false`. The actual
+  `Enable/DisableMouseCapture` syscall is issued by `run_loop` after
+  observing the flag change (because `process_action` does not own
+  stdout).
+- `Action::MouseClickCell(pos)` → set `app.cursor = pos`,
+  `viewport.ensure_visible(pos)`. (No selection.)
+- `Action::MouseDragTo(pos)` → set `app.cursor = pos`,
+  `viewport.ensure_visible(pos)`. The active `VisualState` (created on
+  the prior `Down`) extends naturally because Visual selection is
+  derived from `anchor` and `cursor`.
+- `Action::MouseSelectColumn(c)` / `MouseSelectRow(r)` → enter
+  `VisualBlock` with anchor and cursor spanning the full column or row,
+  reusing the existing whole-column/whole-row selection paths if any
+  exist; otherwise build the equivalent `VisualState` directly.
+- `Action::MouseScroll { dx, dy }` → mutate `viewport.row_offset` and
+  `viewport.col_offset` only. Cursor is **not** moved, even if it
+  scrolls out of view (matches Vim).
+
+---
+
+## Configuration
+
+| Knob                | Mechanism                          | Default | Persisted |
+| ------------------- | ---------------------------------- | ------- | --------- |
+| Mouse enabled       | `:set mouse on \| off \| toggle`   | `off`   | No (session-only) |
+
+`set mouse <garbage>` is a soft error:
+`Action::SetStatus("usage: :set mouse on|off|toggle")`. Same pattern as
+the existing `:set delimiter=` errors in `parse_command`.
+
+---
+
+## Bypass-modifier strategy
+
+Terminal text selection is the user's safety net for copying values out
+of a cell or formula bar to paste elsewhere. When mouse capture is on,
+most terminals stop doing native selection. The bypass modifier
+restores it; which key serves as the bypass is terminal-specific.
+
+Strategy:
+
+1. **App-side passthrough.** When mouse mode is on and Shift is held,
+   `handle_mouse_event` returns `Action::Noop`. Belt-and-suspenders:
+   even if the terminal already does the right thing on Shift+click,
+   the app does not consume the event.
+2. **Documentation.** README and `:help mouse` list the bypass keys for
+   common terminals (Linux: Shift; macOS Terminal/iTerm: Option/Alt;
+   Windows Terminal: Shift; tmux/screen: configure
+   `set -g mouse on` and use the terminal's bypass *plus* tmux's
+   `copy-mode`).
+
+---
+
+## Edge cases
+
+- **Terminals without mouse support.** `EnableMouseCapture` succeeds
+  silently; no `Event::Mouse` ever arrives. No special detection
+  needed.
+- **Click on an empty row past populated data.** Cursor moves there,
+  consistent with `j`-past-data behavior today.
+- **Click on the top-left corner cell** (header row × row-number
+  gutter) → `Outside`, no-op.
+- **Mouse event in Help mode.** Always `Outside`; user must `q` out.
+- **Resize between events.** `GridLayout` is rebuilt each frame, so
+  the next mouse event uses fresh geometry. A click that arrives during
+  a resize-in-flight may map to a stale cell once; acceptable.
+- **Disabling mouse mid-drag.** Processing `Action::SetMouse(false)`
+  resets `MouseDragState` to `Idle` *before* issuing
+  `DisableMouseCapture` so no dangling drag anchor survives.
+- **Restore on exit / panic.** `run_tui`'s cleanup block already
+  disables raw mode and leaves the alternate screen; we add
+  `DisableMouseCapture` to that block. (A panic during the loop still
+  passes through this cleanup because `run_loop` returns a `Result`
+  rather than panicking.)
+
+---
+
+## Testing
+
+### Unit tests (no terminal needed)
+
+`mode/mouse.rs::hit_test_*` — at minimum:
+
+1. Click in a normal data cell.
+2. Click on a column header.
+3. Click on a row header.
+4. Click on the top-left corner (header × gutter) → `Outside`.
+5. Click in formula bar / status bar / command line → `Outside`.
+6. Click in padding to the right of the last visible column → `Outside`.
+7. Click below the last rendered row → `Outside`.
+8. Click on a column with non-default width (verifies the per-column
+   width math, not just `DEFAULT_COL_WIDTH`).
+
+`mode/mouse.rs::handle_mouse_event_*`:
+
+1. Cell click in Normal → `MouseClickCell`, drag state armed.
+2. Cell drag in Normal → drag state transitions to `DraggingCells`,
+   emits `MouseDragTo(target)`.
+3. Column-header drag → emits `MouseSelectColumn` and extends to a
+   range on subsequent drag events.
+4. Double-click on a cell → `ChangeMode(Insert)`. Two `Down(Left)`
+   events on the same cell within `DOUBLE_CLICK_MS` qualify; spaced
+   further apart, they're two single clicks.
+5. Two clicks on *different* cells within the threshold → two single
+   clicks, not a double-click.
+6. Scroll wheel → `MouseScroll { dy: ±3 }`, cursor unchanged even when
+   it leaves the visible area.
+7. Shift+click → `Noop`.
+8. Click on `Outside` while in Insert mode → `Noop`, buffer is *not*
+   committed.
+9. Cell click while `Mode::Insert` → commit-then-move sequence.
+10. Cell click while `Mode::Command` → cancel-then-move sequence.
+11. Cell click while `Mode::Visual` → exit-Visual-then-move sequence.
+12. Drag past visible edge → viewport advances one row/column, target
+    uses the new visible cell.
+13. `Action::SetMouse(false)` while drag is armed resets drag state to
+    `Idle`.
+
+`mode/command.rs::parse_command`:
+
+1. `set mouse on`.
+2. `set mouse off`.
+3. `set mouse toggle`.
+4. `set mouse bogus` → status error, no flag change.
+
+### Integration smoke
+
+Driving `App` with synthetic `MouseEvent`s constructed in code (no
+terminal required). Asserts cursor position, viewport offsets, and
+selection state after sequences of clicks, drags, and scrolls. Lives
+in `crates/cell-sheet-tui/src/mode/mouse.rs` under `#[cfg(test)]` to
+match the existing pattern.
+
+CI on Linux/macOS/Windows already exercises the build with mouse code
+paths compiled (crossterm is cross-platform). No new platform gates.
+
+---
+
+## Help-system updates
+
+Per AGENTS.md, every user-visible binding must have a `HelpEntry`.
+
+- Add `MOUSE_ENTRIES` in
+  `crates/cell-sheet-core/src/help/entries.rs` with one entry per:
+  enable/disable (`:set mouse on|off|toggle`), left-click, click+drag
+  in grid / column header / row header, scroll wheel, double-click to
+  edit, Shift+click bypass.
+- Add a `Mouse` category to `HelpRegistry` in
+  `crates/cell-sheet-core/src/help/mod.rs`.
+- Render the new section in `crates/cell-sheet-tui/src/render/help.rs`.
+- `:help mouse` topic resolves to the new category.
+
+---
+
+## Documentation
+
+- **README.md** — new "Mouse support" subsection under Usage:
+  opt-in via `:set mouse on`; list MVP interactions; the
+  bypass-modifier note (Shift on most terminals; Option/Alt on macOS
+  Terminal/iTerm; tmux/screen need their own bypass key); horizontal
+  scroll depends on terminal support.
+- **AGENTS.md** — short note in the *Things to avoid* list:
+  "Do not enable mouse capture unconditionally; mouse is opt-in via the
+  `mouse_enabled` runtime flag."
+- **CHANGELOG.md** — `## Unreleased` → `Added`:
+  > Optional mouse support (off by default; enable with
+  > `:set mouse on`). Left-click moves the cursor; click+drag selects
+  > a range; header clicks select rows/columns; scroll wheel scrolls
+  > the viewport; double-click enters Insert mode. (#70)
+
+---
+
+## Acceptance criteria
+
+- [ ] Mouse is off by default; opt-in via `:set mouse on` (also `off`,
+      `toggle`).
+- [ ] Left-click on a grid cell moves the cursor there, including from
+      Insert mode (with commit), Command mode (with cancel), and
+      Visual mode (with selection exit). Left-click on padding /
+      formula bar / status bar is a no-op and does not commit.
+- [ ] Click+drag inside the grid creates a Visual (Character) range
+      from the click-down cell to the current cell.
+- [ ] Click+drag on a column header selects whole columns from anchor
+      to current.
+- [ ] Click+drag on a row header selects whole rows from anchor to
+      current.
+- [ ] Drag past the visible edge auto-scrolls the viewport one
+      row/column per event.
+- [ ] Scroll wheel scrolls the viewport without moving the cursor;
+      horizontal wheel scrolls horizontally on terminals that emit
+      `ScrollLeft` / `ScrollRight`.
+- [ ] Double-click on a cell enters Insert mode on it.
+- [ ] Holding Shift while clicking is a `Noop` so the terminal's
+      native selection works for copy.
+- [ ] Mouse capture is properly disabled on `:q`, `:set mouse off`,
+      and any normal exit.
+- [ ] `:help mouse` lists every binding above; entries also appear in
+      the Help screen.
+- [ ] README, AGENTS.md, and CHANGELOG updated.


### PR DESCRIPTION
## Summary

Closes #70.

Adds optional mouse support to cell, off by default. Enable with `:set mouse on`.

When enabled:

- **Left-click** on a cell moves the cursor.
- **Click + drag** inside the grid selects a Visual range.
- **Click + drag** on a column header selects whole columns; **row header** selects whole rows.
- **Scroll wheel** scrolls the viewport without moving the cursor (matches Vim). Horizontal scroll works when the terminal emits `ScrollLeft`/`ScrollRight` (commonly Shift+wheel).
- **Double-click** a cell to enter Insert mode on it.
- **Drag past the visible edge** auto-scrolls the viewport (cell drag: all four edges; column drag: right edge; row drag: bottom edge).
- **Click while in Insert/Command/Visual** commits the buffer / cancels the prompt / exits the selection before moving. A click on the formula bar, status bar, or padding is always a no-op and never commits anything.
- **Shift+click** is a no-op so the terminal's native text selection still works for copying cell contents.

## Design

- Spec: `docs/superpowers/specs/2026-04-30-mouse-support-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-mouse-support.md`

The implementation follows the spec's "pure hit-test seam + mode-handler symmetry" architecture: a new `mode/mouse.rs` mirrors the existing keyboard mode handlers, with a pure `hit_test(GridLayout, x, y) → MouseTarget` for unit-testable coordinate translation. The render layer publishes `GridLayout` to `App.last_grid_layout` on every frame; `run_loop` gains an `Event::Mouse` arm that delegates to `mode::mouse::handle_mouse_event`. Mode-aware click logic and Visual-mode transitions live in `run_loop` parallel to the existing keyboard pathways.

## What's not included (intentional non-goals per the issue)

- Drag column borders to resize columns
- Right-click context menu
- Click on status-line / mode indicator elements
- Drag-to-select inside the cell editor (mouse only acts at grid level)
- Persistent config file (`:set` is the only mechanism — matches the existing `:set delimiter=` precedent)
- Legacy mouse protocols (only SGR 1006 — what crossterm enables by default)

## Test plan

- `cargo fmt --all --check` — clean
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --all-features` — clean
- `cargo test` — **491 passed, 0 failed** (118 core + 5 + 338 tui + 30 headless)
- ~50 new unit + integration tests covering hit-test, every handler arm, edge auto-scroll, double-click detection, mode-aware click behavior, scroll wheel, the `:set mouse` parser, and the `gv` / search-cancel state preservation on mouse-driven mode exit.
- `:help mouse`, `:help click`, `:help drag`, `:help wheel`, `:help double-click`, and `:help shift-click` all resolve via the new `MOUSE_ENTRIES` registry.

Manual smoke checklist (recommended before merge):

- [ ] `:set mouse on` — no error, status bar quiet
- [ ] Click far cell — cursor jumps
- [ ] Click+drag — Visual range
- [ ] Click column header → drag right past visible columns — column selection extends and viewport reveals new columns
- [ ] Click row header → drag down past visible rows — row selection extends and viewport reveals new rows
- [ ] Scroll wheel — viewport scrolls, cursor stays put
- [ ] Double-click on a cell — enters Insert mode at that cell
- [ ] Type into Insert mode after a long-content → short-content double-click — does not panic
- [ ] Shift+click — no-op (terminal text selection works)
- [ ] `:set mouse off` — clicks become no-ops
- [ ] `:q` — clean exit, terminal mouse capture released