### PR TITLE
Centralize sheet mutation invariants

### DIFF
--- a/crates/cell-sheet-core/src/engine.rs
+++ b/crates/cell-sheet-core/src/engine.rs
@@ -1,0 +1,182 @@
+use crate::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use crate::model::{CellPos, Sheet};
+
+/// Coordinates sheet mutations with dependency graph maintenance.
+///
+/// `Sheet` remains the storage type and `DepGraph` remains the graph type, but
+/// callers that mutate raw cell contents should go through this wrapper so
+/// formula edges, dirty marking, and recalculation stay in sync.
+pub struct SheetEngine<'a> {
+    sheet: &'a mut Sheet,
+    deps: &'a mut DepGraph,
+}
+
+impl<'a> SheetEngine<'a> {
+    pub fn new(sheet: &'a mut Sheet, deps: &'a mut DepGraph) -> Self {
+        Self { sheet, deps }
+    }
+
+    pub fn set_cell_raw(&mut self, pos: CellPos, raw: &str) {
+        if raw.starts_with('=') {
+            set_formula(self.sheet, self.deps, pos, raw);
+        } else {
+            self.sheet.set_cell(pos, raw);
+            self.deps.remove(pos);
+        }
+        mark_dirty(self.sheet, self.deps, pos);
+    }
+
+    pub fn clear_cell(&mut self, pos: CellPos) {
+        self.sheet.clear_cell(pos);
+        self.deps.remove(pos);
+        mark_dirty(self.sheet, self.deps, pos);
+    }
+
+    pub fn write_cell_raw(&mut self, pos: CellPos, raw: &str) {
+        if raw.is_empty() {
+            self.clear_cell(pos);
+        } else {
+            self.set_cell_raw(pos, raw);
+        }
+    }
+
+    pub fn write_cell_raw_and_recalculate(&mut self, pos: CellPos, raw: &str) {
+        self.write_cell_raw(pos, raw);
+        self.recalculate();
+    }
+
+    pub fn set_cell_raw_and_recalculate(&mut self, pos: CellPos, raw: &str) {
+        self.set_cell_raw(pos, raw);
+        self.recalculate();
+    }
+
+    pub fn recalculate(&mut self) {
+        recalculate(self.sheet, self.deps);
+    }
+
+    pub fn sort_by_column_and_recalculate(&mut self, col: usize, ascending: bool) {
+        self.sheet.sort_by_column(col, ascending);
+        self.rebuild_formulas_and_recalculate();
+    }
+
+    pub fn rebuild_formulas_and_recalculate(&mut self) {
+        *self.deps = DepGraph::new();
+        let formula_cells: Vec<_> = self
+            .sheet
+            .cells
+            .iter()
+            .filter(|(_, cell)| cell.raw.starts_with('='))
+            .map(|(pos, cell)| (*pos, cell.raw.clone()))
+            .collect();
+        for (pos, raw) in formula_cells {
+            set_formula(self.sheet, self.deps, pos, &raw);
+        }
+        self.recalculate();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CellValue;
+
+    #[test]
+    fn write_value_updates_dependents() {
+        let mut sheet = Sheet::new();
+        let mut deps = DepGraph::new();
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw((0, 0), "10");
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 1), "=A1+5");
+
+        assert_eq!(
+            sheet.get_cell((0, 1)).unwrap().value,
+            CellValue::Number(15.0)
+        );
+
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 0), "20");
+
+        assert_eq!(
+            sheet.get_cell((0, 1)).unwrap().value,
+            CellValue::Number(25.0)
+        );
+    }
+
+    #[test]
+    fn rewriting_formula_as_value_drops_edges() {
+        let mut sheet = Sheet::new();
+        let mut deps = DepGraph::new();
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw((0, 0), "10");
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 1), "=A1+5");
+
+        assert!(deps.dependencies.contains_key(&(0, 1)));
+
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 1), "plain");
+
+        assert!(!deps.dependencies.contains_key(&(0, 1)));
+        assert!(!deps
+            .dependents
+            .get(&(0, 0))
+            .map(|set| set.contains(&(0, 1)))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn set_empty_cell_preserves_extent() {
+        let mut sheet = Sheet::new();
+        let mut deps = DepGraph::new();
+
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw((1, 1), "");
+
+        assert_eq!(sheet.row_count, 2);
+        assert_eq!(sheet.col_count, 2);
+        assert!(sheet.get_cell((1, 1)).is_some());
+    }
+
+    #[test]
+    fn clear_cell_removes_cell_and_updates_dependents() {
+        let mut sheet = Sheet::new();
+        let mut deps = DepGraph::new();
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw((0, 0), "10");
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 1), "=A1+5");
+
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 0), "");
+
+        assert!(sheet.get_cell((0, 0)).is_none());
+        assert_eq!(
+            sheet.get_cell((0, 1)).unwrap().value,
+            CellValue::Number(5.0)
+        );
+    }
+
+    #[test]
+    fn sort_rebuilds_formula_graph() {
+        let mut sheet = Sheet::new();
+        let mut deps = DepGraph::new();
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw((0, 0), "2");
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw((1, 0), "1");
+        SheetEngine::new(&mut sheet, &mut deps).write_cell_raw_and_recalculate((0, 1), "=A1*10");
+
+        SheetEngine::new(&mut sheet, &mut deps).sort_by_column_and_recalculate(0, true);
+        SheetEngine::new(&mut sheet, &mut deps).set_cell_raw_and_recalculate((0, 0), "3");
+
+        assert_eq!(
+            sheet.get_cell((1, 1)).unwrap().value,
+            CellValue::Number(30.0)
+        );
+    }
+
+    #[test]
+    fn rebuilds_formula_graph_for_loaded_sheet() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "10");
+        sheet.set_cell((0, 1), "=A1+5");
+        let mut deps = DepGraph::new();
+
+        SheetEngine::new(&mut sheet, &mut deps).rebuild_formulas_and_recalculate();
+
+        assert!(deps.dependencies.contains_key(&(0, 1)));
+        assert_eq!(
+            sheet.get_cell((0, 1)).unwrap().value,
+            CellValue::Number(15.0)
+        );
+    }
+}

