### PR TITLE
Centralize file format policy

### DIFF
--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -2,6 +2,7 @@ mod dispatch;
 
 use crate::action::{Action, CaseOp, CommandKind, Mode};
 use crate::clipboard::Register;
+use crate::file_format::FileFormat;
 use crate::mode::mouse::GridLayout;
 use crate::mode::visual::VisualKind;
 use crate::undo::{UndoEntry, UndoStack};
@@ -12,13 +13,6 @@ use cell_sheet_core::help::HelpRegistry;
 use cell_sheet_core::model::{CellPos, Sheet};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FileFormat {
-    Csv,
-    Tsv,
-    Cell,
-}
 
 pub struct App {
     pub sheet: Sheet,
@@ -176,17 +170,7 @@ impl App {
     }
 
     fn format_from_path(path: &Path) -> FileFormat {
-        match path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase()
-            .as_str()
-        {
-            "tsv" => FileFormat::Tsv,
-            "cell" => FileFormat::Cell,
-            _ => FileFormat::Csv,
-        }
+        FileFormat::from_path(path)
     }
 
     fn do_save(&mut self, path: &PathBuf, format: FileFormat) {

--- a/crates/cell-sheet-tui/src/app/dispatch.rs
+++ b/crates/cell-sheet-tui/src/app/dispatch.rs
@@ -1,6 +1,7 @@
-use super::{apply_case_op, App, FileFormat};
+use super::{apply_case_op, App};
 use crate::action::{Action, CaseOp, CommandKind, Direction, Mode, SearchDirection};
 use crate::clipboard::Register;
+use crate::file_format::FileFormat;
 use crate::undo::UndoEntry;
 use cell_sheet_core::model::CellPos;
 
@@ -204,17 +205,14 @@ impl App {
                         );
                         return;
                     }
-                    let expected_delim = match format {
-                        FileFormat::Csv => b',',
-                        FileFormat::Tsv => b'\t',
-                        FileFormat::Cell => 0,
-                    };
-                    if !matches!(format, FileFormat::Cell) && self.delimiter != expected_delim {
-                        self.status_message = Some(format!(
-                            "Non-standard delimiter '{}' will be used. Use :w! to force, or save as .tsv / .psv.",
-                            self.delimiter as char
-                        ));
-                        return;
+                    if let Some(expected_delim) = format.canonical_delimiter() {
+                        if self.delimiter != expected_delim {
+                            self.status_message = Some(format!(
+                                "Non-standard delimiter '{}' will be used. Use :w! to force, or save as .tsv / .psv.",
+                                self.delimiter as char
+                            ));
+                            return;
+                        }
                     }
                     self.do_save(&path, format);
                 } else {

--- a/crates/cell-sheet-tui/src/file_format.rs
+++ b/crates/cell-sheet-tui/src/file_format.rs
@@ -1,0 +1,141 @@
+use std::path::Path;
+
+use cell_sheet_core::io::csv as csv_io;
+
+/// File/container formats supported by the TUI and headless CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileFormat {
+    Csv,
+    Tsv,
+    Cell,
+}
+
+impl FileFormat {
+    pub fn from_path(path: &Path) -> Self {
+        match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase()
+            .as_str()
+        {
+            "tsv" => FileFormat::Tsv,
+            "cell" => FileFormat::Cell,
+            _ => FileFormat::Csv,
+        }
+    }
+
+    pub fn from_stdin_bytes(data: &[u8]) -> Self {
+        if data.starts_with(CELL_FORMAT_MAGIC) {
+            FileFormat::Cell
+        } else {
+            FileFormat::Csv
+        }
+    }
+
+    pub fn canonical_delimiter(self) -> Option<u8> {
+        match self {
+            FileFormat::Csv => Some(b','),
+            FileFormat::Tsv => Some(b'\t'),
+            FileFormat::Cell => None,
+        }
+    }
+
+    pub fn resolve_path_delimiter(
+        self,
+        path: &Path,
+        explicit: Option<u8>,
+    ) -> Result<u8, Box<dyn std::error::Error>> {
+        if let Some(d) = explicit {
+            return Ok(d);
+        }
+        match self {
+            FileFormat::Tsv => Ok(b'\t'),
+            FileFormat::Cell => Ok(b','), // unused: .cell files do not use a delimiter
+            FileFormat::Csv => {
+                use std::io::Read as _;
+
+                let mut buf = vec![0u8; 4096];
+                let mut file = std::fs::File::open(path)?;
+                let n = file.read(&mut buf)?;
+                Ok(csv_io::sniff_delimiter(&buf[..n]))
+            }
+        }
+    }
+
+    pub fn resolve_data_delimiter(self, data: &[u8], explicit: Option<u8>) -> u8 {
+        if let Some(d) = explicit {
+            return d;
+        }
+        match self {
+            FileFormat::Tsv => b'\t',
+            FileFormat::Cell => b',', // unused: .cell files do not use a delimiter
+            FileFormat::Csv => csv_io::sniff_delimiter(data),
+        }
+    }
+
+    pub fn resolve_stdin_delimiter(
+        self,
+        data: &[u8],
+        explicit: Option<u8>,
+    ) -> Result<u8, &'static str> {
+        if matches!(self, FileFormat::Cell) && explicit.is_some() {
+            return Err("--delimiter has no effect on .cell-format input piped to stdin");
+        }
+        Ok(self.resolve_data_delimiter(data, explicit))
+    }
+}
+
+/// Magic header for the native `.cell` text format. Both the existing writer
+/// and reader anchor on `# cell v` as the first line, so detecting it on stdin
+/// is unambiguous.
+const CELL_FORMAT_MAGIC: &[u8] = b"# cell v";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_from_path_detects_known_extensions() {
+        assert_eq!(
+            FileFormat::from_path(Path::new("data.csv")),
+            FileFormat::Csv
+        );
+        assert_eq!(
+            FileFormat::from_path(Path::new("data.tsv")),
+            FileFormat::Tsv
+        );
+        assert_eq!(
+            FileFormat::from_path(Path::new("data.cell")),
+            FileFormat::Cell
+        );
+        assert_eq!(
+            FileFormat::from_path(Path::new("data.psv")),
+            FileFormat::Csv
+        );
+    }
+
+    #[test]
+    fn stdin_format_detects_cell_magic() {
+        assert_eq!(
+            FileFormat::from_stdin_bytes(b"# cell v1\n"),
+            FileFormat::Cell
+        );
+        assert_eq!(FileFormat::from_stdin_bytes(b"a,b\n"), FileFormat::Csv);
+    }
+
+    #[test]
+    fn stdin_cell_rejects_explicit_delimiter() {
+        assert!(FileFormat::Cell
+            .resolve_stdin_delimiter(b"# cell v1\n", Some(b'|'))
+            .is_err());
+    }
+
+    #[test]
+    fn path_delimiter_uses_tsv_default() {
+        let delimiter = FileFormat::Tsv
+            .resolve_path_delimiter(Path::new("unused.tsv"), None)
+            .expect("tsv delimiter should not require reading the file");
+        assert_eq!(delimiter, b'\t');
+    }
+}

