### PR TITLE
feat: add ROUND formula function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `ROUND(number, [digits])` formula function (#119)
+
 ## [0.5.0](https://github.com/garritfra/cell/compare/v0.4.0...v0.5.0) - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Formulas start with `=` and support Excel-compatible syntax:
 
 ### Supported Functions (v1)
 
-`SUM`, `AVERAGE`, `COUNT`, `MIN`, `MAX`, `IF`
+`SUM`, `AVERAGE`, `COUNT`, `MIN`, `MAX`, `IF`, `ROUND`
 
 Formula compliance with the ODF (OpenDocument Formula) spec is tracked and will expand over time.
 
@@ -240,7 +240,7 @@ When saving a CSV that contains formulas, cell warns you and suggests saving as 
 | **Language / TUI** | Rust + ratatui | C + ncurses |
 | **Editing model** | True Vim modal editing (`i` → Insert, `ESC` → Normal) | Vim-inspired navigation; `=` to enter a value, `e`/`E` to edit |
 | **Formula syntax** | Excel-compatible (`=SUM(A1:A10)`, `=IF(...)`) | `@`-prefix style (`@sum(A1:A10)`, `@avg(...)`) |
-| **Built-in functions** | SUM, AVERAGE, COUNT, MIN, MAX, IF | Extensive (@sum, @avg, @min, @max, @abs, @sqrt, ...) |
+| **Built-in functions** | SUM, AVERAGE, COUNT, MIN, MAX, IF, ROUND | Extensive (@sum, @avg, @min, @max, @abs, @sqrt, ...) |
 | **File formats** | CSV, TSV, `.cell` | CSV, TSV, XLSX/XLS/ODS import, Markdown export, `.sc` |
 | **Cell formatting** | not yet | Bold, italic, underline, RGB colors |
 | **Scripting** | Headless CLI mode (`--read` / `--write` / `--eval`, stdin pipe) | Lua scripting, external C modules, non-interactive mode |

--- a/crates/cell-sheet-core/src/formula/eval.rs
+++ b/crates/cell-sheet-core/src/formula/eval.rs
@@ -140,6 +140,7 @@ fn eval_expr(expr: &Expr, sheet: &Sheet) -> CellValue {
                 "COUNT" => functions::fn_count(&values),
                 "MIN" => functions::fn_min(&values),
                 "MAX" => functions::fn_max(&values),
+                "ROUND" => functions::fn_round(&values),
                 _ => CellValue::Error(CellError::Name),
             }
         }
@@ -165,6 +166,19 @@ mod tests {
     fn eval(formula: &str) -> CellValue {
         let sheet = Sheet::new();
         eval_with_sheet(formula, &sheet)
+    }
+
+    #[test]
+    fn eval_round_function() {
+        let mut sheet = Sheet::new();
+        sheet.set_cell((0, 0), "10");
+        sheet.set_cell((0, 1), "3");
+        assert_eq!(
+            eval_with_sheet("ROUND(A1/B1, 2)", &sheet),
+            CellValue::Number(3.33)
+        );
+        assert_eq!(eval("ROUND(2.5)"), CellValue::Number(3.0));
+        assert_eq!(eval("ROUND(1/0)"), CellValue::Error(CellError::DivZero));
     }
 
     #[test]

--- a/crates/cell-sheet-core/src/formula/functions.rs
+++ b/crates/cell-sheet-core/src/formula/functions.rs
@@ -94,9 +94,42 @@ pub fn fn_if(args: &[CellValue]) -> CellValue {
     }
 }
 