--- a/crates/cell-sheet-core/src/lib.rs
+++ b/crates/cell-sheet-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod engine;
 pub mod formula;
 pub mod help;
 pub mod io;

--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -6,7 +6,8 @@ use crate::mode::mouse::GridLayout;
 use crate::mode::visual::VisualKind;
 use crate::undo::{UndoEntry, UndoStack};
 use crate::viewport::Viewport;
-use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use cell_sheet_core::engine::SheetEngine;
+use cell_sheet_core::formula::deps::DepGraph;
 use cell_sheet_core::help::HelpRegistry;
 use cell_sheet_core::model::{CellPos, Sheet};
 use std::collections::HashMap;
@@ -368,7 +369,7 @@ impl App {
                 let raw = if redo { new_raw } else { old_raw };
                 self.write_cell_raw(*pos, raw);
                 if self.batch_depth == 0 {
-                    recalculate(&mut self.sheet, &self.deps);
+                    self.recalculate();
                 }
             }
             UndoEntry::MultiCellEdit { changes } => {
@@ -399,8 +400,16 @@ impl App {
         }
         self.batch_depth -= 1;
         if self.batch_depth == 0 {
-            recalculate(&mut self.sheet, &self.deps);
+            self.recalculate();
         }
+    }
+
+    fn recalculate(&mut self) {
+        SheetEngine::new(&mut self.sheet, &mut self.deps).recalculate();
+    }
+
+    fn set_cell_raw(&mut self, pos: CellPos, raw: &str) {
+        SheetEngine::new(&mut self.sheet, &mut self.deps).set_cell_raw(pos, raw);
     }
 
     /// Write `raw` into `pos`, keeping the dep graph consistent and marking
@@ -410,16 +419,7 @@ impl App {
     /// - formula  → register/replace dependencies
     /// - value    → drop any stale graph entry from a prior formula
     fn write_cell_raw(&mut self, pos: CellPos, raw: &str) {
-        if raw.is_empty() {
-            self.sheet.clear_cell(pos);
-            self.deps.remove(pos);
-        } else if raw.starts_with('=') {
-            set_formula(&mut self.sheet, &mut self.deps, pos, raw);
-        } else {
-            self.sheet.set_cell(pos, raw);
-            self.deps.remove(pos);
-        }
-        mark_dirty(&mut self.sheet, &self.deps, pos);
+        SheetEngine::new(&mut self.sheet, &mut self.deps).write_cell_raw(pos, raw);
     }
 }
 