--- a/crates/cell-sheet-tui/src/headless.rs
+++ b/crates/cell-sheet-tui/src/headless.rs
@@ -16,47 +16,7 @@ use cell_sheet_core::formula::{eval, parser};
 use cell_sheet_core::io::{cell_format, csv as csv_io};
 use cell_sheet_core::model::{CellPos, CellValue, Sheet};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Format {
-    Csv,
-    Tsv,
-    Cell,
-}
-
-impl Format {
-    fn from_path(path: &Path) -> Self {
-        match path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase()
-            .as_str()
-        {
-            "tsv" => Format::Tsv,
-            "cell" => Format::Cell,
-            _ => Format::Csv,
-        }
-    }
-}
-
-/// Magic header for the native `.cell` text format. Both the existing
-/// writer (`write_cell_format`) and reader (`read_cell_format`) anchor on
-/// `# cell v1` as the first line, so detecting it on a stdin byte stream
-/// is unambiguous and safe to use to dispatch between the cell-format and
-/// CSV/TSV readers.
-const CELL_FORMAT_MAGIC: &[u8] = b"# cell v";
-
-/// Detect whether a stdin byte stream is in the native `.cell` format.
-/// Returns `Format::Cell` when the first line begins with the cell-format
-/// magic header, otherwise `Format::Csv` (CSV/TSV both go through
-/// `csv_io::read_csv`, with the delimiter sniffed separately).
-fn detect_stdin_format(data: &[u8]) -> Format {
-    if data.starts_with(CELL_FORMAT_MAGIC) {
-        Format::Cell
-    } else {
-        Format::Csv
-    }
-}
+use crate::file_format::FileFormat;
 
 #[derive(Debug)]
 pub struct Options {
@@ -67,27 +27,6 @@ pub struct Options {
     pub evals: Vec<String>,
     pub writes: Vec<(String, String)>,
     pub delimiter: Option<u8>,
-}
-
-fn resolve_delimiter(
-    path: &Path,
-    format: Format,
-    explicit: Option<u8>,
-) -> Result<u8, Box<dyn std::error::Error>> {
-    if let Some(d) = explicit {
-        return Ok(d);
-    }
-    match format {
-        Format::Tsv => Ok(b'\t'),
-        Format::Cell => Ok(b','), // unused — .cell files don't use a delimiter
-        Format::Csv => {
-            use std::io::Read as _;
-            let mut buf = vec![0u8; 4096];
-            let mut file = std::fs::File::open(path)?;
-            let n = file.read(&mut buf)?;
-            Ok(csv_io::sniff_delimiter(&buf[..n]))
-        }
-    }
 }
 
 /// Run the requested headless operations and write their textual results to
@@ -101,21 +40,17 @@ pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
                     .to_string(),
             );
         }
