### PR TITLE
feat: case-insensitive formulas and cell references

### DIFF
--- a/crates/cell-sheet-core/src/formula/eval.rs
+++ b/crates/cell-sheet-core/src/formula/eval.rs
@@ -327,6 +327,28 @@ mod tests {
     }
 
     #[test]
+    fn eval_lowercase_formula_equivalent() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "1");
+        sheet.set_cell((1, 0), "2");
+        assert_eq!(
+            eval_with_sheet("sum(a1:a2)", &sheet),
+            eval_with_sheet("SUM(A1:A2)", &sheet),
+        );
+    }
+
+    #[test]
+    fn eval_mixed_case_formula() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "10");
+        sheet.set_cell((1, 0), "20");
+        assert_eq!(
+            eval_with_sheet("Sum(A1:a2)", &sheet),
+            CellValue::Number(30.0),
+        );
+    }
+
+    #[test]
     fn eval_error_propagation() {
         let mut sheet = Sheet::new();
         sheet.set_cell((0, 0), "=1/0");

--- a/crates/cell-sheet-core/src/formula/token.rs
+++ b/crates/cell-sheet-core/src/formula/token.rs
@@ -108,7 +108,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, CellError> {
                 tokens.push(Token::StringLit(s));
                 i += 1; // skip closing quote
             }
-            c if c == '$' || c.is_ascii_uppercase() => {
+            c if c == '$' || c.is_ascii_alphabetic() => {
                 let mut abs_col = false;
                 let mut j = i;
 
@@ -118,10 +118,13 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, CellError> {
                 }
 
                 let col_start = j;
-                while j < chars.len() && chars[j].is_ascii_uppercase() {
+                while j < chars.len() && chars[j].is_ascii_alphabetic() {
                     j += 1;
                 }
-                let col: String = chars[col_start..j].iter().collect();
+                let col: String = chars[col_start..j]
+                    .iter()
+                    .map(|c| c.to_ascii_uppercase())
+                    .collect();
 
                 if col.is_empty() {
                     return Err(CellError::Parse);
@@ -342,6 +345,52 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn tokenize_lowercase_cell_ref() {
+        let tokens = tokenize("a1").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::CellRef {
+                col: "A".into(),
+                row: "1".into(),
+                abs_col: false,
+                abs_row: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn tokenize_mixed_case_cell_ref() {
+        let tokens = tokenize("Aa10").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::CellRef {
+                col: "AA".into(),
+                row: "10".into(),
+                abs_col: false,
+                abs_row: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn tokenize_lowercase_function_name() {
+        let tokens = tokenize("sum(").unwrap();
+        assert_eq!(tokens, vec![Token::Ident("SUM".into()), Token::LParen]);
+    }
+
+    #[test]
+    fn tokenize_lowercase_boolean_true() {
+        let tokens = tokenize("true").unwrap();
+        assert_eq!(tokens, vec![Token::Bool(true)]);
+    }
+
+    #[test]
+    fn tokenize_lowercase_boolean_false() {
+        let tokens = tokenize("False").unwrap();
+        assert_eq!(tokens, vec![Token::Bool(false)]);
     }
 
     #[test]

--- a/crates/cell-sheet-core/src/model.rs
+++ b/crates/cell-sheet-core/src/model.rs
@@ -173,13 +173,14 @@ pub fn col_index_to_label(mut col: usize) -> String {
 pub fn col_label_to_index(label: &str) -> Option<usize> {
     let mut index = 0usize;
     for (i, c) in label.chars().enumerate() {
-        if !c.is_ascii_uppercase() {
+        if !c.is_ascii_alphabetic() {
             return None;
         }
+        let upper = c.to_ascii_uppercase();
         if i > 0 {
             index = (index + 1) * 26;
         }
-        index += (c as usize) - ('A' as usize);
+        index += (upper as usize) - ('A' as usize);
     }
     Some(index)
 }
@@ -299,6 +300,14 @@ mod tests {
         for i in 0..100 {
             assert_eq!(col_label_to_index(&col_index_to_label(i)).unwrap(), i);
         }
+    }
+
+    #[test]
+    fn col_label_to_index_case_insensitive() {
+        assert_eq!(col_label_to_index("a"), Some(0));
+        assert_eq!(col_label_to_index("z"), Some(25));
+        assert_eq!(col_label_to_index("aA"), col_label_to_index("AA"));
+        assert_eq!(col_label_to_index("Bc"), col_label_to_index("BC"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Formulas and cell references are now case-insensitive: `=sum(a1:a2)` evaluates the same as `=SUM(A1:A2)`, and `true`/`false` work alongside `TRUE`/`FALSE`.
- The lexer accepts any ASCII letter and normalizes column letters to uppercase, so the parser, evaluator, dependency graph, and file I/O are unchanged.
- `col_label_to_index` is also case-insensitive, so `:sort a` works.

Closes #108

## Test plan

- [x] `cargo test` — 526 tests pass, including new regression tests in `token.rs`, `eval.rs`, and `model.rs`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features` clean
- [ ] Manually try `=sum(a1:a2)` in the TUI to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)