@@ -2005,6 +2005,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn clear_cell_updates_dependents() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 1), "99".into()));
+        app.process_action(Action::EditCell((0, 0), "=B1".into()));
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).unwrap().value,
+            cell_sheet_core::model::CellValue::Number(99.0)
+        );
+        app.process_action(Action::ClearCell((0, 1)));
+        assert_eq!(
+            app.sheet.get_cell((0, 0)).map(|c| c.value.clone()),
+            Some(cell_sheet_core::model::CellValue::Number(0.0))
+        );
+    }
+
     // ── DeleteRow recalculation ─────────────────────────────────────────────
 
     #[test]
@@ -2042,6 +2058,25 @@ mod tests {
             val,
             Some(cell_sheet_core::model::CellValue::Number(12.0)),
             "formula depending on deleted rows must not keep stale value"
+        );
+    }
+
+    #[test]
+    fn sort_rebuilds_formula_dependencies() {
+        let mut app = App::new();
+        app.process_action(Action::EditCell((0, 0), "2".into()));
+        app.process_action(Action::EditCell((1, 0), "1".into()));
+        app.process_action(Action::EditCell((0, 1), "=A1*10".into()));
+
+        app.process_action(Action::Sort {
+            col: 0,
+            ascending: true,
+        });
+        app.process_action(Action::EditCell((0, 0), "3".into()));
+
+        assert_eq!(
+            app.sheet.get_cell((1, 1)).map(|c| c.value.clone()),
+            Some(cell_sheet_core::model::CellValue::Number(30.0))
         );
     }
 

--- a/crates/cell-sheet-tui/src/app/dispatch.rs
+++ b/crates/cell-sheet-tui/src/app/dispatch.rs
@@ -2,7 +2,6 @@ use super::{apply_case_op, App, FileFormat};
 use crate::action::{Action, CaseOp, CommandKind, Direction, Mode, SearchDirection};
 use crate::clipboard::Register;
 use crate::undo::UndoEntry;
-use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula};
 use cell_sheet_core::model::CellPos;
 
 impl App {
@@ -36,14 +35,9 @@ impl App {
                     old_raw,
                     new_raw: raw.clone(),
                 });
-                if raw.starts_with('=') {
-                    set_formula(&mut self.sheet, &mut self.deps, pos, &raw);
-                } else {
-                    self.sheet.set_cell(pos, &raw);
-                }
-                mark_dirty(&mut self.sheet, &self.deps, pos);
+                self.set_cell_raw(pos, &raw);
                 if self.batch_depth == 0 {
-                    recalculate(&mut self.sheet, &self.deps);
+                    self.recalculate();
                 }
                 self.dirty = true;
                 self.last_change = Some(Action::EditCell(pos, raw));
@@ -84,7 +78,10 @@ impl App {
                         old_raw,
                         new_raw: String::new(),
                     });
-                    self.sheet.clear_cell(pos);
+                    self.write_cell_raw(pos, "");
+                    if self.batch_depth == 0 {
+                        self.recalculate();
+                    }
                     self.dirty = true;
                 }
                 self.last_change = Some(Action::ClearCell(pos));
@@ -101,7 +98,10 @@ impl App {
                         old_raw,
                         new_raw: String::new(),
                     });
-                    self.sheet.clear_cell(pos);
+                    self.write_cell_raw(pos, "");
+                    if self.batch_depth == 0 {
+                        self.recalculate();
+                    }
                     self.dirty = true;
                 }
                 self.insert_buffer = String::new();
