### PR TITLE
refactor: extract status manager

### DIFF
--- a/crates/cell-sheet-tui/src/app.rs
+++ b/crates/cell-sheet-tui/src/app.rs
@@ -7,6 +7,7 @@ use crate::file_format::FileFormat;
 use crate::mode::mouse::GridLayout;
 use crate::mode::visual::VisualKind;
 use crate::search::SearchState;
+use crate::status::StatusManager;
 use crate::undo::{UndoEntry, UndoStack};
 use crate::viewport::Viewport;
 use cell_sheet_core::engine::SheetEngine;
@@ -25,7 +26,7 @@ pub struct App {
     pub register: Option<Register>,
     pub undo_stack: UndoStack,
     pub command: CommandState,
-    pub status_message: Option<String>,
+    pub status: StatusManager,
     pub search: SearchState,
     pub file_path: Option<PathBuf>,
     pub file_format: FileFormat,
@@ -74,7 +75,7 @@ impl App {
             register: None,
             undo_stack: UndoStack::new(),
             command: CommandState::default(),
-            status_message: None,
+            status: StatusManager::default(),
             search: SearchState::default(),
             file_path: None,
             file_format: FileFormat::Csv,
@@ -169,10 +170,10 @@ impl App {
                 self.file_path = Some(path.clone());
                 self.file_format = format;
                 self.dirty = false;
-                self.status_message = Some(format!("Written to {}", path.display()));
+                self.status.set(format!("Written to {}", path.display()));
             }
             Err(e) => {
-                self.status_message = Some(format!("Error saving: {}", e));
+                self.status.set(format!("Error saving: {}", e));
             }
         }
     }
@@ -731,7 +732,7 @@ mod tests {
         app.mode = Mode::Normal;
         app.process_action(Action::ShowHelp(Some("nonexistent".into())));
         assert_eq!(app.mode, Mode::Normal);
-        assert_eq!(app.status_message, Some("No help for 'nonexistent'".into()));
+        assert_eq!(app.status.as_deref(), Some("No help for 'nonexistent'"));
     }
 
     #[test]
@@ -1040,7 +1041,7 @@ mod tests {
             direction: SearchDirection::Forward,
         });
         assert_eq!(app.cursor, (0, 0));
-        assert!(app.status_message.is_some());
+        assert!(app.status.as_deref().is_some());
     }
 
     #[test]
@@ -1330,11 +1331,7 @@ mod tests {
             line_wise: false,
         });
         assert_eq!(app.cursor, (1, 1));
-        assert!(app
-            .status_message
-            .as_deref()
-            .unwrap()
-            .contains("Mark not set"));
+        assert!(app.status.as_deref().unwrap().contains("Mark not set"));
     }
 
     #[test]
@@ -1539,10 +1536,7 @@ mod tests {
         app.cursor = (0, 0);
         app.process_action(Action::SearchCellValue { backward: false });
         assert_eq!(app.search.pattern, None);
-        assert_eq!(
-            app.status_message.as_deref(),
-            Some("No string under cursor")
-        );
+        assert_eq!(app.status.as_deref(), Some("No string under cursor"));
     }
 
     #[test]
@@ -1551,7 +1545,7 @@ mod tests {
         assert_eq!(app.delimiter, b',', "default delimiter should be comma");
         app.process_action(Action::SetDelimiter(b'|'));
         assert_eq!(app.delimiter, b'|');
-        assert_eq!(app.status_message.as_deref(), Some("Delimiter set to '|'"));
+        assert_eq!(app.status.as_deref(), Some("Delimiter set to '|'"));
     }
 
     #[test]
