### PR TITLE
Extract command state from App

### DIFF
--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -1,7 +1,8 @@
 mod dispatch;
 
-use crate::action::{Action, CaseOp, CommandKind, Mode};
+use crate::action::{Action, CaseOp, Mode};
 use crate::clipboard::Register;
+use crate::command_state::CommandState;
 use crate::file_format::FileFormat;
 use crate::mode::mouse::GridLayout;
 use crate::mode::visual::VisualKind;
@@ -23,8 +24,7 @@ pub struct App {
     pub mode: Mode,
     pub register: Option<Register>,
     pub undo_stack: UndoStack,
-    pub command_line: String,
-    pub command_kind: CommandKind,
+    pub command: CommandState,
     pub status_message: Option<String>,
     pub search: SearchState,
     pub file_path: Option<PathBuf>,
@@ -51,14 +51,6 @@ pub struct App {
     /// When > 0, `EditCell` skips `recalculate`; `commit_batch` triggers it
     /// once when the outermost batch is closed.
     batch_depth: u32,
-    /// Previously executed colon commands, oldest first.
-    pub command_history: Vec<String>,
-    /// Index into `command_history` while the user is cycling with ↑/↓.
-    /// `None` means the user is not currently browsing history.
-    pub command_history_idx: Option<usize>,
-    /// The in-progress command line saved when the user first presses ↑,
-    /// restored when they press ↓ past the most recent entry.
-    pub command_history_scratch: String,
     pub last_change: Option<Action>,
 }
 
@@ -81,8 +73,7 @@ impl App {
             mode: Mode::Normal,
             register: None,
             undo_stack: UndoStack::new(),
-            command_line: String::new(),
-            command_kind: CommandKind::Colon,
+            command: CommandState::default(),
             status_message: None,
             search: SearchState::default(),
             file_path: None,
@@ -101,9 +92,6 @@ impl App {
             jump_idx: 0,
             last_visual: None,
             batch_depth: 0,
-            command_history: Vec::new(),
-            command_history_idx: None,
-            command_history_scratch: String::new(),
             last_change: None,
         }
     }
@@ -807,8 +795,8 @@ mod tests {
         let mut app = App::new();
         app.process_action(Action::EnterSearch(SearchDirection::Forward));
         assert_eq!(app.mode, Mode::Command);
-        assert_eq!(app.command_kind, CommandKind::Slash);
-        assert!(app.command_line.is_empty());
+        assert_eq!(app.command.kind, CommandKind::Slash);
+        assert!(app.command.line.is_empty());
     }
 
     #[test]
@@ -817,7 +805,7 @@ mod tests {
         let mut app = App::new();
         app.process_action(Action::EnterSearch(SearchDirection::Backward));
         assert_eq!(app.mode, Mode::Command);
-        assert_eq!(app.command_kind, CommandKind::Question);
+        assert_eq!(app.command.kind, CommandKind::Question);
     }
 
     #[test]
@@ -828,7 +816,7 @@ mod tests {
         app.process_action(Action::EnterSearch(SearchDirection::Forward));
         app.process_action(Action::ChangeMode(Mode::Normal));
         app.process_action(Action::ChangeMode(Mode::Command));
-        assert_eq!(app.command_kind, CommandKind::Colon);
+        assert_eq!(app.command.kind, CommandKind::Colon);
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app/dispatch.rs
+++ b/crates/cell-sheet-tui/src/app/dispatch.rs
@@ -52,10 +52,7 @@ impl App {
                         .unwrap_or_default();
                 }
                 if mode == Mode::Command {
-                    self.command_kind = CommandKind::Colon;
-                    self.command_line.clear();
-                    self.command_history_idx = None;
-                    self.command_history_scratch.clear();
+                    self.command.enter(CommandKind::Colon);
                 }
                 self.mode = mode;
             }

--- a/crates/cell-sheet-tui/src/command_state.rs
+++ b/crates/cell-sheet-tui/src/command_state.rs
@@ -1,0 +1,142 @@
+use crate::action::CommandKind;
+
+#[derive(Debug, Clone)]
+pub struct CommandState {
+    pub line: String,
+    pub kind: CommandKind,
+    /// Previously executed colon commands, oldest first.
+    pub history: Vec<String>,
+    /// Index into `history` while the user is cycling with up/down.
+    /// `None` means the user is not currently browsing history.
+    pub history_idx: Option<usize>,
+    /// The in-progress command line saved when the user first presses up,
+    /// restored when they press down past the most recent entry.
+    pub history_scratch: String,
+}
+
+impl Default for CommandState {
+    fn default() -> Self {
+        Self {
+            line: String::new(),
+            kind: CommandKind::Colon,
+            history: Vec::new(),
+            history_idx: None,
+            history_scratch: String::new(),
+        }
+    }
+}
+
+impl CommandState {
+    pub fn enter(&mut self, kind: CommandKind) {
+        self.kind = kind;
+        self.line.clear();
+        self.reset_history_browse();
+    }
+
+    pub fn clear_line(&mut self) {
+        self.line.clear();
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.line.push(c);
+    }
+
+    pub fn backspace(&mut self) {
+        self.line.pop();
+    }
+
+    pub fn reset_history_browse(&mut self) {
+        self.history_idx = None;
+        self.history_scratch.clear();
+    }
+
+    pub fn record_submitted_colon_command(&mut self, command: &str) {
+        let command = command.trim();
+        if !command.is_empty() && self.history.last().map(|s| s.as_str()) != Some(command) {
+            self.history.push(command.to_string());
+        }
+        self.reset_history_browse();
+    }
+
+    pub fn history_prev(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+        let new_idx = match self.history_idx {
+            None => {
+                // Save current in-progress text before browsing.
+                self.history_scratch = self.line.clone();
+                self.history.len() - 1
+            }
+            Some(i) => i.saturating_sub(1),
+        };
+        self.history_idx = Some(new_idx);
+        self.line = self.history[new_idx].clone();
+    }
+
+    pub fn history_next(&mut self) {
+        let Some(i) = self.history_idx else {
+            return;
+        };
+        if i + 1 < self.history.len() {
+            let new_idx = i + 1;
+            self.history_idx = Some(new_idx);
+            self.line = self.history[new_idx].clone();
+        } else {
+            // Past the newest entry - restore scratch.
+            self.history_idx = None;
+            self.line = self.history_scratch.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_trimmed_colon_commands_without_consecutive_duplicates() {
+        let mut state = CommandState::default();
+
+        state.record_submitted_colon_command("  write.csv  ");
+        state.record_submitted_colon_command("write.csv");
+        state.record_submitted_colon_command("");
+
+        assert_eq!(state.history, vec!["write.csv"]);
+        assert_eq!(state.history_idx, None);
+        assert!(state.history_scratch.is_empty());
+    }
+
+    #[test]
+    fn history_prev_saves_scratch_and_walks_back() {
+        let mut state = CommandState {
+            history: vec!["first".into(), "second".into()],
+            line: "scratch".into(),
+            ..Default::default()
+        };
+
+        state.history_prev();
+        assert_eq!(state.line, "second");
+        assert_eq!(state.history_idx, Some(1));
+        assert_eq!(state.history_scratch, "scratch");
+
+        state.history_prev();
+        assert_eq!(state.line, "first");
+        assert_eq!(state.history_idx, Some(0));
+    }
+
+    #[test]
+    fn history_next_restores_scratch_after_newest_entry() {
+        let mut state = CommandState {
+            history: vec!["first".into(), "second".into()],
+            line: "scratch".into(),
+            ..Default::default()
+        };
+
+        state.history_prev();
+        state.history_next();
+
+        assert_eq!(state.line, "scratch");
+        assert_eq!(state.history_idx, None);
+    }
+}

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod clipboard;
+mod command_state;
 mod file_format;
 mod headless;
 mod mode;
@@ -356,18 +357,18 @@ fn run_loop(
                         Mode::Help => help_state.handle_key(key, app, grid_height),
                         Mode::Command => {
                             use action::{CommandKind, SearchDirection};
-                            let cmd_action = handle_command_key(key, &app.command_line);
-                            let search_dir = match app.command_kind {
+                            let cmd_action = handle_command_key(key, &app.command.line);
+                            let search_dir = match app.command.kind {
                                 CommandKind::Slash => Some(SearchDirection::Forward),
                                 CommandKind::Question => Some(SearchDirection::Backward),
                                 CommandKind::Colon => None,
                             };
                             match cmd_action {
                                 CommandAction::InsertChar(c) => {
-                                    app.command_line.push(c);
+                                    app.command.insert_char(c);
                                     if let Some(dir) = search_dir {
                                         Action::SearchIncremental {
-                                            pattern: app.command_line.clone(),
+                                            pattern: app.command.line.clone(),
                                             direction: dir,
                                         }
                                     } else {
@@ -375,10 +376,10 @@ fn run_loop(
                                     }
                                 }
                                 CommandAction::Backspace => {
-                                    app.command_line.pop();
+                                    app.command.backspace();
                                     if let Some(dir) = search_dir {
                                         Action::SearchIncremental {
-                                            pattern: app.command_line.clone(),
+                                            pattern: app.command.line.clone(),
                                             direction: dir,
                                         }
                                     } else {
@@ -386,22 +387,16 @@ fn run_loop(
                                     }
                                 }
                                 CommandAction::Execute(cmd) => {
-                                    let kind = app.command_kind;
+                                    let kind = app.command.kind;
                                     let is_wq =
                                         matches!(kind, CommandKind::Colon) && cmd.trim() == "wq";
-                                    // Push non-empty colon commands to history,
-                                    // avoiding consecutive duplicates.
-                                    if matches!(kind, CommandKind::Colon)
-                                        && !cmd.trim().is_empty()
-                                        && app.command_history.last().map(|s| s.as_str())
-                                            != Some(cmd.trim())
-                                    {
-                                        app.command_history.push(cmd.trim().to_string());
+                                    if matches!(kind, CommandKind::Colon) {
+                                        app.command.record_submitted_colon_command(&cmd);
+                                    } else {
+                                        app.command.reset_history_browse();
                                     }
-                                    app.command_history_idx = None;
-                                    app.command_history_scratch.clear();
                                     let parsed = submit(kind, &cmd);
-                                    app.command_line.clear();
+                                    app.command.clear_line();
                                     if is_wq {
                                         wq_pending = true;
                                     }
@@ -412,51 +407,21 @@ fn run_loop(
                                     parsed
                                 }
                                 CommandAction::Cancel => {
-                                    app.command_history_idx = None;
-                                    app.command_history_scratch.clear();
+                                    app.command.reset_history_browse();
                                     if search_dir.is_some() {
                                         Action::CancelSearch
                                     } else {
-                                        app.command_line.clear();
+                                        app.command.clear_line();
                                         Action::ChangeMode(Mode::Normal)
                                     }
                                 }
                                 CommandAction::HistoryPrev => {
-                                    if app.command_history.is_empty() {
-                                        Action::Noop
-                                    } else {
-                                        let new_idx = match app.command_history_idx {
-                                            None => {
-                                                // Save current in-progress text before browsing.
-                                                app.command_history_scratch =
-                                                    app.command_line.clone();
-                                                app.command_history.len() - 1
-                                            }
-                                            Some(i) => i.saturating_sub(1),
-                                        };
-                                        app.command_history_idx = Some(new_idx);
-                                        app.command_line = app.command_history[new_idx].clone();
-                                        Action::Noop
-                                    }
+                                    app.command.history_prev();
+                                    Action::Noop
                                 }
                                 CommandAction::HistoryNext => {
-                                    match app.command_history_idx {
-                                        None => Action::Noop,
-                                        Some(i) => {
-                                            if i + 1 < app.command_history.len() {
-                                                let new_idx = i + 1;
-                                                app.command_history_idx = Some(new_idx);
-                                                app.command_line =
-                                                    app.command_history[new_idx].clone();
-                                            } else {
-                                                // Past the newest entry — restore scratch.
-                                                app.command_history_idx = None;
-                                                app.command_line =
-                                                    app.command_history_scratch.clone();
-                                            }
-                                            Action::Noop
-                                        }
-                                    }
+                                    app.command.history_next();
+                                    Action::Noop
                                 }
                                 CommandAction::Noop => Action::Noop,
                             }
@@ -531,15 +496,14 @@ fn run_loop(
                             }
                             Mode::Command => {
                                 use action::CommandKind;
-                                app.command_history_idx = None;
-                                app.command_history_scratch.clear();
+                                app.command.reset_history_browse();
                                 if matches!(
-                                    app.command_kind,
+                                    app.command.kind,
                                     CommandKind::Slash | CommandKind::Question
                                 ) {
                                     app.process_action(Action::CancelSearch);
                                 } else {
-                                    app.command_line.clear();
+                                    app.command.clear_line();
                                     app.mode = Mode::Normal;
                                 }
                             }

--- a/crates/cell-sheet-tui/src/mode/mouse.rs
+++ b/crates/cell-sheet-tui/src/mode/mouse.rs
@@ -838,22 +838,21 @@ mod tests {
 
         let mut app = App::new();
         app.mode = Mode::Command;
-        app.command_kind = CommandKind::Colon;
-        app.command_line = "se".into();
-        app.command_history_idx = Some(0);
-        app.command_history_scratch = "abc".into();
+        app.command.enter(CommandKind::Colon);
+        app.command.line = "se".into();
+        app.command.history_idx = Some(0);
+        app.command.history_scratch = "abc".into();
 
         // The mouse-cancel branch (colon path):
-        app.command_history_idx = None;
-        app.command_history_scratch.clear();
-        app.command_line.clear();
+        app.command.reset_history_browse();
+        app.command.clear_line();
         app.mode = Mode::Normal;
         app.process_action(Action::MouseClickCell((1, 1)));
 
         assert_eq!(app.mode, Mode::Normal);
-        assert!(app.command_line.is_empty());
-        assert!(app.command_history_idx.is_none());
-        assert!(app.command_history_scratch.is_empty());
+        assert!(app.command.line.is_empty());
+        assert!(app.command.history_idx.is_none());
+        assert!(app.command.history_scratch.is_empty());
         assert_eq!(app.cursor, (1, 1));
     }
 

--- a/crates/cell-sheet-tui/src/render/mod.rs
+++ b/crates/cell-sheet-tui/src/render/mod.rs
@@ -110,8 +110,8 @@ pub fn render(
     let is_command = app.mode == Mode::Command;
     frame.render_widget(
         CommandLine {
-            content: &app.command_line,
-            prefix: app.command_kind.prefix(),
+            content: &app.command.line,
+            prefix: app.command.kind.prefix(),
             active: is_command,
         },
         chunks[3],

--- a/crates/cell-sheet-tui/src/search.rs
+++ b/crates/cell-sheet-tui/src/search.rs
@@ -49,14 +49,12 @@ impl App {
                 }
             }
             Action::EnterSearch(direction) => {
-                self.command_line.clear();
-                self.command_kind = match direction {
+                let kind = match direction {
                     SearchDirection::Forward => CommandKind::Slash,
                     SearchDirection::Backward => CommandKind::Question,
                 };
+                self.command.enter(kind);
                 self.search.origin = Some(self.cursor);
-                self.command_history_idx = None;
-                self.command_history_scratch.clear();
                 self.mode = Mode::Command;
             }
             Action::SearchIncremental { pattern, direction } => {
@@ -81,7 +79,7 @@ impl App {
                     self.cursor = origin;
                     self.viewport.ensure_visible(self.cursor);
                 }
-                self.command_line.clear();
+                self.command.clear_line();
                 self.mode = Mode::Normal;
             }
             Action::FindCharInRow {


### PR DESCRIPTION
## Summary
- Add `CommandState` for command prompt line, kind, history, history index, and scratch state.
- Route command editing, submit bookkeeping, and history navigation through `CommandState` helpers.
- Update render, search, dispatch, and mouse test call sites to use the grouped command state.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test`

Made with [Cursor](https://cursor.com)