### PR TITLE
fix: escape quotes and backslashes in .cell format labels

### DIFF
--- a/crates/cell-sheet-core/src/io/cell_format.rs
+++ b/crates/cell-sheet-core/src/io/cell_format.rs
@@ -1,6 +1,33 @@
 use crate::model::{col_index_to_label, col_label_to_index, CellValue, Sheet};
 use std::io::{BufRead, BufReader, Read, Write};
 
+fn escape_cell_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn unescape_cell_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 fn parse_address(addr: &str) -> Option<(usize, usize)> {
     let mut col_end = 0;
     for (i, c) in addr.chars().enumerate() {
@@ -55,7 +82,7 @@ pub fn write_cell_format<W: Write>(
                     writeln!(writer, "let {} = {}", addr, cell.raw)?;
                 }
                 CellValue::Text(s) => {
-                    writeln!(writer, "label {} = \"{}\"", addr, s)?;
+                    writeln!(writer, "label {} = \"{}\"", addr, escape_cell_string(s))?;
                 }
                 CellValue::Bool(b) => {
                     writeln!(
@@ -67,7 +94,12 @@ pub fn write_cell_format<W: Write>(
                 }
                 CellValue::Empty => {}
                 CellValue::Error(_) => {
-                    writeln!(writer, "label {} = \"{}\"", addr, cell.raw)?;
+                    writeln!(
+                        writer,
+                        "label {} = \"{}\"",
+                        addr,
+                        escape_cell_string(&cell.raw)
+                    )?;
                 }
             }
         }
@@ -151,11 +183,11 @@ pub fn read_cell_format<R: Read>(reader: R) -> Result<Sheet, Box<dyn std::error:
                 if let Some(pos) = parse_address(addr_str.trim()) {
                     let s = value_str.trim();
                     let s = if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-                        &s[1..s.len() - 1]
+                        unescape_cell_string(&s[1..s.len() - 1])
                     } else {
-                        s
+                        s.to_string()
                     };
-                    sheet.set_cell(pos, s);
+                    sheet.set_cell(pos, &s);
                 }
             }
         } else if let Some(rest) = line.strip_prefix("formula ") {
@@ -288,5 +320,44 @@ mod tests {
         let err =
             read_cell_format(data.as_bytes()).expect_err("non-numeric col-width index must error");
         assert!(format!("{err}").contains("col-width"));
+    }
+
+    #[test]
+    fn roundtrip_label_with_embedded_quote() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "hello\"world");
+        let mut buf = Vec::new();
+        write_cell_format(&sheet, &mut buf).unwrap();
+        let sheet2 = read_cell_format(buf.as_slice()).unwrap();
+        assert_eq!(
+            sheet2.get_cell((0, 0)).unwrap().value,
+            CellValue::Text("hello\"world".into())
+        );
+    }
+
+    #[test]
+    fn roundtrip_label_with_embedded_backslash() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "hello\\world");
+        let mut buf = Vec::new();
+        write_cell_format(&sheet, &mut buf).unwrap();
+        let sheet2 = read_cell_format(buf.as_slice()).unwrap();
+        assert_eq!(
+            sheet2.get_cell((0, 0)).unwrap().value,
+            CellValue::Text("hello\\world".into())
+        );
+    }
+
+    #[test]
+    fn roundtrip_label_with_quote_and_backslash() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "say \"hi\\\" to me");
+        let mut buf = Vec::new();
+        write_cell_format(&sheet, &mut buf).unwrap();
+        let sheet2 = read_cell_format(buf.as_slice()).unwrap();
+        assert_eq!(
+            sheet2.get_cell((0, 0)).unwrap().value,
+            CellValue::Text("say \"hi\\\" to me".into())
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #79 — `.cell` format label values containing `"` or `\` are silently corrupted on round-trip.

## Root Cause

`write_cell_format` wrote label values as `label A1 = "hello"` with no escaping. `read_cell_format` stripped quotes naively with `&s[1..s.len() - 1]`. Any embedded `"` would truncate the value, and any `\` would be lost.

## Solution

- **`escape_cell_string`**: walks a string, escapes `\` → `\\` and `"` → `\"` before writing.
- **`unescape_cell_string`**: walks a string, handles `\\` and `\"` escape sequences on read.
- Applied in both `write_cell_format` (Text and Error branches) and `read_cell_format` (label branch).

## Testing

3 new roundtrip tests:
- `roundtrip_label_with_embedded_quote` — `hello"world`
- `roundtrip_label_with_embedded_backslash` — `hello\world`
- `roundtrip_label_with_quote_and_backslash` — `say "hi\" to me`

All 125 tests pass. `cargo clippy` and `cargo fmt` clean.