@@ -1792,7 +1786,7 @@ mod tests {
         app.file_path = Some(std::path::PathBuf::from("data.csv"));
         app.delimiter = b'|';
         app.process_action(Action::Save(None));
-        let msg = app.status_message.as_deref().unwrap_or("");
+        let msg = app.status.as_deref().unwrap_or("");
         assert!(
             msg.contains("Non-standard delimiter"),
             "expected delimiter warning, got: {msg:?}"
@@ -1805,7 +1799,7 @@ mod tests {
         app.file_path = Some(std::path::PathBuf::from("data.tsv"));
         app.delimiter = b'|';
         app.process_action(Action::Save(None));
-        let msg = app.status_message.as_deref().unwrap_or("");
+        let msg = app.status.as_deref().unwrap_or("");
         assert!(
             msg.contains("Non-standard delimiter"),
             "expected delimiter warning, got: {msg:?}"
@@ -1821,7 +1815,7 @@ mod tests {
         app.file_path = Some(std::path::PathBuf::from("data.csv"));
         app.delimiter = b',';
         app.process_action(Action::Save(None));
-        let msg = app.status_message.as_deref().unwrap_or("");
+        let msg = app.status.as_deref().unwrap_or("");
         assert!(
             !msg.contains("Non-standard delimiter"),
             "unexpected delimiter warning: {msg:?}"
@@ -1836,7 +1830,7 @@ mod tests {
         // ForceSave must NOT produce the delimiter warning.
         // (The write may produce an I/O error if the path can't be written, which is fine.)
         app.process_action(Action::ForceSave(None));
-        let msg = app.status_message.as_deref().unwrap_or("");
+        let msg = app.status.as_deref().unwrap_or("");
         assert!(
             !msg.contains("Non-standard delimiter"),
             "ForceSave should bypass delimiter warning, got: {msg:?}"
@@ -2197,7 +2191,7 @@ mod tests {
             app.sheet.get_cell((0, 0)).map(|c| c.raw.as_str()),
             Some("=SUM(A1:A5)")
         );
-        assert!(app.status_message.is_some());
+        assert!(app.status.as_deref().is_some());
     }
 
     #[test]
@@ -2402,10 +2396,7 @@ mod tests {
             raw_before
         );
         // Status message set
-        assert_eq!(
-            app.status_message.as_deref(),
-            Some("E: Cannot increment a formula")
-        );
+        assert_eq!(app.status.as_deref(), Some("E: Cannot increment a formula"));
     }
 
     #[test]

--- a/crates/cell-sheet-tui/src/app/dispatch.rs
+++ b/crates/cell-sheet-tui/src/app/dispatch.rs
@@ -58,8 +58,8 @@ impl App {
             }
             Action::Quit { force } => {
                 if !force && self.dirty {
-                    self.status_message =
-                        Some("No write since last change (use :q! to override)".into());
+                    self.status
+                        .set("No write since last change (use :q! to override)");
                 } else {
                     self.should_quit = true;
                 }
@@ -197,14 +197,14 @@ impl App {
                 if let Some(path) = path {
                     let format = Self::format_from_path(&path);
                     if !matches!(format, FileFormat::Cell) && self.has_formulas() {
-                        self.status_message = Some(
-                            "Sheet contains formulas that will be lost. Use :w file.cell to preserve, or :w! to save as CSV anyway.".into()
+                        self.status.set(
+                            "Sheet contains formulas that will be lost. Use :w file.cell to preserve, or :w! to save as CSV anyway."
                         );
                         return;
                     }
                     if let Some(expected_delim) = format.canonical_delimiter() {
                         if self.delimiter != expected_delim {
-                            self.status_message = Some(format!(
+                            self.status.set(format!(
                                 "Non-standard delimiter '{}' will be used. Use :w! to force, or save as .tsv / .psv.",
                                 self.delimiter as char
                             ));
@@ -213,7 +213,7 @@ impl App {
                     }
                     self.do_save(&path, format);
                 } else {
-                    self.status_message = Some("No file name".into());
+                    self.status.set("No file name");
                 }
             }
             Action::ForceSave(path_opt) => {
@@ -224,7 +224,7 @@ impl App {
                     let format = Self::format_from_path(&path);
                     self.do_save(&path, format);
                 } else {
-                    self.status_message = Some("No file name".into());
+                    self.status.set("No file name");
                 }
             }
             action @ (Action::Search { .. }
@@ -240,7 +240,7 @@ impl App {
                 cell_sheet_core::engine::SheetEngine::new(&mut self.sheet, &mut self.deps)
                     .sort_by_column_and_recalculate(col, ascending);
                 self.dirty = true;
-                self.status_message = Some(format!(
+                self.status.set(format!(
                     "Sorted by column {} {}",
                     cell_sheet_core::model::col_index_to_label(col),
                     if ascending { "ascending" } else { "descending" }
@@ -531,7 +531,7 @@ impl App {
                         self.help_scroll = 0;
                         self.mode = Mode::Help;
                     } else {
-                        self.status_message = Some(format!("No help for '{}'", tag));
+                        self.status.set(format!("No help for '{}'", tag));
                     }
                 }
                 None => {
@@ -587,7 +587,7 @@ impl App {
                     self.viewport.ensure_visible(self.cursor);
                 }
                 None => {
-                    self.status_message = Some(format!("E20: Mark not set: {}", name));
+                    self.status.set(format!("E20: Mark not set: {}", name));
                 }
             },
             Action::JumpBack => {
@@ -626,7 +626,7 @@ impl App {
             }
             Action::SetDelimiter(d) => {
                 self.delimiter = d;
-                self.status_message = Some(format!("Delimiter set to '{}'", d as char));
+                self.status.set(format!("Delimiter set to '{}'", d as char));
             }
             Action::SetMouse(b) => {
                 self.mouse_enabled = b;
@@ -672,7 +672,7 @@ impl App {
                 }
             }
             Action::SetStatus(msg) => {
-                self.status_message = Some(msg);
+                self.status.set(msg);
             }
             Action::RepeatLastChange => {
                 if let Some(change) = self.last_change.take() {
@@ -695,7 +695,7 @@ impl App {
                     return;
                 }
                 if raw.starts_with('=') {
-                    self.status_message = Some("Cannot change case of a formula cell".into());
+                    self.status.set("Cannot change case of a formula cell");
                     return;
                 }
                 let new_raw = apply_case_op(&raw, op);
@@ -747,7 +747,7 @@ impl App {
                 if let Some(cell) = self.sheet.get_cell(pos) {
                     let raw = cell.raw.clone();
                     if raw.starts_with('=') {
-                        self.status_message = Some("E: Cannot increment a formula".into());
+                        self.status.set("E: Cannot increment a formula");
                     } else if let Ok(n) = raw.parse::<f64>() {
                         let new_raw = (n + delta as f64).to_string();
                         self.undo_stack.push(UndoEntry::CellEdit {

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -7,6 +7,7 @@ mod headless;
 mod mode;
 mod render;
 mod search;
+mod status;
 mod undo;
 mod viewport;
 
@@ -285,7 +286,7 @@ fn run_loop(
                         continue;
                     }
 
-                    app.status_message = None;
+                    app.status.clear();
 
                     let action = match app.mode {
                         Mode::Normal => normal_state.handle_key(key, app),
@@ -471,7 +472,7 @@ fn run_loop(
                     if !app.mouse_enabled {
                         continue;
                     }
-                    app.status_message = None;
+                    app.status.clear();
                     let drag_was_idle = mouse_state.drag == mode::mouse::MouseDragState::Idle;
                     let layout = app.last_grid_layout.clone();
                     let action =

--- a/crates/cell-sheet-tui/src/render/mod.rs
+++ b/crates/cell-sheet-tui/src/render/mod.rs
@@ -101,7 +101,7 @@ pub fn render(
             cursor: app.cursor,
             dirty: app.dirty,
             file_name,
-            message: app.status_message.as_deref(),
+            message: app.status.as_deref(),
             partial_command,
         },
         chunks[2],

--- a/crates/cell-sheet-tui/src/search.rs
+++ b/crates/cell-sheet-tui/src/search.rs
@@ -45,7 +45,7 @@ impl App {
                         self.cursor = origin;
                         self.viewport.ensure_visible(self.cursor);
                     }
-                    self.status_message = Some(format!("Pattern not found: {}", pattern));
+                    self.status.set(format!("Pattern not found: {}", pattern));
                 }
             }
             Action::EnterSearch(direction) => {
@@ -124,7 +124,7 @@ impl App {
                         direction,
                     });
                 } else {
-                    self.status_message = Some("No string under cursor".into());
+                    self.status.set("No string under cursor");
                 }
             }
             _ => unreachable!("non-search action routed to search handler"),
@@ -137,7 +137,7 @@ impl App {
             None => return,
         };
         if !self.find_from(&pattern, forward, self.cursor, false) {
-            self.status_message = Some(format!("Pattern not found: {}", pattern));
+            self.status.set(format!("Pattern not found: {}", pattern));
         }
     }
 

--- a/crates/cell-sheet-tui/src/status.rs
+++ b/crates/cell-sheet-tui/src/status.rs
@@ -1,0 +1,34 @@
+#[derive(Debug, Default, Clone)]
+pub struct StatusManager {
+    message: Option<String>,
+}
+
+impl StatusManager {
+    pub fn set(&mut self, message: impl Into<String>) {
+        self.message = Some(message.into());
+    }
+
+    pub fn clear(&mut self) {
+        self.message = None;
+    }
+
+    pub fn as_deref(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_and_clear_status_message() {
+        let mut status = StatusManager::default();
+
+        status.set("saved");
+        assert_eq!(status.as_deref(), Some("saved"));
+
+        status.clear();
+        assert_eq!(status.as_deref(), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `StatusManager` to own App status messages and expose set/clear/read helpers.
- Route dispatch, search, render, and event-loop status access through the manager.
- Complete the final explicit extraction slice from #73 after SearchState and CommandState.

Closes #73.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test`

Made with [Cursor](https://cursor.com)