@@ -326,7 +326,8 @@ impl App {
                 }
             }
             Action::Sort { col, ascending } => {
-                self.sheet.sort_by_column(col, ascending);
+                cell_sheet_core::engine::SheetEngine::new(&mut self.sheet, &mut self.deps)
+                    .sort_by_column_and_recalculate(col, ascending);
                 self.dirty = true;
                 self.status_message = Some(format!(
                     "Sorted by column {} {}",
@@ -812,9 +813,8 @@ impl App {
                         old_raw: raw,
                         new_raw: new_raw.clone(),
                     });
-                    self.sheet.set_cell(pos, &new_raw);
-                    mark_dirty(&mut self.sheet, &self.deps, pos);
-                    recalculate(&mut self.sheet, &self.deps);
+                    self.set_cell_raw(pos, &new_raw);
+                    self.recalculate();
                     self.dirty = true;
                 }
                 self.last_change = Some(Action::CaseOpCell { pos, op });
@@ -843,10 +843,9 @@ impl App {
                 }
                 if !changes.is_empty() {
                     for (pos, _, new_raw) in &changes {
-                        self.sheet.set_cell(*pos, new_raw);
-                        mark_dirty(&mut self.sheet, &self.deps, *pos);
+                        self.set_cell_raw(*pos, new_raw);
                     }
-                    recalculate(&mut self.sheet, &self.deps);
+                    self.recalculate();
                     self.undo_stack.push(UndoEntry::MultiCellEdit { changes });
                     self.dirty = true;
                 }
@@ -864,9 +863,8 @@ impl App {
                             old_raw: raw,
                             new_raw: new_raw.clone(),
                         });
-                        self.sheet.set_cell(pos, &new_raw);
-                        mark_dirty(&mut self.sheet, &self.deps, pos);
-                        recalculate(&mut self.sheet, &self.deps);
+                        self.set_cell_raw(pos, &new_raw);
+                        self.recalculate();
                         self.dirty = true;
                     }
                     // text or empty string: no-op

--- a/crates/cell-sheet-tui/src/headless.rs
+++ b/crates/cell-sheet-tui/src/headless.rs
@@ -9,8 +9,9 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use cell_sheet_core::engine::SheetEngine;
 use cell_sheet_core::formula::ast::{CellRef, Expr};
-use cell_sheet_core::formula::deps::{mark_dirty, recalculate, set_formula, DepGraph};
+use cell_sheet_core::formula::deps::DepGraph;
 use cell_sheet_core::formula::{eval, parser};
 use cell_sheet_core::io::{cell_format, csv as csv_io};
 use cell_sheet_core::model::{CellPos, CellValue, Sheet};
@@ -134,7 +135,7 @@ pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
             })?;
             apply_write(&mut sheet, &mut deps, pos, value);
         }
-        recalculate(&mut sheet, &deps);
+        SheetEngine::new(&mut sheet, &mut deps).recalculate();
         save(&opts.file, format, &sheet, delimiter)
             .map_err(|e| format!("failed to write {}: {e}", opts.file.display()))?;
     }
@@ -173,16 +174,7 @@ fn load(
     };
     let mut deps = DepGraph::new();
 
-    let formula_cells: Vec<_> = sheet
-        .cells
-        .iter()
-        .filter(|(_, cell)| cell.raw.starts_with('='))
-        .map(|(pos, cell)| (*pos, cell.raw.clone()))
-        .collect();
-    for (pos, raw) in formula_cells {
-        set_formula(&mut sheet, &mut deps, pos, &raw);
-    }
-    recalculate(&mut sheet, &deps);
+    SheetEngine::new(&mut sheet, &mut deps).rebuild_formulas_and_recalculate();
 
     Ok((sheet, deps))
 }
@@ -198,16 +190,7 @@ fn load_from_bytes(
     };
     let mut deps = DepGraph::new();
 
-    let formula_cells: Vec<_> = sheet
-        .cells
-        .iter()
-        .filter(|(_, cell)| cell.raw.starts_with('='))
-        .map(|(pos, cell)| (*pos, cell.raw.clone()))
-        .collect();
-    for (pos, raw) in formula_cells {
-        set_formula(&mut sheet, &mut deps, pos, &raw);
-    }
-    recalculate(&mut sheet, &deps);
+    SheetEngine::new(&mut sheet, &mut deps).rebuild_formulas_and_recalculate();
 
     Ok((sheet, deps))
 }
