### PR TITLE
ci: build artifacts after release-plz publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build artifacts for, e.g. v0.5.0"
+        required: true
+        type: string
   push:
     branches: [main]
     tags: ["v*"]
@@ -19,6 +25,9 @@ jobs:
     name: Release-plz release
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release-metadata.outputs.release_tag }}
+      releases_created: ${{ steps.release-plz.outputs.releases_created }}
     permissions:
       contents: write
       id-token: write
@@ -32,11 +41,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Publish release
+        id: release-plz
         uses: release-plz/action@v0.5.128
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release tag
+        id: release-metadata
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+        run: |
+          release_tag="$(echo "$RELEASES" | jq -r 'map(select(.package_name == "cell-sheet-tui"))[0].tag // empty')"
+          if [ -z "$release_tag" ]; then
+            echo "cell-sheet-tui release tag not found in release-plz output" >&2
+            exit 1
+          fi
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
   release-plz-pr:
     name: Release-plz PR
@@ -66,8 +89,13 @@ jobs:
 
   build:
     name: Build (${{ matrix.target }})
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Tags created by release-plz use GITHUB_TOKEN and do not trigger a second
+    # tag-push workflow run, so build artifacts in this same run when released.
+    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || needs.release-plz-release.outputs.releases_created == 'true')
+    needs: release-plz-release
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || startsWith(github.ref, 'refs/tags/v') && github.ref_name || needs.release-plz-release.outputs.release_tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +118,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -112,34 +142,36 @@ jobs:
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'
         run: |
-          mkdir -p dist/${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}
-          cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }} dist/${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}/
-          cp README.md CHANGELOG.md LICENSE dist/${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}/
-          tar czf ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz -C dist ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}
-          shasum -a 256 ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz > ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz.sha256
+          mkdir -p dist/${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }} dist/${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}/
+          cp README.md CHANGELOG.md LICENSE dist/${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}/
+          tar czf ${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz -C dist ${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}
+          shasum -a 256 ${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz > ${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz.sha256
 
       - name: Package (windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          $dist = "dist/${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}"
+          $dist = "dist/${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}"
           New-Item -ItemType Directory -Force -Path $dist
           Copy-Item "target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe" $dist
           Copy-Item README.md,CHANGELOG.md,LICENSE $dist
-          Compress-Archive -Path $dist -DestinationPath "${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.zip"
-          $hash = (Get-FileHash "${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.zip" | Out-File -Encoding ascii "${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.zip.sha256"
+          Compress-Archive -Path $dist -DestinationPath "${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip"
+          $hash = (Get-FileHash "${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  ${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip" | Out-File -Encoding ascii "${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip.sha256"
 
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
-          path: ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.*
+          path: ${{ env.BINARY_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.target }}.*
 
   upload-artifacts:
     name: Upload release artifacts
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    if: always() && needs.build.result == 'success'
+    needs: [release-plz-release, build]
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || startsWith(github.ref, 'refs/tags/v') && github.ref_name || needs.release-plz-release.outputs.release_tag }}
     permissions:
       contents: write
     steps:
@@ -153,19 +185,19 @@ jobs:
       - name: Wait for release-plz draft
         run: |
           for attempt in {1..30}; do
-            if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
               exit 0
             fi
             sleep 2
           done
-          echo "release ${{ github.ref_name }} was not created by release-plz" >&2
+          echo "release $RELEASE_TAG was not created by release-plz" >&2
           exit 1
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Upload release artifacts
         run: |
-          gh release upload "${{ github.ref_name }}" artifacts/* --clobber
-          gh release edit "${{ github.ref_name }}" --draft=false
+          gh release upload "$RELEASE_TAG" artifacts/* --clobber
+          gh release edit "$RELEASE_TAG" --draft=false
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ Releases are automated with [release-plz](https://release-plz.dev/) from the
 - Merging the release PR publishes `cell-sheet-core` and `cell-sheet-tui` to
   [crates.io](https://crates.io) via trusted publishing, creates the `vX.Y.Z`
   tag, and creates a draft GitHub Release.
-- The `vX.Y.Z` tag then builds binaries for Linux (x86_64, aarch64), macOS
-  (x86_64, aarch64), and Windows (x86_64), uploads archives and SHA256
+- The same workflow run then builds binaries for Linux (x86_64, aarch64),
+  macOS (x86_64, aarch64), and Windows (x86_64), uploads archives and SHA256
   checksums, and publishes the GitHub Release.
 
 See [RELEASE.md](RELEASE.md) for maintainer instructions and failure handling.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,9 +20,9 @@ crates.io for both crates.
 4. After the merge, `release-plz` publishes unpublished crates to crates.io via
    trusted publishing, creates a single `vX.Y.Z` tag, and creates a draft
    GitHub Release.
-5. The same workflow runs again for the new `vX.Y.Z` tag, builds release
-   binaries, uploads archives plus `.sha256` checksum files, and publishes the
-   draft GitHub Release.
+5. The same workflow run reads the tag from `release-plz` output, builds
+   release binaries from that tag, uploads archives plus `.sha256` checksum
+   files, and publishes the draft GitHub Release.
 
 No manual tag push is needed.
 
@@ -36,12 +36,18 @@ No manual tag push is needed.
 - the `vX.Y.Z` tag
 - the draft GitHub Release
 
-The tag-triggered artifact jobs in `release.yml` own:
+The artifact jobs in `release.yml` own:
 
 - Linux, macOS, and Windows binary builds
 - release archives
 - SHA256 checksum files
 - publishing the draft GitHub Release after artifacts are attached
+
+The artifact jobs can run from three entry points:
+
+- automatically after `release-plz` publishes a release on a `main` push
+- a manual `workflow_dispatch` with a `vX.Y.Z` tag input, for recovery
+- a direct `v*` tag push, for exceptional manual releases
 
 The workspace has two public crates but one product release, so
 [`release-plz.toml`](release-plz.toml) is only configuration for the
@@ -53,7 +59,8 @@ enables a single `v{{ version }}` tag/release for `cell-sheet-tui`.
 - If crates.io publishing fails, fix the issue and rerun the failed workflow.
   Do not create a manual tag for the same version.
 - If artifact building fails after crates.io publishing succeeds, the GitHub
-  Release remains a draft. Fix the workflow or code, rerun the tag workflow,
-  and let it upload artifacts and publish the draft.
+  Release remains a draft. Fix the workflow or code, run the release workflow
+  manually with the affected `vX.Y.Z` tag, and let it upload artifacts and
+  publish the draft.
 - If the release PR has the wrong changelog or version, edit the source commits
   or `release-plz.toml` configuration and let the release PR update.


### PR DESCRIPTION
## Summary
- Fix the release handoff by using `release-plz` outputs to build and upload artifacts in the same `release.yml` run after crates.io publishing succeeds.
- Add `workflow_dispatch` with a tag input so the existing draft `v0.5.0` release can be repaired without moving tags.
- Update release docs to describe the same-run artifact path and recovery flow.

## Root cause
`release-plz` created `v0.5.0` with `GITHUB_TOKEN`. GitHub does not trigger a new workflow run from tag pushes created by `GITHUB_TOKEN`, so the tag-gated build/upload jobs never ran.

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml yaml ok"'`
- `python3 -c 'import tomllib; tomllib.load(open("release-plz.toml", "rb")); print("release-plz.toml ok")'`
- `cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features && cargo test`


Made with [Cursor](https://cursor.com)