-        let format = detect_stdin_format(data);
-        if matches!(format, Format::Cell) && opts.delimiter.is_some() {
-            return Err(
-                "--delimiter has no effect on .cell-format input piped to stdin".to_string(),
-            );
-        }
-        let delimiter = opts
-            .delimiter
-            .unwrap_or_else(|| csv_io::sniff_delimiter(data));
+        let format = FileFormat::from_stdin_bytes(data);
+        let delimiter = format
+            .resolve_stdin_delimiter(data, opts.delimiter)
+            .map_err(|msg| msg.to_string())?;
         let (sheet, deps) = load_from_bytes(data, format, delimiter)
             .map_err(|e| format!("failed to parse stdin: {e}"))?;
-        (sheet, deps, None::<(Format, u8)>)
+        (sheet, deps, None::<(FileFormat, u8)>)
     } else {
-        let format = Format::from_path(&opts.file);
-        let delimiter = resolve_delimiter(&opts.file, format, opts.delimiter)
+        let format = FileFormat::from_path(&opts.file);
+        let delimiter = format
+            .resolve_path_delimiter(&opts.file, opts.delimiter)
             .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
         let (sheet, deps) = load(&opts.file, format, delimiter)
             .map_err(|e| format!("failed to read {}: {e}", opts.file.display()))?;
@@ -159,15 +94,15 @@ pub fn run<W: Write>(opts: &Options, out: &mut W) -> Result<(), String> {
 
 fn load(
     path: &Path,
-    format: Format,
+    format: FileFormat,
     delimiter: u8,
 ) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
     let mut sheet = match format {
-        Format::Csv | Format::Tsv => {
+        FileFormat::Csv | FileFormat::Tsv => {
             let file = std::fs::File::open(path)?;
             csv_io::read_csv(file, delimiter)?
         }
-        Format::Cell => {
+        FileFormat::Cell => {
             let file = std::fs::File::open(path)?;
             cell_format::read_cell_format(file)?
         }
@@ -181,12 +116,12 @@ fn load(
 
 fn load_from_bytes(
     data: &[u8],
-    format: Format,
+    format: FileFormat,
     delimiter: u8,
 ) -> Result<(Sheet, DepGraph), Box<dyn std::error::Error>> {
     let mut sheet = match format {
-        Format::Cell => cell_format::read_cell_format(data)?,
-        Format::Csv | Format::Tsv => csv_io::read_csv(data, delimiter)?,
+        FileFormat::Cell => cell_format::read_cell_format(data)?,
+        FileFormat::Csv | FileFormat::Tsv => csv_io::read_csv(data, delimiter)?,
     };
     let mut deps = DepGraph::new();
 
@@ -197,14 +132,14 @@ fn load_from_bytes(
 
 fn save(
     path: &Path,
-    format: Format,
+    format: FileFormat,
     sheet: &Sheet,
     delimiter: u8,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let file = std::fs::File::create(path)?;
     match format {
-        Format::Csv | Format::Tsv => csv_io::write_csv(sheet, file, delimiter)?,
-        Format::Cell => cell_format::write_cell_format(sheet, file)?,
+        FileFormat::Csv | FileFormat::Tsv => csv_io::write_csv(sheet, file, delimiter)?,
+        FileFormat::Cell => cell_format::write_cell_format(sheet, file)?,
     }
     Ok(())
 }

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod clipboard;
+mod file_format;
 mod headless;
 mod mode;
 mod render;
@@ -8,7 +9,7 @@ mod undo;
 mod viewport;
 
 use action::{Action, Mode};
-use app::{App, FileFormat};
+use app::App;
 use clap::Parser;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
@@ -19,6 +20,8 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use std::process::ExitCode;
+
+use crate::file_format::FileFormat;
 
 #[derive(Parser)]
 #[command(name = "cell", version, about = "A terminal spreadsheet editor")]
@@ -164,39 +167,23 @@ fn load_file(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use cell_sheet_core::engine::SheetEngine;
 
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-
-    match ext.as_str() {
-        "cell" => {
+    let format = FileFormat::from_path(path);
+    match format {
+        FileFormat::Cell => {
             let file = std::fs::File::open(path)?;
             app.sheet = cell_sheet_core::io::cell_format::read_cell_format(file)?;
-            app.file_format = FileFormat::Cell;
         }
-        _ => {
+        FileFormat::Csv | FileFormat::Tsv => {
             // Read entire file once; use the same bytes for sniffing and parsing.
             let data = std::fs::read(path)?;
-            let delimiter = if let Some(d) = explicit_delimiter {
-                d
-            } else if ext == "tsv" {
-                b'\t'
-            } else {
-                cell_sheet_core::io::csv::sniff_delimiter(&data)
-            };
+            let delimiter = format.resolve_data_delimiter(&data, explicit_delimiter);
             app.sheet = cell_sheet_core::io::csv::read_csv(data.as_slice(), delimiter)?;
-            app.file_format = if ext == "tsv" {
-                FileFormat::Tsv
-            } else {
-                FileFormat::Csv
-            };
             app.delimiter = delimiter;
         }
     }
 
     app.file_path = Some(path.to_path_buf());
+    app.file_format = format;
 
     SheetEngine::new(&mut app.sheet, &mut app.deps).rebuild_formulas_and_recalculate();
 
@@ -212,20 +199,18 @@ fn load_stdin_data(
 
     // Detect the native .cell format by its magic header. Anything else is
     // treated as CSV/TSV with delimiter sniffing (or an explicit override).
-    if data.starts_with(b"# cell v") {
-        if explicit_delimiter.is_some() {
-            return Err("--delimiter has no effect on .cell-format input piped to stdin".into());
+    let format = FileFormat::from_stdin_bytes(&data);
+    let delimiter = format.resolve_stdin_delimiter(&data, explicit_delimiter)?;
+    match format {
+        FileFormat::Cell => {
+            app.sheet = cell_sheet_core::io::cell_format::read_cell_format(data.as_slice())?;
         }
-        app.sheet = cell_sheet_core::io::cell_format::read_cell_format(data.as_slice())?;
-        app.file_format = FileFormat::Cell;
-        // delimiter stays at its default; .cell format doesn't use one
-    } else {
-        let delimiter =
-            explicit_delimiter.unwrap_or_else(|| cell_sheet_core::io::csv::sniff_delimiter(&data));
-        app.sheet = cell_sheet_core::io::csv::read_csv(data.as_slice(), delimiter)?;
-        app.file_format = FileFormat::Csv;
-        app.delimiter = delimiter;
+        FileFormat::Csv | FileFormat::Tsv => {
+            app.sheet = cell_sheet_core::io::csv::read_csv(data.as_slice(), delimiter)?;
+            app.delimiter = delimiter;
+        }
     }
+    app.file_format = format;
     // file_path stays None — unnamed buffer; :w <path> still works to save
 
     SheetEngine::new(&mut app.sheet, &mut app.deps).rebuild_formulas_and_recalculate();


### PR DESCRIPTION
## Summary
- Add a shared TUI `FileFormat` policy module for CSV/TSV/.cell detection and delimiter resolution.
- Reuse the shared policy from interactive load/save paths and headless mode.
- Remove duplicated headless format/delimiter helpers while preserving behavior.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test`

Made with [Cursor](https://cursor.com)