@@ -227,14 +210,7 @@ fn save(
 }
 
 fn apply_write(sheet: &mut Sheet, deps: &mut DepGraph, pos: CellPos, value: &str) {
-    if value.starts_with('=') {
-        set_formula(sheet, deps, pos, value);
-    } else {
-        // Drop any prior formula edges so dependents don't keep tracking this cell.
-        deps.remove(pos);
-        sheet.set_cell(pos, value);
-    }
-    mark_dirty(sheet, deps, pos);
+    SheetEngine::new(sheet, deps).set_cell_raw(pos, value);
 }
 
 /// Parse a single A1-style reference like "A1" or "AB12". 1-indexed rows.

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -162,7 +162,7 @@ fn load_file(
     path: &std::path::Path,
     explicit_delimiter: Option<u8>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use cell_sheet_core::formula::deps::{recalculate, set_formula};
+    use cell_sheet_core::engine::SheetEngine;
 
     let ext = path
         .extension()
@@ -198,18 +198,7 @@ fn load_file(
 
     app.file_path = Some(path.to_path_buf());
 
-    // Register formulas in the dependency graph and evaluate them.
-    let formula_cells: Vec<_> = app
-        .sheet
-        .cells
-        .iter()
-        .filter(|(_, cell)| cell.raw.starts_with('='))
-        .map(|(pos, cell)| (*pos, cell.raw.clone()))
-        .collect();
-    for (pos, raw) in formula_cells {
-        set_formula(&mut app.sheet, &mut app.deps, pos, &raw);
-    }
-    recalculate(&mut app.sheet, &app.deps);
+    SheetEngine::new(&mut app.sheet, &mut app.deps).rebuild_formulas_and_recalculate();
 
     Ok(())
 }
@@ -219,7 +208,7 @@ fn load_stdin_data(
     data: Vec<u8>,
     explicit_delimiter: Option<u8>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use cell_sheet_core::formula::deps::{recalculate, set_formula};
+    use cell_sheet_core::engine::SheetEngine;
 
     // Detect the native .cell format by its magic header. Anything else is
     // treated as CSV/TSV with delimiter sniffing (or an explicit override).
@@ -239,17 +228,7 @@ fn load_stdin_data(
     }
     // file_path stays None — unnamed buffer; :w <path> still works to save
 
-    let formula_cells: Vec<_> = app
-        .sheet
-        .cells
-        .iter()
-        .filter(|(_, cell)| cell.raw.starts_with('='))
-        .map(|(pos, cell)| (*pos, cell.raw.clone()))
-        .collect();
-    for (pos, raw) in formula_cells {
-        set_formula(&mut app.sheet, &mut app.deps, pos, &raw);
-    }
-    recalculate(&mut app.sheet, &app.deps);
+    SheetEngine::new(&mut app.sheet, &mut app.deps).rebuild_formulas_and_recalculate();
 
     Ok(())
 }

--- a/crates/cell-sheet-tui/tests/headless.rs
+++ b/crates/cell-sheet-tui/tests/headless.rs
@@ -159,6 +159,31 @@ fn write_formula_recalculates_dependents() {
 }
 
 #[test]
+fn write_empty_value_recalculates_dependents() {
+    let dir = tempfile::tempdir().unwrap();
+    let cell_file = "# cell v1\nsize 2 1\nlet A0 = 99\nformula A1 = =A1\n";
+    let path = cell_path(&dir, "data.cell");
+    std::fs::write(&path, cell_file).unwrap();
+
+    let out = run(&[path.to_str().unwrap(), "--write", "A1", "", "--read", "A2"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert_eq!(stdout(&out), "0\n");
+}
+
+#[test]
+fn write_empty_value_preserves_requested_extent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = cell_path(&dir, "data.cell");
+    std::fs::write(&path, "# cell v1\nsize 1 1\n").unwrap();
+
+    let out = run(&[path.to_str().unwrap(), "--write", "B2", ""]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let saved = std::fs::read_to_string(&path).unwrap();
+    assert!(saved.contains("size 2 2"), "got: {saved:?}");
+}
+
+#[test]
 fn batched_writes_apply_in_order_and_save_once() {
     let dir = tempfile::tempdir().unwrap();
     let path = write_csv(&dir, "data.csv", ",,\n");


### PR DESCRIPTION
## Summary
- Add a core `SheetEngine` to coordinate sheet writes, dependency graph updates, dirty marking, recalculation, and formula graph rebuilds.
- Route TUI and headless mutation/load paths through the shared engine.
- Add regressions for clearing dependencies, sorting formulas, and empty headless writes.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test`

Made with [Cursor](https://cursor.com)