+/// `ROUND(number, [digits])` — rounds half away from zero, like Excel.
+/// Negative `digits` round to the left of the decimal point.
+pub fn fn_round(args: &[CellValue]) -> CellValue {
+    let (n, digits) = match args {
+        [CellValue::Number(n)] => (*n, 0.0),
+        [CellValue::Number(n), CellValue::Number(d)] => (*n, d.trunc()),
+        [CellValue::Error(e), ..] | [_, CellValue::Error(e)] => return CellValue::Error(e.clone()),
+        _ => return CellValue::Error(CellError::Value),
+    };
+    let factor = 10f64.powi(digits as i32);
+    CellValue::Number((n * factor).round() / factor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn round_matches_excel_semantics() {
+        assert_eq!(fn_round(&[num(2.5)]), num(3.0));
+        assert_eq!(fn_round(&[num(-2.5)]), num(-3.0));
+        assert_eq!(fn_round(&[num(1.23456), num(2.0)]), num(1.23));
+        assert_eq!(fn_round(&[num(1234.5), num(-2.0)]), num(1200.0));
+        assert_eq!(
+            fn_round(&[num(1.0), num(2.0), num(3.0)]),
+            CellValue::Error(CellError::Value)
+        );
+        assert_eq!(
+            fn_round(&[CellValue::Text("x".into())]),
+            CellValue::Error(CellError::Value)
+        );
+        assert_eq!(
+            fn_round(&[CellValue::Error(CellError::DivZero)]),
+            CellValue::Error(CellError::DivZero)
+        );
+    }
 
     fn num(n: f64) -> CellValue {
         CellValue::Number(n)

--- a/crates/cell-sheet-core/src/help/entries.rs
+++ b/crates/cell-sheet-core/src/help/entries.rs
@@ -726,6 +726,12 @@ pub static FORMULA_ENTRIES: &[HelpEntry] = &[
         summary: "Conditional expression",
         detail: "Returns one value if a condition is true, another if false.\n\nUsage: =IF(condition, value_if_true, value_if_false)\n\nExamples:\n  =IF(A1>10, \"big\", \"small\")\n  =IF(B2, C2, D2)",
     },
+    HelpEntry {
+        tags: &["ROUND"],
+        category: HelpCategory::Formula,
+        summary: "Round a number to a given number of digits",
+        detail: "Rounds a number to the given number of decimal digits (default 0).\nHalves round away from zero. Negative digits round to tens, hundreds, etc.\n\nUsage: =ROUND(number, [digits])\n\nExamples:\n  =ROUND(A1/B1, 2)\n  =ROUND(2.5)        -> 3\n  =ROUND(1234.5, -2) -> 1200",
+    },
 ];
 
 pub static MOUSE_ENTRIES: &[HelpEntry] = &[

--- a/crates/cell-sheet-core/src/io/csv.rs
+++ b/crates/cell-sheet-core/src/io/csv.rs
@@ -15,7 +15,7 @@ pub fn sniff_delimiter(sample: &[u8]) -> u8 {
     let line = &sample[..line_end.min(4096)];
 
     // Iterate in preference order so the first candidate wins ties.
-    let candidates = [b',', b'\t', b'|', b';'];
+    let candidates = *b",\t|;";
     let mut best_delim = b',';
     let mut best_count = 0usize;
     for &d in &candidates {

--- a/crates/cell-sheet-tui/src/main.rs
+++ b/crates/cell-sheet-tui/src/main.rs
@@ -109,8 +109,10 @@ fn main() -> ExitCode {
             evals: cli.eval,
             writes: cli
                 .write
-                .chunks_exact(2)
-                .map(|c| (c[0].clone(), c[1].clone()))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|[k, v]| (k.clone(), v.clone()))
                 .collect(),
             delimiter: explicit_delimiter,
         };


### PR DESCRIPTION
Closes #119

Adds `ROUND(number, [digits])` so formula results can be rounded to a given precision.

- Excel semantics: halves round away from zero (`=ROUND(2.5)` → `3`, `=ROUND(-2.5)` → `-3`); negative digits round to tens/hundreds (`=ROUND(1234.5, -2)` → `1200`).
- Wrong arity or non-numeric input → `#VALUE!`; errors propagate.
- Help entry, README function list, and CHANGELOG updated.

Verified with `cargo fmt`, `cargo clippy --workspace --all-targets --all-features`, `cargo test`, and headless `--eval '=ROUND(A1/B1, 2)'` → `3.33`.